### PR TITLE
fix truncate explainer

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1073,7 +1073,7 @@ runs these steps:
   :: Resizes the file associated with |stream| to be |size| bytes long. If |size| is larger than
      the current file size this pads the file with null bytes, otherwise it truncates the file.
 
-     The file cursor is updated when {{truncate}} is called. If the offset is smaller than offset,
+     The file cursor is updated when {{truncate}} is called. If the offset is smaller than |size|,
      it remains unchanged. If the offset is larger than |size|, the offset is set to |size| to
      ensure that subsequent writes do not error.
 
@@ -1120,7 +1120,7 @@ steps:
   :: Resizes the file associated with |stream| to be |size| bytes long. If |size| is larger than
      the current file size this pads the file with null bytes, otherwise it truncates the file.
 
-     The file cursor is updated when {{truncate}} is called. If the offset is smaller than offset,
+     The file cursor is updated when {{truncate}} is called. If the offset is smaller than |size|,
      it remains unchanged. If the offset is larger than |size|, the offset is set to |size| to
      ensure that subsequent writes do not error.
 


### PR DESCRIPTION
> The file cursor is updated when truncate is called. If the offset is smaller than **offset**, it remains unchanged.

That doesn't sound right.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kfdf/file-system-access/pull/304.html" title="Last updated on Jun 14, 2021, 9:38 PM UTC (1b04ad5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/304/3309115...kfdf:1b04ad5.html" title="Last updated on Jun 14, 2021, 9:38 PM UTC (1b04ad5)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kfdf/file-system-access/pull/304.html" title="Last updated on Nov 19, 2022, 4:57 AM UTC (1b04ad5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/304/3309115...kfdf:1b04ad5.html" title="Last updated on Nov 19, 2022, 4:57 AM UTC (1b04ad5)">Diff</a>