### PR TITLE
Add FileSystemHandle::remove() method

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -340,24 +340,26 @@ these steps:
   1. If |permissionStatus| is not {{PermissionState/"granted"}},
      [=/reject=] |result| with a {{NotAllowedError}} and abort.
 
-  1. Attempt to remove |handle| from the underlying file system.
-  1. If |handle| is a [=directory entry=]:
-    1. If |handle|'s path does not exists, [=/reject=] |result| with a
+  1. Attempt to remove |entry| from the underlying file system.
+  1. If |entry| is a [=directory entry=]:
+    1. If |entry|'s path does not exists, [=/reject=] |result| with a
         {{NotFoundError}} and abort
-    1. If |handle|'s path is not a directory, [=/reject=] |result| with a
+    1. If |entry|'s path is not a directory, [=/reject=] |result| with a
         {{NotADirectoryError}} and abort
-    1. If |handle| is not an empty directory, [=/reject=] |result| with a
+    1. If |entry| is not an empty directory, [=/reject=] |result| with a
         {{NotEmptyError}} and abort
 
-  1. If |handle| is a [=file entry=]:
-    1. If |handle|'s path does not exists, [=/reject=] |result| with a
+  1. If |entry| is a [=file entry=]:
+    1. If |entry|'s path does not exists, [=/reject=] |result| with a
         {{NotFoundError}} and abort
-    1. If |handle|'s path is not a file, [=/reject=] |result| with a
+    1. If |entry|'s path is not a file, [=/reject=] |result| with a
         {{NotAFileError}} and abort
 
   1. [=/Resolve=] |result| with `undefined`.
 
 1. Return |result|.
+
+</div>
 
 ### The {{FileSystemHandle/isSameEntry()}} method ### {#api-filesystemhandle-issameentry}
 

