### PR TITLE
Require a "." to be included in the accepted extensions.

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -96,7 +96,7 @@ this new API might integrate with `<input type=file>`.
 // Show a file picker to open a file.
 const [file_ref] = await self.showOpenFilePicker({
     multiple: false,
-    types: [{description: 'Images', accept: {'image/*': ['jpg', 'gif', 'png']}}],
+    types: [{description: 'Images', accept: {'image/*': ['.jpg', '.gif', '.png']}}],
     suggestedStartLocation: 'pictures-library'
 });
 if (!file_ref) {

--- a/changes.md
+++ b/changes.md
@@ -50,14 +50,14 @@ await window.showOpenFilePicker({
     {
       description: 'Text Files',
       accept: {
-        'text/plain': ['txt', 'text'],
-        'text/html': ['html', 'htm']
+        'text/plain': ['.txt', '.text'],
+        'text/html': ['.html', '.htm']
       }
     },
     {
       description: 'Images',
       accept: {
-        'image/*': ['png', 'gif', 'jpeg', 'jpg']
+        'image/*': ['.png', '.gif', '.jpeg', '.jpg']
       }
     }
   ]

--- a/index.bs
+++ b/index.bs
@@ -1345,14 +1345,14 @@ const options = {
     {
       <l>{{FilePickerAcceptType/description}}</l>: 'Text Files',
       <l>{{FilePickerAcceptType/accept}}</l>: {
-        'text/plain': ['txt', 'text'],
-        'text/html': ['html', 'htm']
+        'text/plain': ['.txt', '.text'],
+        'text/html': ['.html', '.htm']
       }
     },
     {
       <l>{{FilePickerAcceptType/description}}</l>: 'Images',
       <l>{{FilePickerAcceptType/accept}}</l>: {
-        'image/*': ['png', 'gif', 'jpeg', 'jpg']
+        'image/*': ['.png', '.gif', '.jpeg', '.jpg']
       }
     }
   ],
@@ -1367,7 +1367,7 @@ const options = {
   <l>{{FilePickerOptions/types}}</l>: [
     {
       <l>{{FilePickerAcceptType/accept}}</l>: {
-        'image/svg+xml': 'svg'
+        'image/svg+xml': '.svg'
       }
     },
   ],
@@ -1384,22 +1384,25 @@ run these steps:
 1. Let |accepts options| be a empty [=/list=] of [=pairs=].
 1. [=list/For each=] |type| of |options|.{{FilePickerOptions/types}}:
   1. Let |description| be |type|.{{FilePickerAcceptType/description}}.
-  1. [=map/For each=] |type string| → |extensions| of |type|.{{FilePickerAcceptType/accept}}:
+  1. [=map/For each=] |type string| → |suffixes| of |type|.{{FilePickerAcceptType/accept}}:
     1. Let |parsedType| be the result of [=parse a MIME type=] with |typeString|.
     1. If |parsedType| is failure, throw a {{TypeError}}.
     1. If |parsedType|'s [=MIME type/parameters=] are not empty, throw a {{TypeError}}.
+    1. If |suffixes| is a string:
+      1. If |suffixes| does not start with ".", throw a {{TypeError}}.
+    1. Otherwise, [=list/for each=] |suffix| of |suffixes|:
+      1. If |suffix| does not start with ".", throw a {{TypeError}}.
 
   1. Let |filter| be the following steps, given a |filename| (a [=string=]), and a |type| (a [=MIME type=]):
-    1. [=map/For each=] |type string| → |extensions| of |type|.{{FilePickerAcceptType/accept}}:
+    1. [=map/For each=] |type string| → |suffixes| of |type|.{{FilePickerAcceptType/accept}}:
     1. Let |parsedType| be the result of [=parse a MIME type=] with |typeString|.
       1. If |parsedType|'s [=MIME type/subtype=] is "*":
         1. If |parsedType|'s [=MIME type/type=] is "*", return `true`.
         1. If |parsedType|'s [=MIME type/type=] is |type|'s [=MIME type/type=], return `true`.
       1. |parsedType|'s [=MIME type/essence=] is |type|'s [=MIME type/essence=], return `true`.
-      1. If |extensions| is a string, set |extensions| to a [=/list=] with a single
-        element equal to |extensions|.
-      1. [=list/For each=] |extension| of |extensions|:
-        1. If |filename| ends with "." followed by |extension|, return `true`.
+      1. If |suffixes| is a string, set |suffixes| to « |suffixes| ».
+      1. [=list/For each=] |suffix| of |suffixes|:
+        1. If |filename| ends with |suffix|, return `true`.
     1. Return `false`.
 
   1. If |description| is an empty string,

--- a/index.bs
+++ b/index.bs
@@ -1384,7 +1384,7 @@ run these steps:
 1. Let |accepts options| be a empty [=/list=] of [=pairs=].
 1. [=list/For each=] |type| of |options|.{{FilePickerOptions/types}}:
   1. Let |description| be |type|.{{FilePickerAcceptType/description}}.
-  1. [=map/For each=] |type string| → |suffixes| of |type|.{{FilePickerAcceptType/accept}}:
+  1. [=map/For each=] |typeString| → |suffixes| of |type|.{{FilePickerAcceptType/accept}}:
     1. Let |parsedType| be the result of [=parse a MIME type=] with |typeString|.
     1. If |parsedType| is failure, throw a {{TypeError}}.
     1. If |parsedType|'s [=MIME type/parameters=] are not empty, throw a {{TypeError}}.
@@ -1394,7 +1394,7 @@ run these steps:
       1. If |suffix| does not start with ".", throw a {{TypeError}}.
 
   1. Let |filter| be the following steps, given a |filename| (a [=string=]), and a |type| (a [=MIME type=]):
-    1. [=map/For each=] |type string| → |suffixes| of |type|.{{FilePickerAcceptType/accept}}:
+    1. [=map/For each=] |typeString| → |suffixes| of |type|.{{FilePickerAcceptType/accept}}:
     1. Let |parsedType| be the result of [=parse a MIME type=] with |typeString|.
       1. If |parsedType|'s [=MIME type/subtype=] is "*":
         1. If |parsedType|'s [=MIME type/type=] is "*", return `true`.

--- a/index.bs
+++ b/index.bs
@@ -1322,6 +1322,7 @@ for filtering the files displayed in the file picker.
 Each option consists of an <span class=allow-2119>optional</span> {{FilePickerAcceptType/description}}
 and a number of MIME types and extensions (specified as a mapping of
 MIME type to a list of extensions). If no description is provided one will be generated.
+Extensions have to be strings that start with a ".".
 
 In addition to complete MIME types, "*" can be used as the subtype of a MIME type to match
 for example all image formats with "image/*".


### PR DESCRIPTION
This is more in line with how accepts in input type=file works, as well
as how the file handling API currently is specified.

Fixes #213


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/pull/219.html" title="Last updated on Aug 18, 2020, 7:45 PM UTC (8e0e0b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/219/ebf0210...8e0e0b9.html" title="Last updated on Aug 18, 2020, 7:45 PM UTC (8e0e0b9)">Diff</a>