### PR TITLE
Add suggested name and directory options to file picker methods.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1153,6 +1153,8 @@ enum WellKnownDirectory {
   "videos",
 };
 
+typedef (WellKnownDirectory or FileSystemHandle) StartInDirectory;
+
 dictionary FilePickerAcceptType {
     USVString description;
     record<USVString, (USVString or sequence<USVString>)> accept;
@@ -1162,7 +1164,7 @@ dictionary FilePickerOptions {
     sequence<FilePickerAcceptType> types;
     boolean excludeAcceptAllOption = false;
     USVString id;
-    (WellKnownDirectory or FileSystemHandle)? startIn;
+    StartInDirectory? startIn;
 };
 
 dictionary OpenFilePickerOptions : FilePickerOptions {
@@ -1175,7 +1177,7 @@ dictionary SaveFilePickerOptions : FilePickerOptions {
 
 dictionary DirectoryPickerOptions {
     USVString id;
-    (WellKnownDirectory or FileSystemHandle)? startIn;
+    StartInDirectory? startIn;
 };
 
 [SecureContext]
@@ -1249,9 +1251,12 @@ To verify that an |environment| <dfn>is allowed to show a file picker</dfn>, run
 The <dfn method for=Window>showOpenFilePicker(|options|)</dfn> method, when invoked, must run
 these steps:
 
-1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
-
 1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
+
+1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
+1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
+   given |options|.{{FilePickerOptions/id}}, |options|.{{FilePickerOptions/startIn}} and |environment|.
+
 1. Let |global| be |environment|'s [=environment settings object/global object=].
 1. Verify that |environment| [=is allowed to show a file picker=].
 
@@ -1266,6 +1271,8 @@ these steps:
 
      The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
      Exactly how this is implemented, and what this prompt looks like is left up to the user agent.
+
+     TODO Something about |starting directory|.
 
   1. Wait for the user to have made their selection.
 
@@ -1283,6 +1290,8 @@ these steps:
          or [=/reject=] |p| with an {{AbortError}} and abort.
 
     1. Add a new {{FileSystemFileHandle}} associated with |entry| to |result|.
+
+  1. [=Remember a picked directory=] given |options|.{{FilePickerOptions/id}}, |entries|[0] and |environment|.
 
   1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
 
@@ -1318,9 +1327,12 @@ these steps:
 The <dfn method for=Window>showSaveFilePicker(|options|)</dfn> method, when invoked, must run
 these steps:
 
-1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
-
 1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
+
+1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
+1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
+   given |options|.{{FilePickerOptions/id}}, |options|.{{FilePickerOptions/startIn}} and |environment|.
+
 1. Let |global| be |environment|'s [=environment settings object/global object=].
 1. Verify that |environment| [=is allowed to show a file picker=].
 
@@ -1336,9 +1348,11 @@ these steps:
      to append to a user provided file name, but this is not required. In particular user agents are free to ignore
      potentially dangerous suffixes such as those ending in `".lnk"` or `".local"`.
 
-      If {{SaveFilePickerOptions/suggestedName}} is specified, the file picker prompt will be pre-filled with the
-     {{SaveFilePickerOptions/suggestedName}} as the default name to save as. The interaction between the
+     If |options|.{{SaveFilePickerOptions/suggestedName}} is specified, the file picker prompt will be pre-filled with the
+     |options|.{{SaveFilePickerOptions/suggestedName}} as the default name to save as. The interaction between the
      {{SaveFilePickerOptions/suggestedName}} and |accepts options| is left up to the user agent.
+
+     TODO Something about |starting directory|.
 
   1. Wait for the user to have made their selection.
 
@@ -1356,6 +1370,8 @@ these steps:
   1. Set |entry|'s [=binary data=] to an empty [=byte sequence=].
 
   1. Set |result| to a new {{FileSystemFileHandle}} associated with |entry|.
+
+  1. [=Remember a picked directory=] given |options|.{{FilePickerOptions/id}}, |entry| and |environment|.
 
   1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
 
@@ -1505,46 +1521,82 @@ To <dfn>validate a suffix</dfn> |suffix|, run the following steps:
 The {{FilePickerOptions/id}} and {{FilePickerOptions/startIn}} fields can be specified to suggest
 the directory which the file picker opens to.
 
+If neither of these options are specified, the user agent remembers the last directory a file
+or directory was picked from, and new pickers will start out in that directory. By specifying an
+{{FilePickerOptions/id}} the user agent can remember different directories for different IDs
+(user agents will only remember directories for a limited number of IDs).
+
+Specifying {{FilePickerOptions/startIn}} as a {{WellKnownDirectory}} will result in the dialog
+starting in that directory, unless an explicit ID was also passed and something...
+
+Specifying {{FilePickerOptions/startIn}} as a {{FileSystemFileHandle}} will result in the dialog
+starting in the parent directory of that file, while passing in a {{FileSystemDirectoryHandle}}
+will result in the dialog to start in the passed in directory. These take precedence even if
+an explicit {{FilePickerOptions/id}} is also passed in.
+
 (TODO: maybe a note about how this is merely where the picker STARTS at, not where it finishes? Particularly with saving files)
 
+For example, given a {{FileSystemDirectoryHandle}} <var ignore>project_dir</var>, the following will show
+a file picker that starts out in that directory:
 <pre class=example id="filepickeroptions-starting-directory-example1" highlight=js>
 const options = {
   <l>{{FilePickerOptions/id}}</l>: 'foo',
-  <l>{{FilePickerOptions/startIn}}</l>: {{FileSystemHandle}},  (TODO: how to represent existing Handle?)
+  <l>{{FilePickerOptions/startIn}}</l>: |project_dir|,
 };
 </pre>
 
 </div>
 
+A user agent holds a <dfn>recently picked directory map</dfn>, which is a
+[=map=] of [=/origins=] to [=path id maps=].
+
+A <dfn>path id map</dfn> is a [=map=] of [=valid path ids=] to paths.
+
+A <dfn>valid path id</dfn> is a [=string=] where each character is [=ASCII alphanumeric=] or "_" or "-".
+
 <div algorithm>
-To <dfn>determine the directory the file picker will start in</dfn>, run the following steps:
+To <dfn>determine the directory the picker will start in</dfn>, given an optional [=string=] |id|,
+an optional {{StartInDirectory}} |startIn| and an [=environment settings object=] |environment|,
+run the following steps:
 
-(TODO: This is just a sketch.
- - The wording here is much more loose and colloquial than it should be
- - URL vs Path?
-)
+1. If |id| given, and is not a [=valid path id=], throw a {{TypeError}}.
+1. If |id|'s [=string/length=] is more than 32, throw a {{TypeError}}.
 
-1. If {{FilePickerOptions/startIn}} is a {{FileSystemHandle}}, resolve to a path.
+1. Let |origin| be |environment|'s [=environment settings object/origin=].
+
+1. If |startIn| is a {{FileSystemHandle}}, resolve to a path.
   1. Is this directory not valid (Sandboxed URL), ignore.
   1. If {{FileSystemFileHandle}}, return parent's path
   1. If {{FileSystemDirectoryHandle}}, return path
 
-1. If {{FilePickerOptions/id}} is non-empty
-  1. If mapping exists ID-> path, return this stored path
+1. If |id| is non-empty:
+  1. If [=recently picked directory map=][|origin|] [=map/exists=]:
+    1. Let |path map| be [=recently picked directory map=][|origin|].
+    1. If |path map|[|id|] [=map/exists=], then return |path map|[|id|].
 
-1. If {{FilePickerOptions/startIn}} is a {{WellKnownDirectory}}...
-  1. If invalid, ignore.
-  1. Otherwise return corresponding path
+1. If |startIn| is a {{WellKnownDirectory}}:
+  1. TODO Return the corresponding path.
 
-1. If mapping default ID -> stored path exists, return stored path
+1. If |id| is not specified, or is an empty string:
+  1. If [=recently picked directory map=][|origin|] [=map/exists=]:
+    1. Let |path map| be [=recently picked directory map=][|origin|].
+    1. If |path map|[""] [=map/exists=], then return |path map|[""].
 
-1. Return a default path (ex: Documents)
+1. Return a default path in a user agent specific manner.
 
-If file picker operation succeeded:
+</div>
 
-1. If {{FilePickerOptions/id}} is non-empty, store mapping from ID -> picked path
-1. If {{FilePickerOptions/id}} is empty, store mapping from default ID -> picked path
-(TODO: do we need to mention the limit here?)
+<div algorithm>
+To <dfn>remember a picked directory</dfn>, given an optional [=string=] |id|,
+an [=/entry=] |entry|, and an [=environment settings object=] |environment|,
+run the following steps:
+
+1. Let |origin| be |environment|'s [=environment settings object/origin=].
+1. If [=recently picked directory map=][|origin|] does not [=map/exist=],
+  then set [=recently picked directory map=][|origin|] to a empty [=path id map=].
+1. Set [=recently picked directory map=][|origin|][|id|] to |entry|'s path.
+
+(TODO: We should mention the limit here?)
 
 </div>
 
@@ -1555,16 +1607,20 @@ If file picker operation succeeded:
   :: Shows a directory picker that lets the user select a single directory, returning a handle for
     the selected directory.
 
-  The {{DirectoryPickerOptions\id}} and {{DirectoryPickerOptions\startIn}} fields behave
-  identically to the {{FilePickerOptions\id}} and {{FilePickerOptions\startIn}} fields, respectively.
+  The {{DirectoryPickerOptions/id}} and {{DirectoryPickerOptions/startIn}} fields behave
+  identically to the {{FilePickerOptions/id}} and {{FilePickerOptions/startIn}} fields, respectively.
   See [[#api-filepickeroptions-starting-directory]] for details on how to use these fields.
 </div>
 
 <div algorithm>
-The <dfn method for=Window>showDirectoryPicker(<var ignore>options</var>)</dfn> method, when invoked, must run
+The <dfn method for=Window>showDirectoryPicker(<var>options</var>)</dfn> method, when invoked, must run
 these steps:
 
 1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
+
+1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
+   given |options|.{{DirectoryPickerOptions/id}}, |options|.{{DirectoryPickerOptions/startIn}} and |environment|.
+
 1. Let |global| be |environment|'s [=environment settings object/global object=].
 1. Verify that |environment| [=is allowed to show a file picker=].
 
@@ -1574,7 +1630,7 @@ these steps:
   1. Optionally, wait until any prior execution of this algorithm has terminated.
 
   1. Display a prompt to the user requesting that the user pick a directory.
-    (TODO: mention starting directory here)
+     This prompt should start out showing |starting directory|, if that is a valid directory.
 
   1. Wait for the user to have made their selection.
 
@@ -1590,6 +1646,8 @@ these steps:
        or [=/reject=] |p| with an {{AbortError}} and abort.
 
   1. Set |result| to a new {{FileSystemDirectoryHandle}} associated with |entry|.
+
+  1. [=Remember a picked directory=] given |options|.{{DirectoryPickerOptions/id}}, |entry| and |environment|.
 
   1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
 

--- a/index.bs
+++ b/index.bs
@@ -1639,12 +1639,12 @@ run the following steps:
 1. If |startIn| is a {{FileSystemHandle}}:
   1. Let |entry| be |startIn|'s [=FileSystemHandle/entry=].
   1. If |entry| does not represent an [=/entry=] in an [=origin private file system=]:
-    1. If |entry| is a [=file entry=],
-       return the path on the local file system corresponding to the parent directory of |entry|,
-       if such a path can be determined.
-    1. If |entry| is a [=directory entry=],
-       return the path on the local file system corresponding to |entry|,
-       if such a path can be determined.
+    1. If |entry| is a [=file entry=], and a path on the local file system
+       corresponding to the parent directory if |entry| can be determined,
+       then return that path.
+    1. If |entry| is a [=directory entry=], and a path on the local file system
+       corresponding to |entry| can be determined,
+       then return that path.
 
 1. If |id| is non-empty:
   1. If [=recently picked directory map=][|origin|] [=map/exists=]:

--- a/index.bs
+++ b/index.bs
@@ -1526,22 +1526,61 @@ or directory was picked from, and new pickers will start out in that directory. 
 {{FilePickerOptions/id}} the user agent can remember different directories for different IDs
 (user agents will only remember directories for a limited number of IDs).
 
-Specifying {{FilePickerOptions/startIn}} as a {{WellKnownDirectory}} will result in the dialog
-starting in that directory, unless an explicit ID was also passed and something...
+<pre class=example id="filepickeroptions-starting-directory-example1" highlight=js>
+// If a mapping exists from this ID to a previousy picked directory, start in
+// this directory. Otherwise, a mapping will be created from this ID to the
+// directory of the resulting file picker invocation.
+const options = {
+  <l>{{FilePickerOptions/id}}</l>: 'foo',
+};
+</pre>
 
 Specifying {{FilePickerOptions/startIn}} as a {{FileSystemFileHandle}} will result in the dialog
 starting in the parent directory of that file, while passing in a {{FileSystemDirectoryHandle}}
 will result in the dialog to start in the passed in directory. These take precedence even if
 an explicit {{FilePickerOptions/id}} is also passed in.
 
-(TODO: maybe a note about how this is merely where the picker STARTS at, not where it finishes? Particularly with saving files)
-
-For example, given a {{FileSystemDirectoryHandle}} <var ignore>project_dir</var>, the following will show
+For example, given a {{FileSystemDirectoryHandle}} <var>project_dir</var>, the following will show
 a file picker that starts out in that directory:
-<pre class=example id="filepickeroptions-starting-directory-example1" highlight=js>
+
+<pre class=example id="filepickeroptions-starting-directory-example2" highlight=js>
+// The picker will open to the directory of |project_dir| regardless of whether
+// 'foo' has a valid mapping.
 const options = {
   <l>{{FilePickerOptions/id}}</l>: 'foo',
   <l>{{FilePickerOptions/startIn}}</l>: |project_dir|,
+};
+</pre>
+
+NOTE: The {{FilePickerOptions/id}} and {{FilePickerOptions/startIn}} fields control only
+the directory the picker opens to. In the above example, it cannot be assumed that
+the {{FilePickerOptions/id}} 'foo' will map to the same directory as |project_dir|
+once the file picker operation has completed.
+
+Specifying {{FilePickerOptions/startIn}} as a {{WellKnownDirectory}} will result in the dialog
+starting in that directory, unless an explicit ID was also passed in which has a mapping to a
+valid directory.
+
+Below is an example of specifying both an {{FilePickerOptions/id}} and
+{{FilePickerOptions/startIn}} as a {{WellKnownDirectory}}. If there is an existing
+mapping from the given ID to a path, this mapping is used. Otherwise, the path suggested
+via the {{WellKnownDirectory}} is used.
+
+<pre class=example id="filepickeroptions-starting-directory-example3" highlight=js>
+// First time specifying the ID 'foo'. It is not mapped to a directory.
+// The file picker will fall back to opening to the Downloads directory. TODO: link this.
+const options = {
+  <l>{{FilePickerOptions/id}}</l>: 'foo',  // Unmapped.
+  <l>{{FilePickerOptions/startIn}}</l>: 'downloads',  // Start here.
+};
+
+// Later...
+
+// The ID 'foo' may or may not be mapped. For example, the mapping for this ID
+// may have been evicted.
+const options = {
+  <l>{{FilePickerOptions/id}}</l>: 'foo',  // Maybe mapped. If so, start here.
+  <l>{{FilePickerOptions/startIn}}</l>: 'downloads',  // Otherwise, start here.
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -1319,7 +1319,7 @@ these steps:
     file picker will open to. See [[#api-filepickeroptions]] for details.
 </div>
 
-Advisement: The {{FilePickerOptions/suggestedName}} option was first introduced in Chrome 91.
+Advisement: The {{SaveFilePickerOptions/suggestedName}} option was first introduced in Chrome 91.
 
 <div algorithm>
 The <dfn method for=Window>showSaveFilePicker(|options|)</dfn> method, when invoked, must run
@@ -1549,14 +1549,14 @@ const options = {
 };
 </pre>
 
-NOTE: The {{FilePickerOptions/id}} and {{FilePickerOptions/startIn}} fields control only
+The {{FilePickerOptions/id}} and {{FilePickerOptions/startIn}} fields control only
 the directory the picker opens to. In the above example, it cannot be assumed that
 the {{FilePickerOptions/id}} 'foo' will map to the same directory as |project_dir|
 once the file picker operation has completed.
 
 Specifying {{FilePickerOptions/startIn}} as a {{WellKnownDirectory}} will result in the dialog
-starting in that directory, unless an explicit ID was also passed in which has a mapping to a
-valid directory.
+starting in that directory, unless an explicit {{FilePickerOptions/id}} was also passed
+in which has a mapping to a valid directory.
 
 Below is an example of specifying both an {{FilePickerOptions/id}} and
 {{FilePickerOptions/startIn}} as a {{WellKnownDirectory}}. If there is an existing
@@ -1568,16 +1568,16 @@ via the {{WellKnownDirectory}} is used.
 // The file picker will fall back to opening to the Downloads directory. TODO: link this.
 const options = {
   <l>{{FilePickerOptions/id}}</l>: 'foo',  // Unmapped.
-  <l>{{FilePickerOptions/startIn}}</l>: 'downloads',  // Start here.
+  <l>{{FilePickerOptions/startIn}}</l>: <l>{{WellKnownDirectory/"downloads"}}</l>,  // Start here.
 };
 
 // Later...
 
-// The ID 'foo' may or may not be mapped. For example, the mapping for this ID
-// may have been evicted.
+// The ID 'foo' might or might not be mapped. For example, the mapping for this ID
+// might have been evicted.
 const options = {
   <l>{{FilePickerOptions/id}}</l>: 'foo',  // Maybe mapped. If so, start here.
-  <l>{{FilePickerOptions/startIn}}</l>: 'downloads',  // Otherwise, start here.
+  <l>{{FilePickerOptions/startIn}}</l>: <l>{{WellKnownDirectory/"downloads"}}</l>,  // Otherwise, start here.
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -1228,162 +1228,6 @@ To verify that an |environment| <dfn>is allowed to show a file picker</dfn>, run
 
 </div>
 
-## The {{showOpenFilePicker()}} method ## {#api-showopenfilepicker}
-
-<div class="note domintro">
-  : [ |handle| ] = await window . {{showOpenFilePicker()}}
-  : [ |handle| ] = await window . {{showOpenFilePicker()|showOpenFilePicker}}({ {{OpenFilePickerOptions/multiple}}: false })
-  :: Shows a file picker that lets a user select a single existing file, returning a handle for
-    the selected file.
-
-  : handles = await window . {{showOpenFilePicker()|showOpenFilePicker}}({ {{OpenFilePickerOptions/multiple}}: true })
-  :: Shows a file picker that lets a user select multiple existing files, returning handles for
-    the selected files.
-
-    Additional options can be passed to {{showOpenFilePicker()}} to indicate the types of files
-    the website wants the user to select and the preferred directory which the
-    file picker will open to. See [[#api-filepickeroptions]] for details.
-</div>
-
-<div algorithm>
-The <dfn method for=Window>showOpenFilePicker(|options|)</dfn> method, when invoked, must run
-these steps:
-
-1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
-
-1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
-1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
-   given |options|.{{FilePickerOptions/id}}, |options|.{{FilePickerOptions/startIn}} and |environment|.
-
-1. Let |global| be |environment|'s [=environment settings object/global object=].
-1. Verify that |environment| [=is allowed to show a file picker=].
-
-1. Let |p| be [=a new promise=].
-1. Run the following steps [=in parallel=]:
-
-  1. Optionally, wait until any prior execution of this algorithm has terminated.
-
-  1. Display a prompt to the user requesting that the user pick some files.
-     If |options|.{{OpenFilePickerOptions/multiple}} is false, there must be no more than one file selected;
-     otherwise any number may be selected.
-
-     The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
-     Exactly how this is implemented, and what this prompt looks like is left up to the user agent.
-
-     When possible, this prompt should start out showing |starting directory|.
-
-  1. Wait for the user to have made their selection.
-
-  1. If the user dismissed the prompt without making a selection,
-     [=/reject=] |p| with an {{AbortError}} and abort.
-
-  1. Let |entries| be a [=/list=] of [=file entries=] representing the selected files or directories.
-  1. Let |result| be a empty [=/list=].
-
-  1. [=list/For each=] |entry| of |entries|:
-    1. If |entry| is deemed [=too sensitive or dangerous=] to be exposed to this website by the user agent:
-      1. Inform the user that the selected files or directories can't be exposed to this website.
-      1. At the discretion of the user agent,
-         either go back to the beginning of these [=in parallel=] steps,
-         or [=/reject=] |p| with an {{AbortError}} and abort.
-
-    1. Add a new {{FileSystemFileHandle}} associated with |entry| to |result|.
-
-  1. [=Remember a picked directory=] given |options|.{{FilePickerOptions/id}}, |entries|[0] and |environment|.
-
-  1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
-
-     Note: This lets a website immediately perform operations on the returned handles that
-     might require user activation, such as requesting more permissions.
-
-  1. [=/Resolve=] |p| with |result|.
-
-1. Return |p|.
-
-</div>
-
-## The {{Window/showSaveFilePicker()}} method ## {#api-showsavefilepicker}
-
-<div class="note domintro">
-  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}( |options| )
-  :: Shows a file picker that lets a user select a single file, returning a handle for
-    the selected file. The selected file does not have to exist already. If the selected
-    file does not exist a new empty file is created before this method returns, otherwise
-    the existing file is cleared before this method returned.
-
-  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}({ {{SaveFilePickerOptions/suggestedName}}: "README.md" })
-  :: Shows a file picker with the suggested "README.md" file name pre-filled as the default file name to save as.
-
-    Additional |options| can be passed to {{showSaveFilePicker()}} to indicate the types of files
-    the website wants the user to select and the preferred directory which the
-    file picker will open to. See [[#api-filepickeroptions]] for details.
-</div>
-
-Advisement: The {{SaveFilePickerOptions/suggestedName}} option was first introduced in Chrome 91.
-
-<div algorithm>
-The <dfn method for=Window>showSaveFilePicker(|options|)</dfn> method, when invoked, must run
-these steps:
-
-1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
-
-1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
-1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
-   given |options|.{{FilePickerOptions/id}}, |options|.{{FilePickerOptions/startIn}} and |environment|.
-
-1. Let |global| be |environment|'s [=environment settings object/global object=].
-1. Verify that |environment| [=is allowed to show a file picker=].
-
-1. Let |p| be [=a new promise=].
-1. Run the following steps [=in parallel=]:
-
-  1. Optionally, wait until any prior execution of this algorithm has terminated.
-
-  1. Display a prompt to the user requesting that the user pick exactly one file.
-     The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
-     Exactly how this is implemented, and what this prompt looks like is left up to the user agent.
-     If |accepts options| are displayed in the UI, the selected option should also be used to suggest an extension
-     to append to a user provided file name, but this is not required. In particular user agents are free to ignore
-     potentially dangerous suffixes such as those ending in `".lnk"` or `".local"`.
-
-     When possible, this prompt should start out showing |starting directory|.
-
-     If |options|.{{SaveFilePickerOptions/suggestedName}} is specified, the file picker prompt will be pre-filled with the
-     |options|.{{SaveFilePickerOptions/suggestedName}} as the default name to save as. The interaction between the
-     {{SaveFilePickerOptions/suggestedName}} and |accepts options| is left up to the user agent.
-     If the {{SaveFilePickerOptions/suggestedName}} is deemed too dangerous, user agents should ignore or sanitize the
-     suggested file name, similar to the sanitization done when fetching something <a spec=html>as a download</a>.
-
-  1. Wait for the user to have made their selection.
-
-  1. If the user dismissed the prompt without making a selection,
-     [=/reject=] |p| with an {{AbortError}} and abort.
-
-  1. Let |entry| be a [=file entry=] representing the selected file.
-
-  1. If |entry| is deemed [=too sensitive or dangerous=] to be exposed to this website by the user agent:
-    1. Inform the user that the selected files or directories can't be exposed to this website.
-    1. At the discretion of the user agent,
-       either go back to the beginning of these [=in parallel=] steps,
-       or [=/reject=] |p| with an {{AbortError}} and abort.
-
-  1. Set |entry|'s [=binary data=] to an empty [=byte sequence=].
-
-  1. Set |result| to a new {{FileSystemFileHandle}} associated with |entry|.
-
-  1. [=Remember a picked directory=] given |options|.{{FilePickerOptions/id}}, |entry| and |environment|.
-
-  1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
-
-     Note: This lets a website immediately perform operations on the returned handles that
-     might require user activation, such as requesting more permissions.
-
-  1. [=/Resolve=] |p| with |result|.
-
-1. Return |p|.
-
-</div>
-
 ## File picker options ## {#api-filepickeroptions}
 
 ### Accepted file types ### {#api-filepickeroptions-types}
@@ -1668,6 +1512,162 @@ run the following steps:
 1. If |id| is not specified, let |id| be an empty string.
 1. Set [=recently picked directory map=][|origin|][|id|] to the path on the local file system corresponding to |entry|,
    if such a path can be determined.
+
+</div>
+
+## The {{showOpenFilePicker()}} method ## {#api-showopenfilepicker}
+
+<div class="note domintro">
+  : [ |handle| ] = await window . {{showOpenFilePicker()}}
+  : [ |handle| ] = await window . {{showOpenFilePicker()|showOpenFilePicker}}({ {{OpenFilePickerOptions/multiple}}: false })
+  :: Shows a file picker that lets a user select a single existing file, returning a handle for
+    the selected file.
+
+  : handles = await window . {{showOpenFilePicker()|showOpenFilePicker}}({ {{OpenFilePickerOptions/multiple}}: true })
+  :: Shows a file picker that lets a user select multiple existing files, returning handles for
+    the selected files.
+
+    Additional options can be passed to {{showOpenFilePicker()}} to indicate the types of files
+    the website wants the user to select and the preferred directory which the
+    file picker will open to. See [[#api-filepickeroptions]] for details.
+</div>
+
+<div algorithm>
+The <dfn method for=Window>showOpenFilePicker(|options|)</dfn> method, when invoked, must run
+these steps:
+
+1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
+
+1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
+1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
+   given |options|.{{FilePickerOptions/id}}, |options|.{{FilePickerOptions/startIn}} and |environment|.
+
+1. Let |global| be |environment|'s [=environment settings object/global object=].
+1. Verify that |environment| [=is allowed to show a file picker=].
+
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+
+  1. Optionally, wait until any prior execution of this algorithm has terminated.
+
+  1. Display a prompt to the user requesting that the user pick some files.
+     If |options|.{{OpenFilePickerOptions/multiple}} is false, there must be no more than one file selected;
+     otherwise any number may be selected.
+
+     The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
+     Exactly how this is implemented, and what this prompt looks like is left up to the user agent.
+
+     When possible, this prompt should start out showing |starting directory|.
+
+  1. Wait for the user to have made their selection.
+
+  1. If the user dismissed the prompt without making a selection,
+     [=/reject=] |p| with an {{AbortError}} and abort.
+
+  1. Let |entries| be a [=/list=] of [=file entries=] representing the selected files or directories.
+  1. Let |result| be a empty [=/list=].
+
+  1. [=list/For each=] |entry| of |entries|:
+    1. If |entry| is deemed [=too sensitive or dangerous=] to be exposed to this website by the user agent:
+      1. Inform the user that the selected files or directories can't be exposed to this website.
+      1. At the discretion of the user agent,
+         either go back to the beginning of these [=in parallel=] steps,
+         or [=/reject=] |p| with an {{AbortError}} and abort.
+
+    1. Add a new {{FileSystemFileHandle}} associated with |entry| to |result|.
+
+  1. [=Remember a picked directory=] given |options|.{{FilePickerOptions/id}}, |entries|[0] and |environment|.
+
+  1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
+
+     Note: This lets a website immediately perform operations on the returned handles that
+     might require user activation, such as requesting more permissions.
+
+  1. [=/Resolve=] |p| with |result|.
+
+1. Return |p|.
+
+</div>
+
+## The {{Window/showSaveFilePicker()}} method ## {#api-showsavefilepicker}
+
+<div class="note domintro">
+  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}( |options| )
+  :: Shows a file picker that lets a user select a single file, returning a handle for
+    the selected file. The selected file does not have to exist already. If the selected
+    file does not exist a new empty file is created before this method returns, otherwise
+    the existing file is cleared before this method returned.
+
+  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}({ {{SaveFilePickerOptions/suggestedName}}: "README.md" })
+  :: Shows a file picker with the suggested "README.md" file name pre-filled as the default file name to save as.
+
+    Additional |options| can be passed to {{showSaveFilePicker()}} to indicate the types of files
+    the website wants the user to select and the preferred directory which the
+    file picker will open to. See [[#api-filepickeroptions]] for details.
+</div>
+
+Advisement: The {{SaveFilePickerOptions/suggestedName}} option was first introduced in Chrome 91.
+
+<div algorithm>
+The <dfn method for=Window>showSaveFilePicker(|options|)</dfn> method, when invoked, must run
+these steps:
+
+1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
+
+1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
+1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
+   given |options|.{{FilePickerOptions/id}}, |options|.{{FilePickerOptions/startIn}} and |environment|.
+
+1. Let |global| be |environment|'s [=environment settings object/global object=].
+1. Verify that |environment| [=is allowed to show a file picker=].
+
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+
+  1. Optionally, wait until any prior execution of this algorithm has terminated.
+
+  1. Display a prompt to the user requesting that the user pick exactly one file.
+     The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
+     Exactly how this is implemented, and what this prompt looks like is left up to the user agent.
+     If |accepts options| are displayed in the UI, the selected option should also be used to suggest an extension
+     to append to a user provided file name, but this is not required. In particular user agents are free to ignore
+     potentially dangerous suffixes such as those ending in `".lnk"` or `".local"`.
+
+     When possible, this prompt should start out showing |starting directory|.
+
+     If |options|.{{SaveFilePickerOptions/suggestedName}} is specified, the file picker prompt will be pre-filled with the
+     |options|.{{SaveFilePickerOptions/suggestedName}} as the default name to save as. The interaction between the
+     {{SaveFilePickerOptions/suggestedName}} and |accepts options| is left up to the user agent.
+     If the {{SaveFilePickerOptions/suggestedName}} is deemed too dangerous, user agents should ignore or sanitize the
+     suggested file name, similar to the sanitization done when fetching something <a spec=html>as a download</a>.
+
+  1. Wait for the user to have made their selection.
+
+  1. If the user dismissed the prompt without making a selection,
+     [=/reject=] |p| with an {{AbortError}} and abort.
+
+  1. Let |entry| be a [=file entry=] representing the selected file.
+
+  1. If |entry| is deemed [=too sensitive or dangerous=] to be exposed to this website by the user agent:
+    1. Inform the user that the selected files or directories can't be exposed to this website.
+    1. At the discretion of the user agent,
+       either go back to the beginning of these [=in parallel=] steps,
+       or [=/reject=] |p| with an {{AbortError}} and abort.
+
+  1. Set |entry|'s [=binary data=] to an empty [=byte sequence=].
+
+  1. Set |result| to a new {{FileSystemFileHandle}} associated with |entry|.
+
+  1. [=Remember a picked directory=] given |options|.{{FilePickerOptions/id}}, |entry| and |environment|.
+
+  1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
+
+     Note: This lets a website immediately perform operations on the returned handles that
+     might require user activation, such as requesting more permissions.
+
+  1. [=/Resolve=] |p| with |result|.
+
+1. Return |p|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1198,8 +1198,6 @@ file pickers will also let you pick files and directories on Google Drive.
 
 Advisement: In Chrome versions earlier than 85, this was implemented as a generic `chooseFileSystemEntries` method.
 
-(TODO: Do we need an advisement about when file picker enhancements were introduced?)
-
 ## Local File System Permissions ## {#local-file-system-permissions}
 
 The fact that the user picked the specific files returned by the [=local file system handle factories=] in a prompt
@@ -1265,14 +1263,14 @@ these steps:
 
   1. Optionally, wait until any prior execution of this algorithm has terminated.
 
-  1. Display a prompt to the user requesting that the user pick some files. (TODO: do we need more info here?)
+  1. Display a prompt to the user requesting that the user pick some files.
      If |options|.{{OpenFilePickerOptions/multiple}} is false, there must be no more than one file selected;
      otherwise any number may be selected.
 
      The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
      Exactly how this is implemented, and what this prompt looks like is left up to the user agent.
 
-     TODO Something about |starting directory|.
+     When possible, this prompt should start out showing |starting directory|.
 
   1. Wait for the user to have made their selection.
 
@@ -1313,15 +1311,15 @@ these steps:
     file does not exist a new empty file is created before this method returns, otherwise
     the existing file is cleared before this method returned.
 
-  (TODO: Confirm this is how we're supposed to describe the suggestedName arg)
-
-  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}({ {{SaveFilePickerOptions/suggestedName}}: "fruit" })
-  :: Shows a file picker with the suggested file name pre-filled as the default file name to save as.
+  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}({ {{SaveFilePickerOptions/suggestedName}}: "README.md" })
+  :: Shows a file picker with the suggested "README.md" file name pre-filled as the default file name to save as.
 
     Additional |options| can be passed to {{showSaveFilePicker()}} to indicate the types of files
     the website wants the user to select and the preferred directory which the
     file picker will open to. See [[#api-filepickeroptions]] for details.
 </div>
+
+Advisement: The {{FilePickerOptions/suggestedName}} option was first introduced in Chrome 91.
 
 <div algorithm>
 The <dfn method for=Window>showSaveFilePicker(|options|)</dfn> method, when invoked, must run
@@ -1348,11 +1346,13 @@ these steps:
      to append to a user provided file name, but this is not required. In particular user agents are free to ignore
      potentially dangerous suffixes such as those ending in `".lnk"` or `".local"`.
 
+     When possible, this prompt should start out showing |starting directory|.
+
      If |options|.{{SaveFilePickerOptions/suggestedName}} is specified, the file picker prompt will be pre-filled with the
      |options|.{{SaveFilePickerOptions/suggestedName}} as the default name to save as. The interaction between the
      {{SaveFilePickerOptions/suggestedName}} and |accepts options| is left up to the user agent.
-
-     TODO Something about |starting directory|.
+     If the {{SaveFilePickerOptions/suggestedName}} is deemed too dangerous, user agents should ignore or sanitize the
+     suggested file name, similar to the sanitization done when fetching something <a spec=html>as a download</a>.
 
   1. Wait for the user to have made their selection.
 
@@ -1384,18 +1384,15 @@ these steps:
 
 </div>
 
-## {{FilePickerOptions}} ## {#api-filepickeroptions}
+## File picker options ## {#api-filepickeroptions}
+
+### Accepted file types ### {#api-filepickeroptions-types}
 
 <div class="note domintro">
 The {{showOpenFilePicker(options)}} and {{showSaveFilePicker(options)}} methods accept a
 {{FilePickerOptions}} argument, which lets the website specify the types of files
-the file picker will let the user select and the preferred directory which the
-file picker will open to.
-</div>
+the file picker will let the user select.
 
-### {{FilePickerOptions}}.{{FilePickerOptions/types}} ### {#api-filepickeroptions-types}
-
-<div class="note domintro">
 Each entry in {{FilePickerOptions/types}} specifies a single user selectable option
 for filtering the files displayed in the file picker.
 
@@ -1515,7 +1512,7 @@ To <dfn>validate a suffix</dfn> |suffix|, run the following steps:
 
 </div>
 
-### {{FilePickerOptions}} Starting Directory ### {#api-filepickeroptions-starting-directory}
+### Starting Directory ### {#api-filepickeroptions-starting-directory}
 
 <div class="note domintro">
 The {{FilePickerOptions/id}} and {{FilePickerOptions/startIn}} fields can be specified to suggest
@@ -1547,12 +1544,42 @@ const options = {
 
 </div>
 
+Advisement: The {{FilePickerOptions/startIn}} and {{FilePickerOptions/id}} options were first introduced in Chrome 91.
+
 A user agent holds a <dfn>recently picked directory map</dfn>, which is a
 [=map=] of [=/origins=] to [=path id maps=].
 
 A <dfn>path id map</dfn> is a [=map=] of [=valid path ids=] to paths.
 
 A <dfn>valid path id</dfn> is a [=string=] where each character is [=ASCII alphanumeric=] or "_" or "-".
+
+To prevent a [=path id map=] from growing without a bound, user agents should implement
+some mechanism to limit how many recently picked directories will be remembered. This
+can for example be done by evicting least recently used entries.
+
+The <dfn enum>WellKnownDirectory</dfn> enum lets a website pick one of several well-known
+paths. The exact paths the various values of this enum map to is left up to the user agent.
+The following list describes the meaning of each of the values, and gives possible example paths on different operating systems:
+
+<dl dfn-for=WellKnownDirectory>
+: <dfn enum-value>"desktop"</dfn>
+:: The user's Desktop directory, if such a thing exists. For example this could be
+   `C:\Documents and Settings\username\Desktop`, `/Users/username/Desktop`, or `/home/username/Desktop`.
+: <dfn enum-value>"documents"</dfn>
+:: Directory in which documents created by the user would typically be stored.
+   For example `C:\Documents and Settings\username\My Documents`, `/Users/username/Documents`, or `/home/username/Documents`.
+: <dfn enum-value>"downloads"</dfn>
+:: Directory where downloaded files would typically be stored.
+   For example `C:\Documents and Settings\username\Downloads`, `/Users/username/Downloads`, or `/home/username/Downloads`.
+: <dfn enum-value>"music"</dfn>
+:: Directory where audio files would typically be stored.
+   For example `C:\Documents and Settings\username\My Documents\My Music`, `/Users/username/Music`, or `/home/username/Music`.
+: <dfn enum-value>"pictures"</dfn>
+:: Directory where photos and other still images would typically be stored.
+   For example `C:\Documents and Settings\username\My Documents\My Pictures`, `/Users/username/Pictures`, or `/home/username/Pictures`.
+: <dfn enum-value>"videos"</dfn>
+:: Directory where videos/movies would typically be stored.
+   For example `C:\Documents and Settings\username\My Documents\My Videos`, `/Users/username/Movies`, or `/home/username/Videos`.
 
 <div algorithm>
 To <dfn>determine the directory the picker will start in</dfn>, given an optional [=string=] |id|,
@@ -1564,10 +1591,15 @@ run the following steps:
 
 1. Let |origin| be |environment|'s [=environment settings object/origin=].
 
-1. If |startIn| is a {{FileSystemHandle}}, resolve to a path.
-  1. Is this directory not valid (Sandboxed URL), ignore.
-  1. If {{FileSystemFileHandle}}, return parent's path
-  1. If {{FileSystemDirectoryHandle}}, return path
+1. If |startIn| is a {{FileSystemHandle}}:
+  1. Let |entry| be |startIn|'s [=FileSystemHandle/entry=].
+  1. If |entry| does not represent an [=/entry=] in an [=origin private file system=]:
+    1. If |entry| is a [=file entry=],
+       return the path on the local file system corresponding to the parent directory of |entry|,
+       if such a path can be determined.
+    1. Else, if |entry| is a [=directory entry=],
+       return the path on the local file system corresponding to |entry|,
+       if such a path can be determined.
 
 1. If |id| is non-empty:
   1. If [=recently picked directory map=][|origin|] [=map/exists=]:
@@ -1575,7 +1607,7 @@ run the following steps:
     1. If |path map|[|id|] [=map/exists=], then return |path map|[|id|].
 
 1. If |startIn| is a {{WellKnownDirectory}}:
-  1. TODO Return the corresponding path.
+  1. Return a user agent defined path corresponding to the {{WellKnownDirectory}} value of |startIn|.
 
 1. If |id| is not specified, or is an empty string:
   1. If [=recently picked directory map=][|origin|] [=map/exists=]:
@@ -1593,10 +1625,10 @@ run the following steps:
 
 1. Let |origin| be |environment|'s [=environment settings object/origin=].
 1. If [=recently picked directory map=][|origin|] does not [=map/exist=],
-  then set [=recently picked directory map=][|origin|] to a empty [=path id map=].
-1. Set [=recently picked directory map=][|origin|][|id|] to |entry|'s path.
-
-(TODO: We should mention the limit here?)
+   then set [=recently picked directory map=][|origin|] to a empty [=path id map=].
+1. If |id| is not specified, let |id| be an empty string.
+1. Set [=recently picked directory map=][|origin|][|id|] to the path on the local file system corresponding to |entry|,
+   if such a path can be determined.
 
 </div>
 
@@ -1630,7 +1662,8 @@ these steps:
   1. Optionally, wait until any prior execution of this algorithm has terminated.
 
   1. Display a prompt to the user requesting that the user pick a directory.
-     This prompt should start out showing |starting directory|, if that is a valid directory.
+
+     When possible, this prompt should start out showing |starting directory|.
 
   1. Wait for the user to have made their selection.
 

--- a/index.bs
+++ b/index.bs
@@ -1228,6 +1228,162 @@ To verify that an |environment| <dfn>is allowed to show a file picker</dfn>, run
 
 </div>
 
+## The {{showOpenFilePicker()}} method ## {#api-showopenfilepicker}
+
+<div class="note domintro">
+  : [ |handle| ] = await window . {{showOpenFilePicker()}}
+  : [ |handle| ] = await window . {{showOpenFilePicker()|showOpenFilePicker}}({ {{OpenFilePickerOptions/multiple}}: false })
+  :: Shows a file picker that lets a user select a single existing file, returning a handle for
+    the selected file.
+
+  : handles = await window . {{showOpenFilePicker()|showOpenFilePicker}}({ {{OpenFilePickerOptions/multiple}}: true })
+  :: Shows a file picker that lets a user select multiple existing files, returning handles for
+    the selected files.
+
+    Additional options can be passed to {{showOpenFilePicker()}} to indicate the types of files
+    the website wants the user to select and the preferred directory which the
+    file picker will open to. See [[#api-filepickeroptions]] for details.
+</div>
+
+<div algorithm>
+The <dfn method for=Window>showOpenFilePicker(|options|)</dfn> method, when invoked, must run
+these steps:
+
+1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
+
+1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
+1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
+   given |options|.{{FilePickerOptions/id}}, |options|.{{FilePickerOptions/startIn}} and |environment|.
+
+1. Let |global| be |environment|'s [=environment settings object/global object=].
+1. Verify that |environment| [=is allowed to show a file picker=].
+
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+
+  1. Optionally, wait until any prior execution of this algorithm has terminated.
+
+  1. Display a prompt to the user requesting that the user pick some files.
+     If |options|.{{OpenFilePickerOptions/multiple}} is false, there must be no more than one file selected;
+     otherwise any number may be selected.
+
+     The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
+     Exactly how this is implemented, and what this prompt looks like is left up to the user agent.
+
+     When possible, this prompt should start out showing |starting directory|.
+
+  1. Wait for the user to have made their selection.
+
+  1. If the user dismissed the prompt without making a selection,
+     [=/reject=] |p| with an {{AbortError}} and abort.
+
+  1. Let |entries| be a [=/list=] of [=file entries=] representing the selected files or directories.
+  1. Let |result| be a empty [=/list=].
+
+  1. [=list/For each=] |entry| of |entries|:
+    1. If |entry| is deemed [=too sensitive or dangerous=] to be exposed to this website by the user agent:
+      1. Inform the user that the selected files or directories can't be exposed to this website.
+      1. At the discretion of the user agent,
+         either go back to the beginning of these [=in parallel=] steps,
+         or [=/reject=] |p| with an {{AbortError}} and abort.
+
+    1. Add a new {{FileSystemFileHandle}} associated with |entry| to |result|.
+
+  1. [=Remember a picked directory=] given |options|.{{FilePickerOptions/id}}, |entries|[0] and |environment|.
+
+  1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
+
+     Note: This lets a website immediately perform operations on the returned handles that
+     might require user activation, such as requesting more permissions.
+
+  1. [=/Resolve=] |p| with |result|.
+
+1. Return |p|.
+
+</div>
+
+## The {{Window/showSaveFilePicker()}} method ## {#api-showsavefilepicker}
+
+<div class="note domintro">
+  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}( |options| )
+  :: Shows a file picker that lets a user select a single file, returning a handle for
+    the selected file. The selected file does not have to exist already. If the selected
+    file does not exist a new empty file is created before this method returns, otherwise
+    the existing file is cleared before this method returned.
+
+  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}({ {{SaveFilePickerOptions/suggestedName}}: "README.md" })
+  :: Shows a file picker with the suggested "README.md" file name pre-filled as the default file name to save as.
+
+    Additional |options| can be passed to {{showSaveFilePicker()}} to indicate the types of files
+    the website wants the user to select and the preferred directory which the
+    file picker will open to. See [[#api-filepickeroptions]] for details.
+</div>
+
+Advisement: The {{SaveFilePickerOptions/suggestedName}} option was first introduced in Chrome 91.
+
+<div algorithm>
+The <dfn method for=Window>showSaveFilePicker(|options|)</dfn> method, when invoked, must run
+these steps:
+
+1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
+
+1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
+1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
+   given |options|.{{FilePickerOptions/id}}, |options|.{{FilePickerOptions/startIn}} and |environment|.
+
+1. Let |global| be |environment|'s [=environment settings object/global object=].
+1. Verify that |environment| [=is allowed to show a file picker=].
+
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+
+  1. Optionally, wait until any prior execution of this algorithm has terminated.
+
+  1. Display a prompt to the user requesting that the user pick exactly one file.
+     The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
+     Exactly how this is implemented, and what this prompt looks like is left up to the user agent.
+     If |accepts options| are displayed in the UI, the selected option should also be used to suggest an extension
+     to append to a user provided file name, but this is not required. In particular user agents are free to ignore
+     potentially dangerous suffixes such as those ending in `".lnk"` or `".local"`.
+
+     When possible, this prompt should start out showing |starting directory|.
+
+     If |options|.{{SaveFilePickerOptions/suggestedName}} is specified, the file picker prompt will be pre-filled with the
+     |options|.{{SaveFilePickerOptions/suggestedName}} as the default name to save as. The interaction between the
+     {{SaveFilePickerOptions/suggestedName}} and |accepts options| is left up to the user agent.
+     If the {{SaveFilePickerOptions/suggestedName}} is deemed too dangerous, user agents should ignore or sanitize the
+     suggested file name, similar to the sanitization done when fetching something <a spec=html>as a download</a>.
+
+  1. Wait for the user to have made their selection.
+
+  1. If the user dismissed the prompt without making a selection,
+     [=/reject=] |p| with an {{AbortError}} and abort.
+
+  1. Let |entry| be a [=file entry=] representing the selected file.
+
+  1. If |entry| is deemed [=too sensitive or dangerous=] to be exposed to this website by the user agent:
+    1. Inform the user that the selected files or directories can't be exposed to this website.
+    1. At the discretion of the user agent,
+       either go back to the beginning of these [=in parallel=] steps,
+       or [=/reject=] |p| with an {{AbortError}} and abort.
+
+  1. Set |entry|'s [=binary data=] to an empty [=byte sequence=].
+
+  1. Set |result| to a new {{FileSystemFileHandle}} associated with |entry|.
+
+  1. [=Remember a picked directory=] given |options|.{{FilePickerOptions/id}}, |entry| and |environment|.
+
+  1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
+
+     Note: This lets a website immediately perform operations on the returned handles that
+     might require user activation, such as requesting more permissions.
+
+  1. [=/Resolve=] |p| with |result|.
+
+1. Return |p|.
+
+</div>
+
 ## File picker options ## {#api-filepickeroptions}
 
 ### Accepted file types ### {#api-filepickeroptions-types}
@@ -1512,162 +1668,6 @@ run the following steps:
 1. If |id| is not specified, let |id| be an empty string.
 1. Set [=recently picked directory map=][|origin|][|id|] to the path on the local file system corresponding to |entry|,
    if such a path can be determined.
-
-</div>
-
-## The {{showOpenFilePicker()}} method ## {#api-showopenfilepicker}
-
-<div class="note domintro">
-  : [ |handle| ] = await window . {{showOpenFilePicker()}}
-  : [ |handle| ] = await window . {{showOpenFilePicker()|showOpenFilePicker}}({ {{OpenFilePickerOptions/multiple}}: false })
-  :: Shows a file picker that lets a user select a single existing file, returning a handle for
-    the selected file.
-
-  : handles = await window . {{showOpenFilePicker()|showOpenFilePicker}}({ {{OpenFilePickerOptions/multiple}}: true })
-  :: Shows a file picker that lets a user select multiple existing files, returning handles for
-    the selected files.
-
-    Additional options can be passed to {{showOpenFilePicker()}} to indicate the types of files
-    the website wants the user to select and the preferred directory which the
-    file picker will open to. See [[#api-filepickeroptions]] for details.
-</div>
-
-<div algorithm>
-The <dfn method for=Window>showOpenFilePicker(|options|)</dfn> method, when invoked, must run
-these steps:
-
-1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
-
-1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
-1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
-   given |options|.{{FilePickerOptions/id}}, |options|.{{FilePickerOptions/startIn}} and |environment|.
-
-1. Let |global| be |environment|'s [=environment settings object/global object=].
-1. Verify that |environment| [=is allowed to show a file picker=].
-
-1. Let |p| be [=a new promise=].
-1. Run the following steps [=in parallel=]:
-
-  1. Optionally, wait until any prior execution of this algorithm has terminated.
-
-  1. Display a prompt to the user requesting that the user pick some files.
-     If |options|.{{OpenFilePickerOptions/multiple}} is false, there must be no more than one file selected;
-     otherwise any number may be selected.
-
-     The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
-     Exactly how this is implemented, and what this prompt looks like is left up to the user agent.
-
-     When possible, this prompt should start out showing |starting directory|.
-
-  1. Wait for the user to have made their selection.
-
-  1. If the user dismissed the prompt without making a selection,
-     [=/reject=] |p| with an {{AbortError}} and abort.
-
-  1. Let |entries| be a [=/list=] of [=file entries=] representing the selected files or directories.
-  1. Let |result| be a empty [=/list=].
-
-  1. [=list/For each=] |entry| of |entries|:
-    1. If |entry| is deemed [=too sensitive or dangerous=] to be exposed to this website by the user agent:
-      1. Inform the user that the selected files or directories can't be exposed to this website.
-      1. At the discretion of the user agent,
-         either go back to the beginning of these [=in parallel=] steps,
-         or [=/reject=] |p| with an {{AbortError}} and abort.
-
-    1. Add a new {{FileSystemFileHandle}} associated with |entry| to |result|.
-
-  1. [=Remember a picked directory=] given |options|.{{FilePickerOptions/id}}, |entries|[0] and |environment|.
-
-  1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
-
-     Note: This lets a website immediately perform operations on the returned handles that
-     might require user activation, such as requesting more permissions.
-
-  1. [=/Resolve=] |p| with |result|.
-
-1. Return |p|.
-
-</div>
-
-## The {{Window/showSaveFilePicker()}} method ## {#api-showsavefilepicker}
-
-<div class="note domintro">
-  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}( |options| )
-  :: Shows a file picker that lets a user select a single file, returning a handle for
-    the selected file. The selected file does not have to exist already. If the selected
-    file does not exist a new empty file is created before this method returns, otherwise
-    the existing file is cleared before this method returned.
-
-  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}({ {{SaveFilePickerOptions/suggestedName}}: "README.md" })
-  :: Shows a file picker with the suggested "README.md" file name pre-filled as the default file name to save as.
-
-    Additional |options| can be passed to {{showSaveFilePicker()}} to indicate the types of files
-    the website wants the user to select and the preferred directory which the
-    file picker will open to. See [[#api-filepickeroptions]] for details.
-</div>
-
-Advisement: The {{SaveFilePickerOptions/suggestedName}} option was first introduced in Chrome 91.
-
-<div algorithm>
-The <dfn method for=Window>showSaveFilePicker(|options|)</dfn> method, when invoked, must run
-these steps:
-
-1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
-
-1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
-1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
-   given |options|.{{FilePickerOptions/id}}, |options|.{{FilePickerOptions/startIn}} and |environment|.
-
-1. Let |global| be |environment|'s [=environment settings object/global object=].
-1. Verify that |environment| [=is allowed to show a file picker=].
-
-1. Let |p| be [=a new promise=].
-1. Run the following steps [=in parallel=]:
-
-  1. Optionally, wait until any prior execution of this algorithm has terminated.
-
-  1. Display a prompt to the user requesting that the user pick exactly one file.
-     The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
-     Exactly how this is implemented, and what this prompt looks like is left up to the user agent.
-     If |accepts options| are displayed in the UI, the selected option should also be used to suggest an extension
-     to append to a user provided file name, but this is not required. In particular user agents are free to ignore
-     potentially dangerous suffixes such as those ending in `".lnk"` or `".local"`.
-
-     When possible, this prompt should start out showing |starting directory|.
-
-     If |options|.{{SaveFilePickerOptions/suggestedName}} is specified, the file picker prompt will be pre-filled with the
-     |options|.{{SaveFilePickerOptions/suggestedName}} as the default name to save as. The interaction between the
-     {{SaveFilePickerOptions/suggestedName}} and |accepts options| is left up to the user agent.
-     If the {{SaveFilePickerOptions/suggestedName}} is deemed too dangerous, user agents should ignore or sanitize the
-     suggested file name, similar to the sanitization done when fetching something <a spec=html>as a download</a>.
-
-  1. Wait for the user to have made their selection.
-
-  1. If the user dismissed the prompt without making a selection,
-     [=/reject=] |p| with an {{AbortError}} and abort.
-
-  1. Let |entry| be a [=file entry=] representing the selected file.
-
-  1. If |entry| is deemed [=too sensitive or dangerous=] to be exposed to this website by the user agent:
-    1. Inform the user that the selected files or directories can't be exposed to this website.
-    1. At the discretion of the user agent,
-       either go back to the beginning of these [=in parallel=] steps,
-       or [=/reject=] |p| with an {{AbortError}} and abort.
-
-  1. Set |entry|'s [=binary data=] to an empty [=byte sequence=].
-
-  1. Set |result| to a new {{FileSystemFileHandle}} associated with |entry|.
-
-  1. [=Remember a picked directory=] given |options|.{{FilePickerOptions/id}}, |entry| and |environment|.
-
-  1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
-
-     Note: This lets a website immediately perform operations on the returned handles that
-     might require user activation, such as requesting more permissions.
-
-  1. [=/Resolve=] |p| with |result|.
-
-1. Return |p|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1228,166 +1228,6 @@ To verify that an |environment| <dfn>is allowed to show a file picker</dfn>, run
 
 </div>
 
-## The {{showOpenFilePicker()}} method ## {#api-showopenfilepicker}
-
-<div class="note domintro">
-  : [ |handle| ] = await window . {{showOpenFilePicker()}}
-  : [ |handle| ] = await window . {{showOpenFilePicker()|showOpenFilePicker}}({ {{OpenFilePickerOptions/multiple}}: false })
-  :: Shows a file picker that lets a user select a single existing file, returning a handle for
-    the selected file.
-
-  : handles = await window . {{showOpenFilePicker()|showOpenFilePicker}}({ {{OpenFilePickerOptions/multiple}}: true })
-  :: Shows a file picker that lets a user select multiple existing files, returning handles for
-    the selected files.
-
-    Additional options can be passed to {{showOpenFilePicker()}} to indicate the types of files
-    the website wants the user to select and the directory in which the
-    file picker will open. See [[#api-filepickeroptions]] for details.
-</div>
-
-<div algorithm>
-The <dfn method for=Window>showOpenFilePicker(|options|)</dfn> method, when invoked, must run
-these steps:
-
-1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
-
-1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
-1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
-   given |options|.{{FilePickerOptions/id}}, |options|.{{FilePickerOptions/startIn}} and |environment|.
-
-1. Let |global| be |environment|'s [=environment settings object/global object=].
-1. Verify that |environment| [=is allowed to show a file picker=].
-
-1. Let |p| be [=a new promise=].
-1. Run the following steps [=in parallel=]:
-
-  1. Optionally, wait until any prior execution of this algorithm has terminated.
-
-  1. Display a prompt to the user requesting that the user pick some files.
-     If |options|.{{OpenFilePickerOptions/multiple}} is false, there must be no more than one file selected;
-     otherwise any number may be selected.
-
-     The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
-     Exactly how this is implemented, and what this prompt looks like is [=implementation-defined=].
-
-     When possible, this prompt should start out showing |starting directory|.
-
-  1. Wait for the user to have made their selection.
-
-  1. If the user dismissed the prompt without making a selection,
-     [=/reject=] |p| with an {{AbortError}} and abort.
-
-  1. Let |entries| be a [=/list=] of [=file entries=] representing the selected files or directories.
-  1. Let |result| be a empty [=/list=].
-
-  1. [=list/For each=] |entry| of |entries|:
-    1. If |entry| is deemed [=too sensitive or dangerous=] to be exposed to this website by the user agent:
-      1. Inform the user that the selected files or directories can't be exposed to this website.
-      1. At the discretion of the user agent,
-         either go back to the beginning of these [=in parallel=] steps,
-         or [=/reject=] |p| with an {{AbortError}} and abort.
-
-    1. Add a new {{FileSystemFileHandle}} associated with |entry| to |result|.
-
-  1. [=Remember a picked directory=] given |options|.{{FilePickerOptions/id}}, |entries|[0] and |environment|.
-
-  1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
-
-     Note: This lets a website immediately perform operations on the returned handles that
-     might require user activation, such as requesting more permissions.
-
-  1. [=/Resolve=] |p| with |result|.
-
-1. Return |p|.
-
-</div>
-
-## The {{Window/showSaveFilePicker()}} method ## {#api-showsavefilepicker}
-
-<div class="note domintro">
-  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}( |options| )
-  :: Shows a file picker that lets a user select a single file, returning a handle for
-    the selected file. The selected file does not have to exist already. If the selected
-    file does not exist a new empty file is created before this method returns, otherwise
-    the existing file is cleared before this method returned.
-
-  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}({ {{SaveFilePickerOptions/suggestedName}}: "README.md" })
-  :: Shows a file picker with the suggested "README.md" file name pre-filled as the default file name to save as.
-
-    Additional |options| can be passed to {{showSaveFilePicker()}} to indicate the types of files
-    the website wants the user to select and the directory in which the
-    file picker will open. See [[#api-filepickeroptions]] for details.
-</div>
-
-Advisement: The {{SaveFilePickerOptions/suggestedName}} option was first introduced in Chrome 91.
-
-<div algorithm>
-The <dfn method for=Window>showSaveFilePicker(|options|)</dfn> method, when invoked, must run
-these steps:
-
-1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
-
-1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
-1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
-   given |options|.{{FilePickerOptions/id}}, |options|.{{FilePickerOptions/startIn}} and |environment|.
-
-1. Let |global| be |environment|'s [=environment settings object/global object=].
-1. Verify that |environment| [=is allowed to show a file picker=].
-
-1. Let |p| be [=a new promise=].
-1. Run the following steps [=in parallel=]:
-
-  1. Optionally, wait until any prior execution of this algorithm has terminated.
-
-  1. Display a prompt to the user requesting that the user pick exactly one file.
-     The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
-     Exactly how this is implemented, and what this prompt looks like is [=implementation-defined=].
-     If |accepts options| are displayed in the UI, the selected option should also be used to suggest an extension
-     to append to a user provided file name, but this is not required. In particular user agents are free to ignore
-     potentially dangerous suffixes such as those ending in `".lnk"` or `".local"`.
-
-     When possible, this prompt should start out showing |starting directory|.
-
-     If |options|.{{SaveFilePickerOptions/suggestedName}} is specified and not null,
-     the file picker prompt will be pre-filled with the
-     |options|.{{SaveFilePickerOptions/suggestedName}} as the default name to save as. The interaction between the
-     {{SaveFilePickerOptions/suggestedName}} and |accepts options| is [=implementation-defined=].
-     If the {{SaveFilePickerOptions/suggestedName}} is deemed too dangerous, user agents should ignore or sanitize the
-     suggested file name, similar to the sanitization done when fetching something <a spec=html>as a download</a>.
-
-     Note: A user agent could for example pick whichever option in |accepts options| that matches
-     {{SaveFilePickerOptions/suggestedName}} as the default filter.
-
-  1. Wait for the user to have made their selection.
-
-  1. If the user dismissed the prompt without making a selection,
-     [=/reject=] |p| with an {{AbortError}} and abort.
-
-  1. Let |entry| be a [=file entry=] representing the selected file.
-
-  1. If |entry| is deemed [=too sensitive or dangerous=] to be exposed to this website by the user agent:
-    1. Inform the user that the selected files or directories can't be exposed to this website.
-    1. At the discretion of the user agent,
-       either go back to the beginning of these [=in parallel=] steps,
-       or [=/reject=] |p| with an {{AbortError}} and abort.
-
-  1. Set |entry|'s [=binary data=] to an empty [=byte sequence=].
-
-  1. Set |result| to a new {{FileSystemFileHandle}} associated with |entry|.
-
-  1. [=Remember a picked directory=] given |options|.{{FilePickerOptions/id}}, |entry| and |environment|.
-
-  1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
-
-     Note: This lets a website immediately perform operations on the returned handles that
-     might require user activation, such as requesting more permissions.
-
-  1. [=/Resolve=] |p| with |result|.
-
-1. Return |p|.
-
-</div>
-
 ## File picker options ## {#api-filepickeroptions}
 
 ### Accepted file types ### {#api-filepickeroptions-types}
@@ -1674,6 +1514,166 @@ run the following steps:
 1. If |id| is not specified, let |id| be an empty string.
 1. Set [=recently picked directory map=][|origin|][|id|] to the path on the local file system corresponding to |entry|,
    if such a path can be determined.
+
+</div>
+
+## The {{showOpenFilePicker()}} method ## {#api-showopenfilepicker}
+
+<div class="note domintro">
+  : [ |handle| ] = await window . {{showOpenFilePicker()}}
+  : [ |handle| ] = await window . {{showOpenFilePicker()|showOpenFilePicker}}({ {{OpenFilePickerOptions/multiple}}: false })
+  :: Shows a file picker that lets a user select a single existing file, returning a handle for
+    the selected file.
+
+  : handles = await window . {{showOpenFilePicker()|showOpenFilePicker}}({ {{OpenFilePickerOptions/multiple}}: true })
+  :: Shows a file picker that lets a user select multiple existing files, returning handles for
+    the selected files.
+
+    Additional options can be passed to {{showOpenFilePicker()}} to indicate the types of files
+    the website wants the user to select and the directory in which the
+    file picker will open. See [[#api-filepickeroptions]] for details.
+</div>
+
+<div algorithm>
+The <dfn method for=Window>showOpenFilePicker(|options|)</dfn> method, when invoked, must run
+these steps:
+
+1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
+
+1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
+1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
+   given |options|.{{FilePickerOptions/id}}, |options|.{{FilePickerOptions/startIn}} and |environment|.
+
+1. Let |global| be |environment|'s [=environment settings object/global object=].
+1. Verify that |environment| [=is allowed to show a file picker=].
+
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+
+  1. Optionally, wait until any prior execution of this algorithm has terminated.
+
+  1. Display a prompt to the user requesting that the user pick some files.
+     If |options|.{{OpenFilePickerOptions/multiple}} is false, there must be no more than one file selected;
+     otherwise any number may be selected.
+
+     The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
+     Exactly how this is implemented, and what this prompt looks like is [=implementation-defined=].
+
+     When possible, this prompt should start out showing |starting directory|.
+
+  1. Wait for the user to have made their selection.
+
+  1. If the user dismissed the prompt without making a selection,
+     [=/reject=] |p| with an {{AbortError}} and abort.
+
+  1. Let |entries| be a [=/list=] of [=file entries=] representing the selected files or directories.
+  1. Let |result| be a empty [=/list=].
+
+  1. [=list/For each=] |entry| of |entries|:
+    1. If |entry| is deemed [=too sensitive or dangerous=] to be exposed to this website by the user agent:
+      1. Inform the user that the selected files or directories can't be exposed to this website.
+      1. At the discretion of the user agent,
+         either go back to the beginning of these [=in parallel=] steps,
+         or [=/reject=] |p| with an {{AbortError}} and abort.
+
+    1. Add a new {{FileSystemFileHandle}} associated with |entry| to |result|.
+
+  1. [=Remember a picked directory=] given |options|.{{FilePickerOptions/id}}, |entries|[0] and |environment|.
+
+  1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
+
+     Note: This lets a website immediately perform operations on the returned handles that
+     might require user activation, such as requesting more permissions.
+
+  1. [=/Resolve=] |p| with |result|.
+
+1. Return |p|.
+
+</div>
+
+## The {{Window/showSaveFilePicker()}} method ## {#api-showsavefilepicker}
+
+<div class="note domintro">
+  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}( |options| )
+  :: Shows a file picker that lets a user select a single file, returning a handle for
+    the selected file. The selected file does not have to exist already. If the selected
+    file does not exist a new empty file is created before this method returns, otherwise
+    the existing file is cleared before this method returned.
+
+  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}({ {{SaveFilePickerOptions/suggestedName}}: "README.md" })
+  :: Shows a file picker with the suggested "README.md" file name pre-filled as the default file name to save as.
+
+    Additional |options| can be passed to {{showSaveFilePicker()}} to indicate the types of files
+    the website wants the user to select and the directory in which the
+    file picker will open. See [[#api-filepickeroptions]] for details.
+</div>
+
+Advisement: The {{SaveFilePickerOptions/suggestedName}} option was first introduced in Chrome 91.
+
+<div algorithm>
+The <dfn method for=Window>showSaveFilePicker(|options|)</dfn> method, when invoked, must run
+these steps:
+
+1. Let |environment| be <b>[=this=]</b>'s [=relevant settings object=].
+
+1. Let |accepts options| be the result of [=process accept types|processing accept types=] given |options|.
+1. Let |starting directory| be the result of [=determine the directory the picker will start in|determining the directory the picker will start in=]
+   given |options|.{{FilePickerOptions/id}}, |options|.{{FilePickerOptions/startIn}} and |environment|.
+
+1. Let |global| be |environment|'s [=environment settings object/global object=].
+1. Verify that |environment| [=is allowed to show a file picker=].
+
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+
+  1. Optionally, wait until any prior execution of this algorithm has terminated.
+
+  1. Display a prompt to the user requesting that the user pick exactly one file.
+     The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
+     Exactly how this is implemented, and what this prompt looks like is [=implementation-defined=].
+     If |accepts options| are displayed in the UI, the selected option should also be used to suggest an extension
+     to append to a user provided file name, but this is not required. In particular user agents are free to ignore
+     potentially dangerous suffixes such as those ending in `".lnk"` or `".local"`.
+
+     When possible, this prompt should start out showing |starting directory|.
+
+     If |options|.{{SaveFilePickerOptions/suggestedName}} is specified and not null,
+     the file picker prompt will be pre-filled with the
+     |options|.{{SaveFilePickerOptions/suggestedName}} as the default name to save as. The interaction between the
+     {{SaveFilePickerOptions/suggestedName}} and |accepts options| is [=implementation-defined=].
+     If the {{SaveFilePickerOptions/suggestedName}} is deemed too dangerous, user agents should ignore or sanitize the
+     suggested file name, similar to the sanitization done when fetching something <a spec=html>as a download</a>.
+
+     Note: A user agent could for example pick whichever option in |accepts options| that matches
+     {{SaveFilePickerOptions/suggestedName}} as the default filter.
+
+  1. Wait for the user to have made their selection.
+
+  1. If the user dismissed the prompt without making a selection,
+     [=/reject=] |p| with an {{AbortError}} and abort.
+
+  1. Let |entry| be a [=file entry=] representing the selected file.
+
+  1. If |entry| is deemed [=too sensitive or dangerous=] to be exposed to this website by the user agent:
+    1. Inform the user that the selected files or directories can't be exposed to this website.
+    1. At the discretion of the user agent,
+       either go back to the beginning of these [=in parallel=] steps,
+       or [=/reject=] |p| with an {{AbortError}} and abort.
+
+  1. Set |entry|'s [=binary data=] to an empty [=byte sequence=].
+
+  1. Set |result| to a new {{FileSystemFileHandle}} associated with |entry|.
+
+  1. [=Remember a picked directory=] given |options|.{{FilePickerOptions/id}}, |entry| and |environment|.
+
+  1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
+
+     Note: This lets a website immediately perform operations on the returned handles that
+     might require user activation, such as requesting more permissions.
+
+  1. [=/Resolve=] |p| with |result|.
+
+1. Return |p|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1163,8 +1163,8 @@ dictionary FilePickerAcceptType {
 dictionary FilePickerOptions {
     sequence<FilePickerAcceptType> types;
     boolean excludeAcceptAllOption = false;
-    USVString id;
-    StartInDirectory? startIn;
+    DOMString id;
+    StartInDirectory startIn;
 };
 
 dictionary OpenFilePickerOptions : FilePickerOptions {
@@ -1176,8 +1176,8 @@ dictionary SaveFilePickerOptions : FilePickerOptions {
 };
 
 dictionary DirectoryPickerOptions {
-    USVString id;
-    StartInDirectory? startIn;
+    DOMString id;
+    StartInDirectory startIn;
 };
 
 [SecureContext]
@@ -1241,8 +1241,8 @@ To verify that an |environment| <dfn>is allowed to show a file picker</dfn>, run
     the selected files.
 
     Additional options can be passed to {{showOpenFilePicker()}} to indicate the types of files
-    the website wants the user to select and the preferred directory which the
-    file picker will open to. See [[#api-filepickeroptions]] for details.
+    the website wants the user to select and the directory in which the
+    file picker will open. See [[#api-filepickeroptions]] for details.
 </div>
 
 <div algorithm>
@@ -1268,7 +1268,7 @@ these steps:
      otherwise any number may be selected.
 
      The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
-     Exactly how this is implemented, and what this prompt looks like is left up to the user agent.
+     Exactly how this is implemented, and what this prompt looks like is [=implementation-defined=].
 
      When possible, this prompt should start out showing |starting directory|.
 
@@ -1315,8 +1315,8 @@ these steps:
   :: Shows a file picker with the suggested "README.md" file name pre-filled as the default file name to save as.
 
     Additional |options| can be passed to {{showSaveFilePicker()}} to indicate the types of files
-    the website wants the user to select and the preferred directory which the
-    file picker will open to. See [[#api-filepickeroptions]] for details.
+    the website wants the user to select and the directory in which the
+    file picker will open. See [[#api-filepickeroptions]] for details.
 </div>
 
 Advisement: The {{SaveFilePickerOptions/suggestedName}} option was first introduced in Chrome 91.
@@ -1341,18 +1341,22 @@ these steps:
 
   1. Display a prompt to the user requesting that the user pick exactly one file.
      The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
-     Exactly how this is implemented, and what this prompt looks like is left up to the user agent.
+     Exactly how this is implemented, and what this prompt looks like is [=implementation-defined=].
      If |accepts options| are displayed in the UI, the selected option should also be used to suggest an extension
      to append to a user provided file name, but this is not required. In particular user agents are free to ignore
      potentially dangerous suffixes such as those ending in `".lnk"` or `".local"`.
 
      When possible, this prompt should start out showing |starting directory|.
 
-     If |options|.{{SaveFilePickerOptions/suggestedName}} is specified, the file picker prompt will be pre-filled with the
+     If |options|.{{SaveFilePickerOptions/suggestedName}} is specified and not null,
+     the file picker prompt will be pre-filled with the
      |options|.{{SaveFilePickerOptions/suggestedName}} as the default name to save as. The interaction between the
-     {{SaveFilePickerOptions/suggestedName}} and |accepts options| is left up to the user agent.
+     {{SaveFilePickerOptions/suggestedName}} and |accepts options| is [=implementation-defined=].
      If the {{SaveFilePickerOptions/suggestedName}} is deemed too dangerous, user agents should ignore or sanitize the
      suggested file name, similar to the sanitization done when fetching something <a spec=html>as a download</a>.
+
+     Note: A user agent could for example pick whichever option in |accepts options| that matches
+     {{SaveFilePickerOptions/suggestedName}} as the default filter.
 
   1. Wait for the user to have made their selection.
 
@@ -1516,7 +1520,7 @@ To <dfn>validate a suffix</dfn> |suffix|, run the following steps:
 
 <div class="note domintro">
 The {{FilePickerOptions/id}} and {{FilePickerOptions/startIn}} fields can be specified to suggest
-the directory which the file picker opens to.
+the directory in which the file picker opens.
 
 If neither of these options are specified, the user agent remembers the last directory a file
 or directory was picked from, and new pickers will start out in that directory. By specifying an
@@ -1595,9 +1599,11 @@ A <dfn>valid path id</dfn> is a [=string=] where each character is [=ASCII alpha
 To prevent a [=path id map=] from growing without a bound, user agents should implement
 some mechanism to limit how many recently picked directories will be remembered. This
 can for example be done by evicting least recently used entries.
+User agents should allow at least 16 entries to be stored in a [=path id map=].
 
 The <dfn enum>WellKnownDirectory</dfn> enum lets a website pick one of several well-known
-paths. The exact paths the various values of this enum map to is left up to the user agent.
+directories. The exact paths the various values of this enum map to is [=implementation-defined=]
+(and in some cases these might not even represent actual paths on disk).
 The following list describes the meaning of each of the values, and gives possible example paths on different operating systems:
 
 <dl dfn-for=WellKnownDirectory>
@@ -1636,7 +1642,7 @@ run the following steps:
     1. If |entry| is a [=file entry=],
        return the path on the local file system corresponding to the parent directory of |entry|,
        if such a path can be determined.
-    1. Else, if |entry| is a [=directory entry=],
+    1. If |entry| is a [=directory entry=],
        return the path on the local file system corresponding to |entry|,
        if such a path can be determined.
 
@@ -1664,7 +1670,7 @@ run the following steps:
 
 1. Let |origin| be |environment|'s [=environment settings object/origin=].
 1. If [=recently picked directory map=][|origin|] does not [=map/exist=],
-   then set [=recently picked directory map=][|origin|] to a empty [=path id map=].
+   then set [=recently picked directory map=][|origin|] to an empty [=path id map=].
 1. If |id| is not specified, let |id| be an empty string.
 1. Set [=recently picked directory map=][|origin|][|id|] to the path on the local file system corresponding to |entry|,
    if such a path can be determined.

--- a/index.bs
+++ b/index.bs
@@ -1144,6 +1144,15 @@ steps:
 # Accessing Local File System # {#local-filesystem}
 
 <xmp class=idl>
+enum WellKnownDirectory {
+  "desktop",
+  "documents",
+  "downloads",
+  "music",
+  "pictures",
+  "videos",
+};
+
 dictionary FilePickerAcceptType {
     USVString description;
     record<USVString, (USVString or sequence<USVString>)> accept;
@@ -1152,6 +1161,8 @@ dictionary FilePickerAcceptType {
 dictionary FilePickerOptions {
     sequence<FilePickerAcceptType> types;
     boolean excludeAcceptAllOption = false;
+    USVString id;
+    (WellKnownDirectory or FileSystemHandle)? startIn;
 };
 
 dictionary OpenFilePickerOptions : FilePickerOptions {
@@ -1159,9 +1170,12 @@ dictionary OpenFilePickerOptions : FilePickerOptions {
 };
 
 dictionary SaveFilePickerOptions : FilePickerOptions {
+    USVString? suggestedName;
 };
 
 dictionary DirectoryPickerOptions {
+    USVString id;
+    (WellKnownDirectory or FileSystemHandle)? startIn;
 };
 
 [SecureContext]
@@ -1181,6 +1195,8 @@ could just as well be backed by a cloud provider. For example on Chrome OS these
 file pickers will also let you pick files and directories on Google Drive.
 
 Advisement: In Chrome versions earlier than 85, this was implemented as a generic `chooseFileSystemEntries` method.
+
+(TODO: Do we need an advisement about when file picker enhancements were introduced?)
 
 ## Local File System Permissions ## {#local-file-system-permissions}
 
@@ -1225,7 +1241,8 @@ To verify that an |environment| <dfn>is allowed to show a file picker</dfn>, run
     the selected files.
 
     Additional options can be passed to {{showOpenFilePicker()}} to indicate the types of files
-    the website wants the user to select. See [[#api-filpickeroptions-types]] for details.
+    the website wants the user to select and the preferred directory which the
+    file picker will open to. See [[#api-filepickeroptions]] for details.
 </div>
 
 <div algorithm>
@@ -1243,7 +1260,7 @@ these steps:
 
   1. Optionally, wait until any prior execution of this algorithm has terminated.
 
-  1. Display a prompt to the user requesting that the user pick some files.
+  1. Display a prompt to the user requesting that the user pick some files. (TODO: do we need more info here?)
      If |options|.{{OpenFilePickerOptions/multiple}} is false, there must be no more than one file selected;
      otherwise any number may be selected.
 
@@ -1287,8 +1304,14 @@ these steps:
     file does not exist a new empty file is created before this method returns, otherwise
     the existing file is cleared before this method returned.
 
+  (TODO: Confirm this is how we're supposed to describe the suggestedName arg)
+
+  : |handle| = await window . {{showSaveFilePicker()|showSaveFilePicker}}({ {{SaveFilePickerOptions/suggestedName}}: "fruit" })
+  :: Shows a file picker with the suggested file name pre-filled as the default file name to save as.
+
     Additional |options| can be passed to {{showSaveFilePicker()}} to indicate the types of files
-    the website wants the user to select. See [[#api-filpickeroptions-types]] for details.
+    the website wants the user to select and the preferred directory which the
+    file picker will open to. See [[#api-filepickeroptions]] for details.
 </div>
 
 <div algorithm>
@@ -1307,12 +1330,15 @@ these steps:
   1. Optionally, wait until any prior execution of this algorithm has terminated.
 
   1. Display a prompt to the user requesting that the user pick exactly one file.
-
      The displayed prompt should let the user pick one of the |accepts options| to filter the list of displayed files.
      Exactly how this is implemented, and what this prompt looks like is left up to the user agent.
      If |accepts options| are displayed in the UI, the selected option should also be used to suggest an extension
      to append to a user provided file name, but this is not required. In particular user agents are free to ignore
      potentially dangerous suffixes such as those ending in `".lnk"` or `".local"`.
+
+      If {{SaveFilePickerOptions/suggestedName}} is specified, the file picker prompt will be pre-filled with the
+     {{SaveFilePickerOptions/suggestedName}} as the default name to save as. The interaction between the
+     {{SaveFilePickerOptions/suggestedName}} and |accepts options| is left up to the user agent.
 
   1. Wait for the user to have made their selection.
 
@@ -1342,13 +1368,18 @@ these steps:
 
 </div>
 
-## {{FilePickerOptions}}.{{FilePickerOptions/types}} ## {#api-filpickeroptions-types}
+## {{FilePickerOptions}} ## {#api-filepickeroptions}
 
 <div class="note domintro">
 The {{showOpenFilePicker(options)}} and {{showSaveFilePicker(options)}} methods accept a
 {{FilePickerOptions}} argument, which lets the website specify the types of files
-the file picker will let the user select.
+the file picker will let the user select and the preferred directory which the
+file picker will open to.
+</div>
 
+### {{FilePickerOptions}}.{{FilePickerOptions/types}} ### {#api-filepickeroptions-types}
+
+<div class="note domintro">
 Each entry in {{FilePickerOptions/types}} specifies a single user selectable option
 for filtering the files displayed in the file picker.
 
@@ -1374,7 +1405,7 @@ For example , the following options will let the user pick one of three differen
 One for text files (either plain text or HTML), one for images, and a third one that doesn't apply
 any filter and lets the user select any file.
 
-<pre class=example id="filepickeroptions-example1" highlight=js>
+<pre class=example id="filepickeroptions-types-example1" highlight=js>
 const options = {
   <l>{{FilePickerOptions/types}}</l>: [
     {
@@ -1397,7 +1428,7 @@ const options = {
 On the other hand, the following example will only let the user select SVG files. The dialog
 will not show an option to not apply any filters.
 
-<pre class=example id="filepickeroptions-example2" highlight=js>
+<pre class=example id="filepickeroptions-types-example2" highlight=js>
 const options = {
   <l>{{FilePickerOptions/types}}</l>: [
     {
@@ -1468,12 +1499,65 @@ To <dfn>validate a suffix</dfn> |suffix|, run the following steps:
 
 </div>
 
+### {{FilePickerOptions}} Starting Directory ### {#api-filepickeroptions-starting-directory}
+
+<div class="note domintro">
+The {{FilePickerOptions/id}} and {{FilePickerOptions/startIn}} fields can be specified to suggest
+the directory which the file picker opens to.
+
+(TODO: maybe a note about how this is merely where the picker STARTS at, not where it finishes? Particularly with saving files)
+
+<pre class=example id="filepickeroptions-starting-directory-example1" highlight=js>
+const options = {
+  <l>{{FilePickerOptions/id}}</l>: 'foo',
+  <l>{{FilePickerOptions/startIn}}</l>: {{FileSystemHandle}},  (TODO: how to represent existing Handle?)
+};
+</pre>
+
+</div>
+
+<div algorithm>
+To <dfn>determine the directory the file picker will start in</dfn>, run the following steps:
+
+(TODO: This is just a sketch.
+ - The wording here is much more loose and colloquial than it should be
+ - URL vs Path?
+)
+
+1. If {{FilePickerOptions/startIn}} is a {{FileSystemHandle}}, resolve to a path.
+  1. Is this directory not valid (Sandboxed URL), ignore.
+  1. If {{FileSystemFileHandle}}, return parent's path
+  1. If {{FileSystemDirectoryHandle}}, return path
+
+1. If {{FilePickerOptions/id}} is non-empty
+  1. If mapping exists ID-> path, return this stored path
+
+1. If {{FilePickerOptions/startIn}} is a {{WellKnownDirectory}}...
+  1. If invalid, ignore.
+  1. Otherwise return corresponding path
+
+1. If mapping default ID -> stored path exists, return stored path
+
+1. Return a default path (ex: Documents)
+
+If file picker operation succeeded:
+
+1. If {{FilePickerOptions/id}} is non-empty, store mapping from ID -> picked path
+1. If {{FilePickerOptions/id}} is empty, store mapping from default ID -> picked path
+(TODO: do we need to mention the limit here?)
+
+</div>
+
 ## The {{Window/showDirectoryPicker()}} method ## {#api-showdirectorypicker}
 
 <div class="note domintro">
   : |handle| = await window . {{Window/showDirectoryPicker()}}
   :: Shows a directory picker that lets the user select a single directory, returning a handle for
     the selected directory.
+
+  The {{DirectoryPickerOptions\id}} and {{DirectoryPickerOptions\startIn}} fields behave
+  identically to the {{FilePickerOptions\id}} and {{FilePickerOptions\startIn}} fields, respectively.
+  See [[#api-filepickeroptions-starting-directory]] for details on how to use these fields.
 </div>
 
 <div algorithm>
@@ -1490,6 +1574,7 @@ these steps:
   1. Optionally, wait until any prior execution of this algorithm has terminated.
 
   1. Display a prompt to the user requesting that the user pick a directory.
+    (TODO: mention starting directory here)
 
   1. Wait for the user to have made their selection.
 


### PR DESCRIPTION
This adds the options as described in https://github.com/WICG/file-system-access/blob/main/SuggestedNameAndDir.md.

Fixes #85, fixes #144, fixes #94 and fixes #80


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/pull/287.html" title="Last updated on Jun 4, 2021, 5:56 PM UTC (a6f5bba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/287/e74baf7...a6f5bba.html" title="Last updated on Jun 4, 2021, 5:56 PM UTC (a6f5bba)">Diff</a>