--- a/index.bs
+++ b/index.bs
@@ -262,6 +262,8 @@ interface FileSystemHandle {
   readonly attribute FileSystemHandleKind kind;
   readonly attribute USVString name;
 
+  Promise<void> remove();
+
   Promise<boolean> isSameEntry(FileSystemHandle other);
 
   Promise<PermissionState> queryPermission(optional FileSystemHandlePermissionDescriptor descriptor = {});
@@ -314,6 +316,48 @@ and return {{FileSystemHandleKind/"directory"}} otherwise.
 
 The <dfn attribute for=FileSystemHandle>name</dfn> attribute must return the [=entry/name=] of the
 associated [=FileSystemHandle/entry=].
+
+### The {{FileSystemHandle/remove()}} method ### {#api-filesystemhandle-remove}
+
+<div class="note domintro">
+  : await |handle| . {{FileSystemHandle/remove()|remove}}()
+  :: Attempts to remove the entry represented by |handle| from the underlying file system.
+
+     For files or directories with multiple hardlinks or symlinks, the entry which is deleted
+     is the entry corresponding to the path which was used to obtain the handle.
+</div>
+
+<div algorithm>
+The <dfn method for=FileSystemHandle>remove()</dfn> method, when invoked, must run
+these steps:
+
+1. Let |result| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+  1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
+  1. Let |permissionStatus| be the result of [=requesting file system permission=]
+     given <b>[=this=]</b> and {{"readwrite"}}.
+     If that throws an exception, [=reject=] |result| with that exception and abort.
+  1. If |permissionStatus| is not {{PermissionState/"granted"}},
+     [=/reject=] |result| with a {{NotAllowedError}} and abort.
+
+  1. Attempt to remove |handle| from the underlying file system.
+  1. If |handle| is a [=directory entry=]:
+    1. If |handle|'s path does not exists, [=/reject=] |result| with a
+        {{NotFoundError}} and abort
+    1. If |handle|'s path is not a directory, [=/reject=] |result| with a
+        {{NotADirectoryError}} and abort
+    1. If |handle| is not an empty directory, [=/reject=] |result| with a
+        {{NotEmptyError}} and abort
+
+  1. If |handle| is a [=file entry=]:
+    1. If |handle|'s path does not exists, [=/reject=] |result| with a
+        {{NotFoundError}} and abort
+    1. If |handle|'s path is not a file, [=/reject=] |result| with a
+        {{NotAFileError}} and abort
+
+  1. [=/Resolve=] |result| with `undefined`.
+
+1. Return |result|.
 
 ### The {{FileSystemHandle/isSameEntry()}} method ### {#api-filesystemhandle-issameentry}
 

--- a/index.bs
+++ b/index.bs
@@ -262,7 +262,7 @@ interface FileSystemHandle {
   readonly attribute FileSystemHandleKind kind;
   readonly attribute USVString name;
 
-  Promise<void> remove();
+  Promise<void> remove(optional FileSystemRemoveOptions options = {});
 
   Promise<boolean> isSameEntry(FileSystemHandle other);
 
@@ -321,15 +321,26 @@ associated [=FileSystemHandle/entry=].
 
 <div class="note domintro">
   : await |handle| . {{FileSystemHandle/remove()|remove}}()
+  : await |handle| . {{FileSystemHandle/remove()|remove}}({ {{FileSystemRemoveOptions/recursive}}: false })
   :: Attempts to remove the entry represented by |handle| from the underlying file system.
 
      For files or directories with multiple hardlinks or symlinks, the entry which is deleted
      is the entry corresponding to the path which was used to obtain the handle.
+
+     Attempting to delete a file or directory that does not exist is considered success,
+     while attempting to delete a non-empty directory will result in a promise rejection.
+
+  : await |handle| . {{FileSystemHandle/remove()|remove}}({ {{FileSystemRemoveOptions/recursive}}: true })
+  :: Attempts to remove the entry represented by |handle| from the underlying file system.
+
+     If the entry is a directory, its contents will also be deleted recursively.
+
+     Attempting to delete a file or directory that does not exist is considered success.
 </div>
 
 <div algorithm>
-The <dfn method for=FileSystemHandle>remove()</dfn> method, when invoked, must run
-these steps:
+The <dfn method for=FileSystemHandle>remove(|options|)</dfn> method,
+when invoked, must run these steps:
 
 1. Let |result| be [=a new promise=].
 1. Run the following steps [=in parallel=]:
@@ -342,18 +353,21 @@ these steps:
 
   1. Attempt to remove |entry| from the underlying file system.
   1. If |entry| is a [=directory entry=]:
-    1. If |entry|'s path does not exists, [=/reject=] |result| with a
-        {{NotFoundError}} and abort
-    1. If |entry|'s path is not a directory, [=/reject=] |result| with a
-        {{NotADirectoryError}} and abort
-    1. If |entry| is not an empty directory, [=/reject=] |result| with a
-        {{NotEmptyError}} and abort
-
+    1. If |entry|'s path does not exist:
+      1. [=/Reject=] |result| with a {{NotFoundError}} and abort.
+    1. If |entry|'s path is not a directory:
+      1. [=/Reject=] |result| with a {{TypeMismatchError}} and abort.
+    1. If |entry| is not an empty directory and |options|.{{FileSystemRemoveOptions/recursive}} is `false`:
+      1. [=/Reject=] |result| with an {{InvalidModificationError}} and abort.
   1. If |entry| is a [=file entry=]:
-    1. If |entry|'s path does not exists, [=/reject=] |result| with a
-        {{NotFoundError}} and abort
-    1. If |entry|'s path is not a file, [=/reject=] |result| with a
-        {{NotAFileError}} and abort
+    1. If |entry|'s path does not exist:
+      1. [=/Reject=] |result| with a {{NotFoundError}} and abort.
+    1. If |entry|'s path is not a file:
+      1. [=/Reject=] |result| with a {{TypeMismatchError}} and abort.
+
+     Note: If {{FileSystemRemoveOptions/recursive}} is `true`, the removal can fail
+     non-atomically. Some files or directories might have been removed while other files
+     or directories still exist.
 
   1. [=/Resolve=] |result| with `undefined`.
 
@@ -802,7 +816,6 @@ invoked, must run these steps:
   : await |directoryHandle| . {{FileSystemDirectoryHandle/removeEntry()|removeEntry}}(|name|, { {{FileSystemRemoveOptions/recursive}}: true })
   :: Removes the entry named |name| in the directory represented by |directoryHandle|.
      If that entry is a directory, its contents will also be deleted recursively.
-     recursively.
 
      Attempting to delete a file or directory that does not exist is considered success.
 </div>
@@ -830,17 +843,16 @@ these steps:
       1. [=set/Remove=] |child| from |entry|'s [=directory entry/children=].
 
       1. If |child| is a [=directory entry=]:
-        1. If |child|'s path does not exists, [=/reject=] |result| with a
-            {{NotFoundError}} and abort
-        1. If |child|'s path is not a directory, [=/reject=] |result| with a
-            {{NotADirectoryError}} and abort
-        1. If |child| is not an empty directory, [=/reject=] |result| with a
-            {{NotEmptyError}} and abort
+        1. If |child|'s path does not exist:
+          1. [=/Reject=] |result| with a {{NotFoundError}} and abort.
+        1. If |child|'s path is not a directory:
+          1. [=/Reject=] |result| with a {{TypeMismatchError}} and abort.
+
       1. If |child| is a [=file entry=]:
-        1. If |child|'s path does not exists, [=/reject=] |result| with a
-            {{NotFoundError}} and abort
-        1. If |child|'s path is not a file, [=/reject=] |result| with a
-            {{NotAFileError}} and abort
+        1. If |child|'s path does not exist:
+          1. [=/Reject=] |result| with a {{NotFoundError}} and abort.
+        1. If |child|'s path is not a file:
+          1. [=/Reject=] |result| with a {{TypeMismatchError}} and abort.
 
          Note: If {{FileSystemRemoveOptions/recursive}} is `true`, the removal can fail
          non-atomically. Some files or directories might have been removed while other files

--- a/index.bs
+++ b/index.bs
@@ -828,14 +828,24 @@ these steps:
         1. If |child|'s [=directory entry/children=] is not [=set/is empty|empty=] and |options|.{{FileSystemRemoveOptions/recursive}} is `false`:
           1. [=/Reject=] |result| with an {{InvalidModificationError}} and abort.
       1. [=set/Remove=] |child| from |entry|'s [=directory entry/children=].
-      1. If removing |child| in the underlying file system throws an exception,
-         [=/reject=] |result| with that exception and abort.
+
+      1. If |child| is a [=directory entry=]:
+        1. If |child|'s path does not exists, [=/reject=] |result| with a
+            {{NotFoundError}} and abort
+        1. If |child|'s path is not a directory, [=/reject=] |result| with a
+            {{NotADirectoryError}} and abort
+        1. If |child| is not an empty directory, [=/reject=] |result| with a
+            {{NotEmptyError}} and abort
+      1. If |child| is a [=file entry=]:
+        1. If |child|'s path does not exists, [=/reject=] |result| with a
+            {{NotFoundError}} and abort
+        1. If |child|'s path is not a file, [=/reject=] |result| with a
+            {{NotAFileError}} and abort
 
          Note: If {{FileSystemRemoveOptions/recursive}} is `true`, the removal can fail
          non-atomically. Some files or directories might have been removed while other files
          or directories still exist.
 
-         Issue(68): Better specify what possible exceptions this could throw.
       1. [=/Resolve=] |result| with `undefined`.
   1. [=/Reject=] |result| with a {{NotFoundError}}.
 1. Return |result|.


### PR DESCRIPTION
Adds the ability for a file or directory to delete itself.

Currently, it is not possible to remove a file or directory given its handle. You must obtain the handle of the parent directory and call FileSystemDirectoryHandle::RemoveEntry. 

This would enable the common use case where you obtain a file handle from showSaveFilePicker, but then decide you don't want to save after all, and delete the file.

Fixes #214


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/pull/283.html" title="Last updated on Jun 8, 2021, 3:20 PM UTC (9429f48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/283/e74baf7...9429f48.html" title="Last updated on Jun 8, 2021, 3:20 PM UTC (9429f48)">Diff</a>