### PR TITLE
Fix ignored wildcards in spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1327,8 +1327,8 @@ and a number of MIME types and extensions (specified as a mapping of
 MIME type to a list of extensions). If no description is provided one will be generated.
 Extensions have to be strings that start with a ".".
 
-In addition to complete MIME types, "*" can be used as the subtype of a MIME type to match
-for example all image formats with "image/*".
+In addition to complete MIME types, "\*" can be used as the subtype of a MIME type to match
+for example all image formats with "image/\*".
 
 Websites <span class=allow-2119>should</span> always provide both MIME types and file
 extensions for each option. On platforms that only use file extensions to describe file types


### PR DESCRIPTION
Seems like wildcard characters are being ignored in the spec.

I'm not very familiar with writing specifications, so not sure if this fixes the problem. If it doesn't, just consider this a regular "bug report".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Anoesj/file-system-access/pull/251.html" title="Last updated on Nov 16, 2020, 6:25 PM UTC (1074f50)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/251/7b3f9f9...Anoesj:1074f50.html" title="Last updated on Nov 16, 2020, 6:25 PM UTC (1074f50)">Diff</a>