### PR TITLE
Trivial typo fix

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1333,7 +1333,7 @@ By default the file picker will also include an option to not apply any filter,
 letting the user select any file. Set {{excludeAcceptAllOption}} to `true` to not
 include this option in the file picker.
 
-For example , the following options will let the user pick one of three different filter.
+For example , the following options will let the user pick one of three different filters.
 One for text files (either plain text or HTML), one for images, and a third one that doesn't apply
 any filter and lets the user select any file.
 


### PR DESCRIPTION
`s/three different filter/three different filters/`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tomayac/native-file-system/pull/212.html" title="Last updated on Aug 5, 2020, 9:04 AM UTC (394e99b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/212/7fbe134...tomayac:394e99b.html" title="Last updated on Aug 5, 2020, 9:04 AM UTC (394e99b)">Diff</a>