### PR TITLE
Limit what code points are allowed in suffixes.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -96,6 +96,13 @@ other operating systems. Additionally underlying file systems might have further
 on what names are or aren't allowed, so a string merely being a [=valid file name=] is not
 a guarantee that creating a file or directory with that name will succeed.
 
+Issue: We should consider having further normative restrictions on file names that will
+never be allowed using this API, rather than leaving it entirely up to underlying file
+systems.
+
+A <dfn>valid suffix code point</dfn> is a [=code point=] that is [=ASCII alphanumeric=],
+or U+0021 (!), U+0023 (#), U+0024 ($), U+002B (+), U+002D (-), U+002E (.), or U+005F (_).
+
 A <dfn lt="file|file entry">file entry</dfn> additionally consists of
 <dfn for="file entry">binary data</dfn> (a [=byte sequence=]) and a
 <dfn for="file entry">modification timestamp</dfn> (a number representing the number of milliseconds since the <a spec=FileAPI>Unix Epoch</a>).
@@ -1325,7 +1332,8 @@ for filtering the files displayed in the file picker.
 Each option consists of an <span class=allow-2119>optional</span> {{FilePickerAcceptType/description}}
 and a number of MIME types and extensions (specified as a mapping of
 MIME type to a list of extensions). If no description is provided one will be generated.
-Extensions have to be strings that start with a ".".
+Extensions have to be strings that start with a "." and only contain [=valid suffix code points=].
+Additionally extensions are limited to a length of 16 code points.
 
 In addition to complete MIME types, "\*" can be used as the subtype of a MIME type to match
 for example all image formats with "image/\*".
@@ -1393,9 +1401,9 @@ run these steps:
     1. If |parsedType| is failure, throw a {{TypeError}}.
     1. If |parsedType|'s [=MIME type/parameters=] are not empty, throw a {{TypeError}}.
     1. If |suffixes| is a string:
-      1. If |suffixes| does not start with ".", throw a {{TypeError}}.
+      1. [=Validate a suffix=] given |suffixes|.
     1. Otherwise, [=list/for each=] |suffix| of |suffixes|:
-      1. If |suffix| does not start with ".", throw a {{TypeError}}.
+      1. [=Validate a suffix=] given |suffix|.
 
   1. Let |filter| be the following steps, given a |filename| (a [=string=]), and a |type| (a [=MIME type=]):
     1. [=map/For each=] |typeString| → |suffixes| of |type|.{{FilePickerAcceptType/accept}}:
@@ -1423,6 +1431,17 @@ run these steps:
 1. If |accepts options| is empty, throw a {{TypeError}}.
 
 1. Return |accepts options|.
+
+</div>
+
+<div algorithm>
+To <dfn>validate a suffix</dfn> |suffix|, run the following steps:
+
+1. If |suffix| does not [=string/starts with|start with=] ".", throw a {{TypeError}}.
+1. If |suffix| contains any [=code points=] that are not [=valid suffix code points=],
+   throw a {{TypeError}}.
+1. If |suffix| ends with ".", ".local" or ".lnk", throw a {{TypeError}}.
+1. If |suffix|'s [=string/length=] is more than 16, throw a {{TypeError}}.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -101,7 +101,12 @@ never be allowed using this API, rather than leaving it entirely up to underlyin
 systems.
 
 A <dfn>valid suffix code point</dfn> is a [=code point=] that is [=ASCII alphanumeric=],
-or U+0021 (!), U+0023 (#), U+0024 ($), U+002B (+), U+002D (-), U+002E (.), or U+005F (_).
+U+002B (+), or U+002E (.).
+
+Note: These code points were chosen to support most pre-existing file formats. The vast
+majority of file extensions are purely alphanumeric, but compound extensions (such as
+`.tar.gz`) and extensions such as `.c++` for C++ source code are also fairly common,
+hence the inclusion of + and . as allowed code points.
 
 A <dfn lt="file|file entry">file entry</dfn> additionally consists of
 <dfn for="file entry">binary data</dfn> (a [=byte sequence=]) and a
@@ -1290,6 +1295,9 @@ these steps:
 
      The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
      Exactly how this is implemented, and what this prompt looks like is left up to the user agent.
+     If |accepts options| are displayed in the UI, the selected option should also be used to suggest an extension
+     to append to a user provided file name, but this is not required. In particular user agents are free to ignore
+     potentially dangerous suffixes such as those ending in `".lnk"` or `".local"`.
 
   1. Wait for the user to have made their selection.
 
@@ -1440,7 +1448,7 @@ To <dfn>validate a suffix</dfn> |suffix|, run the following steps:
 1. If |suffix| does not [=string/starts with|start with=] ".", throw a {{TypeError}}.
 1. If |suffix| contains any [=code points=] that are not [=valid suffix code points=],
    throw a {{TypeError}}.
-1. If |suffix| ends with ".", ".local" or ".lnk", throw a {{TypeError}}.
+1. If |suffix| ends with ".", throw a {{TypeError}}.
 1. If |suffix|'s [=string/length=] is more than 16, throw a {{TypeError}}.
 
 </div>
@@ -1678,6 +1686,12 @@ Examples of directories that user agents might want to restrict as being
   but user agents should not generally let users give blanket access to the entire directory.
 * The default directory for downloads, if the user agent has such a thing.
   Individual files inside the directory again should be allowed, but the whole directory would risk leaking more data than a user realizes.
+* Files with names that end in `.lnk`, when selecting a file to write to. Writing to
+  these files on Windows is similar to creating symlinks on other operating systems,
+  and as such can be used to attempt to trick users into giving access to files they didn't intend to expose.
+* Files with names that end in `.local`, when selecting a file to write to.
+  Windows uses these files to decide what DLLs to load, and as such writing to
+  these files could be used to cause code to be executed.
 
 ## Websites trying to use this API for tracking. ## {#privacy-tracking}
 

--- a/security-privacy-questionnaire.md
+++ b/security-privacy-questionnaire.md
@@ -48,7 +48,7 @@ Not really. The exception would be devices that are exposed as files or director
 
 ### 2.11. Does this specification allow an origin some measure of control over a user agent’s native UI?
 
-Not really. The origin can pop up native file or directory pickers, and have some control over what appears inside that native UI (e.g. accepted file types), but that control is very limited.
+The origin can pop up native file or directory pickers, and have some control over what appears inside that native UI (e.g. accepted file types), but that control is very limited. The spec does put limitations on what is allowed as an accepted file type to limit the security impact of allowing websites to control the native UI.
 
 ### 2.12. What temporary identifiers might this this specification create or expose to the web?
 


### PR DESCRIPTION
There are a number of issues with what we allow in extensions that a website can provide when showing a file picker. Since the file picker (on most platforms) appends these extensions to the filename the user enters, this can result in filenames with characters we don’t want to allow/that are otherwise problematic. In particular we don't want to allow control characters or whitespace in suffixes, or filenames that end in a '.'. As such this PR adds restrictions on what characters are allowed in accepts file extensions/suffixes, as well as limiting their length to 16.

Limiting extensions to only contain alphanumeric characters, + or . still allows all
extensions in the [shared-mime-info](https://freedesktop.org/wiki/Software/shared-mime-info/) database as well as nearly all extensions in [Wikipedia's List of filename extensions](https://en.wikipedia.org/wiki/List_of_filename_extensions).

On Windows file suffixes such as `.lnk` and `.local` are also particularly dangerous to be written to. We opted not to reject these when specified as "accepted" file types in `showSaveFilePicker` though, instead leaving it up to the user agent to ignore these file suffixes, and/or block writing to these file types completely.

### Considered alternatives

- Have a bigger allow list of characters. Other characters, such as +, -, $, # and ! are probably safe in file extensions, and have been used occasionally by applications in the past. Because of how rarely these are used, we're limiting extensions to just those characters that are at least somewhat in common use.

- Have a block list rather than an allow list. This option was rejected since while we could try to enumerate all characters that might be problematic, the consequences of not blocking something we should have blocked are much worse than not allowing something we could have allowed. As such a minimal allow list was chosen instead.

- Also reject when suffixes ending in `.lnk` or `.local` appear in the accepted file types for a showSaveFilePicker or showOpenFilePicker call. We opted against this because different platforms will likely have different extensions they might want to block. Rejecting for these only on some platforms would result in unpredictability where a website might work fine on one platform but fail on another. Rejecting these on platforms where these suffixes don't have special meaning would be needlessly limiting. Giving user agents the option to ignore these file suffixes, or at least not auto-append them to file names in save dialogs still protects the user without these downsides.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/pull/252.html" title="Last updated on Dec 2, 2020, 9:24 PM UTC (ae858c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/252/94472cf...ae858c9.html" title="Last updated on Dec 2, 2020, 9:24 PM UTC (ae858c9)">Diff</a>