### PR TITLE
Fix example code.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1540,9 +1540,9 @@ elem.addEventListener('drop', async (e) => {
     if (item.kind === 'file') {
       const entry = await item.getAsFileSystemHandle();
       if (entry.kind === 'file') {
-        handleDirectoryEntry(entry);
-      } else if (entry.kind === 'directory') {
         handleFileEntry(entry);
+      } else if (entry.kind === 'directory') {
+        handleDirectoryEntry(entry);
       }
     }
   }


### PR DESCRIPTION
The call to handleFileEntry() should be for entry.type === 'file' and vice versa for directories.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/adanilo/native-file-system/pull/223.html" title="Last updated on Aug 21, 2020, 5:04 AM UTC (61e76c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/223/3dd57a2...adanilo:61e76c4.html" title="Last updated on Aug 21, 2020, 5:04 AM UTC (61e76c4)">Diff</a>