### PR TITLE
Remove last occurrence of `chooseFileSystemEntries()`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -811,7 +811,7 @@ const dir_ref = current_project_dir;
 if (!dir_ref) return;
 
 // Now get a file reference by showing a file picker:
-const file_ref = await self.chooseFileSystemEntries({type: 'openFile'});
+const file_ref = await self.showOpenFilePicker();
 if (!file_ref) {
     // User cancelled, or otherwise failed to open a file.
     return;
@@ -1153,8 +1153,7 @@ strictly refer to the file system on the local device. What we call the local fi
 could just as well be backed by a cloud provider. For example on Chrome OS these
 file pickers will also let you pick files and directories on Google Drive.
 
-Advisement: In Chrome this is currently implemented as a `chooseFileSystemEntries` method.
-Starting in Chrome 85 these new methods will also become available.
+Advisement: In Chrome versions earlier than 85, this was implemented as a generic `chooseFileSystemEntries` method.
 
 ## Local File System Permissions ## {#local-file-system-permissions}
 


### PR DESCRIPTION
- Remove `chooseFileSystemEntries()` and replace it with `showOpenFilePicker()`.
- Update advisement to present situation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tomayac/native-file-system/pull/233.html" title="Last updated on Sep 28, 2020, 8:06 PM UTC (601b555)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/233/58d2fe8...tomayac:601b555.html" title="Last updated on Sep 28, 2020, 8:06 PM UTC (601b555)">Diff</a>