### PR TITLE
Update chooseFileSystemEntries domintro text.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -223,32 +223,41 @@ The <dfn method for=FileSystemFileHandle>getFile()</dfn> method, when invoked, m
 <div class="note domintro">
   : |writer| = await |fileHandle| . {{FileSystemFileHandle/createWriter()}}
   : |writer| = await |fileHandle| . {{FileSystemFileHandle/createWriter()|createWriter}}({ {{FileSystemCreateWriterOptions/inPlace}}: false })
-  : |writer| = await |fileHandle| . {{FileSystemFileHandle/createWriter()|createWriter}}({ {{FileSystemCreateWriterOptions/keepExistingData}}: |keepExistingData|, {{FileSystemCreateWriterOptions/inPlace}}: false })
+  : |writer| = await |fileHandle| . {{FileSystemFileHandle/createWriter()|createWriter}}({ {{FileSystemCreateWriterOptions/inPlace}}: false, {{FileSystemCreateWriterOptions/keepExistingData}}: true/false })
   :: Returns a {{FileSystemWriter}} that can be used to write to the file. Any changes made through
      |writer| won't be reflected in the file represented by |fileHandle| until its
      {{FileSystemWriter/close()}} method is called.
      User agents try to ensure that no partial writes happen, i.e. the file represented by
      |fileHandle| will either contains its old contents or it will contain whatever data was written
-     through |writer| up until one of these methods was called.
+     through |writer| up until {{FileSystemWriter/close()}} was called.
 
      This is typically implemented by writing data to a temporary file, and only replacing the file
      represented by |fileHandle| with the temporary file when the writer is closed.
 
-     If |keepExistingData| is `false` or not specified, the temporary file starts out empty,
+     If {{FileSystemCreateWriterOptions/keepExistingData}} is `false` or not specified,
+     the temporary file starts out empty,
      otherwise the existing file is first copied to this temporary file.
 
    : |writer| = await |fileHandle| . {{FileSystemFileHandle/createWriter()|createWriter}}({ {{FileSystemCreateWriterOptions/inPlace}}: true })
-   : |writer| = await |fileHandle| . {{FileSystemFileHandle/createWriter()|createWriter}}({ {{FileSystemCreateWriterOptions/keepExistingData}}: |keepExistingData|, {{FileSystemCreateWriterOptions/inPlace}}: true })
+   : |writer| = await |fileHandle| . {{FileSystemFileHandle/createWriter()|createWriter}}({ {{FileSystemCreateWriterOptions/inPlace}}: true, {{FileSystemCreateWriterOptions/keepExistingData}}: true/false })
    :: Returns a {{FileSystemWriter}} that can be used to write to the file. Any changes made through
       |writer| might not be reflected in the file represented by |fileHandle| until its
-      {{FileSystemWriter/close()}} method is called.
+      {{FileSystemWriter/close()}} method is called, but there are no guarantees that such changes
+      aren't immediately visible either.
+
       User agents are free to either flush changes to the file as they are made, or batch them
       up (possibly by writing to some kind of change log) until {{FileSystemWriter/close()}}
       is called. Specifically for less trusted websites, user agents
-      will want to batch up changes so that malware scanners or other security checks can be
+      might want to batch up changes so that malware scanners or other security checks can be
       performed before actually flushing changes to disk.
 
-      If |keepExistingData| is `false` or not specified, the file will start out empty.
+      If {{FileSystemCreateWriterOptions/keepExistingData}} is `false` or not specified,
+      the file will start out empty.
+
+      Advisement: The {{FileSystemCreateWriterOptions/inPlace}} option (and thus this functionality)
+      is not currently implemented in Chrome. Implementing this is currently blocked on figuring out
+      how to combine the desire to run malware checks with the desire to let websites make fast
+      in-place modifications to existing large files.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
Tries to make the difference between inPlace: true and false clearer,
mentions the implementation status for inPlace: true in Chrome, and
tries to make it clearer what is going on with keepExistingData.

Addresses #76 and #67


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/pull/88.html" title="Last updated on Aug 27, 2019, 12:00 AM UTC (01b0861)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/88/051d26c...01b0861.html" title="Last updated on Aug 27, 2019, 12:00 AM UTC (01b0861)">Diff</a>