### PR TITLE
Fix trivial typo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -473,7 +473,7 @@ Advisement: In the Origin Trial as available in Chrome 82, createWritable replac
   :: Returns a {{FileSystemWritableFileStream}} that can be used to write to the file. Any changes made through
      |stream| won't be reflected in the file represented by |fileHandle| until the stream has been closed.
      User agents try to ensure that no partial writes happen, i.e. the file represented by
-     |fileHandle| will either contains its old contents or it will contain whatever data was written
+     |fileHandle| will either contain its old contents or it will contain whatever data was written
      through |stream| up until the stream has been closed.
 
      This is typically implemented by writing data to a temporary file, and only replacing the file


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tomayac/native-file-system/pull/307.html" title="Last updated on Jul 1, 2021, 11:13 AM UTC (9136a8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/307/3309115...tomayac:9136a8e.html" title="Last updated on Jul 1, 2021, 11:13 AM UTC (9136a8e)">Diff</a>