### PR TITLE
requestPermission example typo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -366,14 +366,14 @@ The <dfn method for=FileSystemHandle>queryPermission(|descriptor|)</dfn> method,
 ### The {{FileSystemHandle/requestPermission()}} method ### {#api-filesystemhandle-requestpermission}
 
 <div class="note domintro">
-  : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} = {{"read"}} })
+  : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : {{"read"}} })
   : |status| = await |handle| . {{FileSystemHandle/requestPermission()}}
   :: If the state of the read permission of this handle is anything other than `"prompt"`, this
      will return that state directly. If it is `"prompt"` however, user activation is needed and
      this will show a confirmation prompt to the user. The new read permission state is then
      returned, depending on the user's response to the prompt.
 
-  : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} = {{"readwrite"}} })
+  : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : {{"readwrite"}} })
   :: If the state of the write permission of this handle is anything other than `"prompt"`, this
      will return that state directly. If the status of the read permission of this handle is
      `"denied"` this will return that.


### PR DESCRIPTION
In the requestPermission() section (2.3.3), the example for web developers uses an `=` in the object param. Seems like a type and it should be `:`. Opening a pr to fix.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Rumyra/file-system-access/pull/249.html" title="Last updated on Nov 16, 2020, 11:12 AM UTC (9c98133)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/249/848a4e9...Rumyra:9c98133.html" title="Last updated on Nov 16, 2020, 11:12 AM UTC (9c98133)">Diff</a>