### PR TITLE
Add AccessHandle proposal

### DIFF
--- a/AccessHandle.md
+++ b/AccessHandle.md
@@ -46,9 +46,10 @@ a [duplex stream](https://streams.spec.whatwg.org/#other-specs-duplex) and
 auxiliary methods. The readable/writable pair in the duplex stream communicates
 with the same backing file, allowing the user to read unflushed contents.
 Another new method, *createSyncAccessHandle()*, would only be exposed on Worker
-threads. This method would offer a more buffer-based surface for reading and
-writing. The creation of AccessHandle also creates a lock that prevents write
-access to the file across (and within the same) execution contexts.
+threads. This method would offer a more buffer-based surface with synchronous
+reading and writing. The creation of AccessHandle also creates a lock that
+prevents write access to the file across (and within the same) execution
+contexts.
 
 This proposal is part of our effort to integrate [Storage Foundation
 API](https://github.com/WICG/storage-foundation-api-explainer) into File System
@@ -133,6 +134,11 @@ found in the [Appendix](#appendix).
 The reason for offering a Worker-only synchronous interface, is that consuming
 asynchronous APIs from Wasm has severe performance implications (more details
 [here](https://docs.google.com/document/d/1lsQhTsfcVIeOW80dr467Auud_VCeAUv2ZOkC63oSyKo)).
+Since this overhead is most impactful on methods that are called often, we've
+only made *read()* and *write()* synchronous. This allows us to keep a simpler
+mental model (where the sync and async handle are identical, except reading and
+writing) and reduce the number of new sync methods, while avoiding the most
+important perfomance penalties.
 
 This proposal assumes that [seekable
 streams](https://github.com/whatwg/streams/issues/1128) will be available. If
@@ -221,7 +227,7 @@ interface FileSystemSyncAccessHandle {
 
   Promise<undefined> truncate([EnforceRange] unsigned long long size);
   Promise<unsigned long long> getSize();
-  Promise<undefined> flush(); 
+  Promise<undefined> flush();
   Promise<undefined> close();
 };
 

--- a/AccessHandle.md
+++ b/AccessHandle.md
@@ -56,7 +56,7 @@ that primarily contribute to Storage Foundation’s performance:
 
 In order to bring this use cases to OPFS, we propose adding a method to
 *FileSystemFileHandle* that returns an *AccessHandle*, a new interface.
-AccessHandles provide the right kind of access and locking semantics to achieve
+*AccessHandles* provide the right kind of access and locking semantics to achieve
 similar performance to Storage Foundation API.
 
 Further details on the origins of this proposal, and alternatives considered,
@@ -74,7 +74,7 @@ new surface is particularly well suited for Wasm-based libraries and
 applications that want to use custom storage algorithms to fine-tune execution
 speed and memory usage.
 
-A few examples of what could be done with AccessHandles:
+A few examples of what could be done with *AccessHandles*:
 
 *   Allow tried and true technologies to be performantly used as part of web
     applications e.g. using a port of your favorite storage library
@@ -154,12 +154,12 @@ await handle1.close();
 
 In order to avoid multiple contexts modifying a file at the same time, locking
 semantics would be added to the new surface. At any given time, and across
-execution contexts, there would only either be a single AccessHandle per
+execution contexts, there would only either be a single *AccessHandle* per
 FileHandle, or potentially multiple Writables created through
 *createWritable()*.
 
-When creating an AccessHandle, a lock will be taken. This lock will be released
-when the AccessHandle is closed or destroyed. When a Writable is created, a
+When creating an *AccessHandle*, a lock will be taken. This lock will be released
+when the *AccessHandle* is closed or destroyed. When a Writable is created, a
 lock is taken if there are no other open Writables. This lock will be released
 once the last Writable closed or destroyed. Only one lock may be taken at a
 given time for a given FileHandle.

--- a/AccessHandle.md
+++ b/AccessHandle.md
@@ -114,13 +114,15 @@ var writtenBytes = handle.write(buffer);
 var readBytes = handle.read(buffer {at: 1});
 ```
 
-A new *createAccessHandle()* (a placeholder name) method would be added.
-*createAccessHandle()* would return an object that contains a duplex stream,
-offering a readable/writable pair that communicates with the same backing file,
-allowing the user to read unflushed contents. Another new method,
-*createSyncAccessHandle()*, would be only exposed on Worker threads. This method
-would offer a more buffer based surface for read and write. An IDL description
-of the new interface can be found in the [Appendix](#appendix).
+A new *createAccessHandle()* method would be added to *FileSystemFileHandle*.
+It  would return an *AccessHandle* that contains a
+[duplex stream](https://streams.spec.whatwg.org/#other-specs-duplex) and
+auxilliary methods. The readable/writable pair in the duplex stream would
+communicate with the same backing file, allowing the user to read unflushed
+contents. Another new method, *createSyncAccessHandle()*, would be only exposed
+on Worker threads. This method would offer a more buffer based surface for read
+and write. An IDL description of the new interface can be found in the
+[Appendix](#appendix).
 
 The reason for offering a Worker-only synchronous interface, is that consuming
 asynchronous APIs from Wasm has severe performance implications (more details
@@ -148,13 +150,12 @@ try {
   //This catch will always be executed, since there is an open access handle
 }
 await handle1.close();
-
 //Now a new access handle may be created
 ```
 
 In order to avoid multiple contexts modifying a file at the same time, locking
 semantics would be added to the new surface. At any given time, and across
-execution contexts, there would only either be a single *AccessHandle* per
+execution contexts, there would only be either a single *AccessHandle* per
 FileHandle, or potentially multiple Writables created through
 *createWritable()*.
 
@@ -173,15 +174,15 @@ There are some important edge cases to mention:
     means that Files created while there is an active handle will be invalidated
     when a flush is executed (either explicitly through flush() or implicitly by
     the OS). It also means that these Files could be used to observe flushed
-    changes done through the new API, even if a lock is still being held.)
+    changes done through the new API, even if a lock is still being held.
 
 ## Open Questions
 
 ### Naming
 
 The exact name of the new methods hasn’t been defined. The current placeholder
-for data access is createAccessHandle() and createSyncAccessHandle().
-createUnflushedStreams() and createDuplexStream() have been suggested.
+for data access is *createAccessHandle()* and *createSyncAccessHandle()*.
+*createUnflushedStreams()* and *createDuplexStream()* have been suggested.
 
 ### Assurances on non-awaited consistency
 
@@ -238,13 +239,6 @@ dictionary FilesystemReadWriteOptions {
   [EnforceRange] unsigned long long at;
 };
 ```
-
-## Stakeholder Feedback / Opposition
-
-* Chrome : Positive, authoring this explainer
-* Gecko : No signals
-* WebKit : No signals
-* Web developers : Positive, frequently requested (See #85, #144, #94 and #80.)
 
 ## References & acknowledgements
 

--- a/AccessHandle.md
+++ b/AccessHandle.md
@@ -1,3 +1,34 @@
+# Adding AccessHandles
+
+## Authors:
+
+* Emanuel Krivoy (fivedots@chromium.org)
+* Richard Stotz (rstz@chromium.org)
+
+## Participate
+
+* [Issue tracker](https://github.com/WICG/file-system-access/issues)
+
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+- [Goals & Use Cases](#goals--use-cases)
+- [Non-goals](#non-goals)
+- [What makes the new surface fast?](#what-makes-the-new-surface-fast)
+- [Proposed API](#proposed-api)
+  - [New data access surface](#new-data-access-surface)
+  - [Locking semantics](#locking-semantics)
+- [Open Questions](#open-questions)
+  - [Naming](#naming)
+  - [Assurances on non-awaited consistency](#assurances-on-non-awaited-consistency)
+- [Appendix](#appendix)
+  - [AccessHandle IDL](#accesshandle-idl)
+- [References & acknowledgements](#references--acknowledgements)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Introduction
 
@@ -19,8 +50,8 @@ threads. This method would offer a more buffer-based surface for reading and
 writing. The creation of AccessHandle also creates a lock that prevents write
 access to the file across (and within the same) execution contexts.
 
-This proposal is part of our effort to merge [Storage Foundation
-API](https://github.com/WICG/storage-foundation-api-explainer) and File System
+This proposal is part of our effort to integrate [Storage Foundation
+API](https://github.com/WICG/storage-foundation-api-explainer) into File System
 Access API. For more context the origins of this proposal, and alternatives
 considered, please check out: [Merging Storage Foundation API and the Origin
 Private File
@@ -61,16 +92,16 @@ AccessHandles:
 
 *   Write operations are not guaranteed to be immediately persistent, rather
     persistency is achieved through calls to *flush()*. At the same time, data
-can be consistently read before flushing. This allows applications to only
-schedule time consuming flushes when they are required for long-term data
-storage, and not as a precondition to operate on recently written data.
+    can be consistently read before flushing. This allows applications to only
+    schedule time consuming flushes when they are required for long-term data
+    storage, and not as a precondition to operate on recently written data.
 *   The exclusive write lock held by the AccessHandle saves implementations
     from having to provide a central data access point across execution
-contexts. In multi-process browsers, such as Chrome, this helps avoid costly
-inter-process communication (IPCs) between renderer and browser processes.
+    contexts. In multi-process browsers, such as Chrome, this helps avoid costly
+    inter-process communication (IPCs) between renderer and browser processes.
 *   Data copies are avoided when reading or writing. In the async surface this
     is achieved through SharedArrayBuffers and BYOB readers. In the sync
-surface, we rely on user-allocated buffers to hold the data.
+    surface, we rely on user-allocated buffers to hold the data.
 
 For more information on what affects the performance of similar storage APIs,
 see [Design considerations for the Storage Foundation
@@ -86,7 +117,7 @@ const handle = await file.createAccessHandle();
 await handle.writable.getWriter().write(buffer);
 const reader = handle.readable.getReader({mode: "byob"});
 // Assumes seekable streams, and SharedArrayBuffer support are available
-var done = await reader.read(buffer, {at: 1});
+await reader.read(buffer, {at: 1});
 
 // Only in a worker context
 const handle = await file.createSyncAccessHandle();

--- a/AccessHandles.md
+++ b/AccessHandles.md
@@ -1,0 +1,253 @@
+# Adding AccessHandles to files
+
+## Authors:
+
+* Emanuel Krivoy (fivedots@chromium.org)
+* Richard Stotz (rstz@chromium.org)
+
+## Participate
+
+* [Issue tracker](https://github.com/WICG/file-system-access/issues)
+
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+- [Goals and Use Cases](#goals-and-use-cases)
+- [Non-goals](#non-goals)
+- [Proposed API](#proposed-api)
+  - [New data access surface](#new-data-access-surface)
+  - [Locking semantics](#locking-semantics)
+- [Open Questions](#open-questions)
+  - [Naming](#naming)
+  - [Assurances on non-awaited consistency](#assurances-on-non-awaited-consistency)
+- [Appendix](#appendix)
+  - [AccessHandle IDL](#accesshandle-idl)
+- [Stakeholder Feedback / Opposition](#stakeholder-feedback--opposition)
+- [References & acknowledgements](#references--acknowledgements)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Introduction
+
+This is a proposal to support
+[Storage Foundation API's](https://github.com/WICG/storage-foundation-api-explainer)
+use cases through the Origin Private File System (OPFS), to provide a unified
+interface and a simpler model to developers.
+
+Storage Foundation’s main objective is to support performance-sensitive
+applications through a very fast and generic storage backend. It especially
+focuses on ported WebAssembly programs for which existing storage web APIs
+don’t match the expectations of native code. There are a few design choices
+that primarily contribute to Storage Foundation’s performance:
+
+*   Developers get control of when data is flushed to disk, and reads can be
+    executed consistently without flushing. This allows programs to only schedule
+    time consuming flushes when they are required for persistency, and not as a
+    precondition to operate on recently written data.
+*   Its design ensures that implementations can access data from “the renderer
+    process” (i.e. without needing to rely on a component that coordinates
+    between execution contexts) to avoid costly inter-process communication
+    (IPCs). Examples of this approach include the allocation-based quota system
+    and only allowing one open file handle per file.
+*   We avoid extra memory allocations by taking a buffer when reading.
+
+In order to bring this use cases to OPFS, we propose adding a method to
+*FileSystemFileHandle* that returns an *AccessHandle*, a new interface.
+AccessHandles provide the right kind of access and locking semantics to achieve
+similar performance to Storage Foundation API.
+
+Further details on the origins of this proposal, and alternatives considered,
+can be found in the following documents:
+[Merging Storage Foundation API and the Origin Private File System](https://docs.google.com/document/d/121OZpRk7bKSF7qU3kQLqAEUVSNxqREnE98malHYwWec),
+[Recommendation for Augmented OPFS](https://docs.google.com/document/d/1g7ZCqZ5NdiU7oqyCpsc2iZ7rRAY1ZXO-9VoG4LfP7fM).
+
+## Goals and Use Cases
+
+Out goals and use cases are the same as
+[Storage Foundation API](https://github.com/WICG/storage-foundation-api-explainer),
+namely to give developers flexibility by providing generic, simple, and
+performant primitives upon which they can build higher-level components. The
+new surface is particularly well suited for Wasm-based libraries and
+applications that want to use custom storage algorithms to fine-tune execution
+speed and memory usage.
+
+A few examples of what could be done with AccessHandles:
+
+*   Allow tried and true technologies to be performantly used as part of web
+    applications e.g. using a port of your favorite storage library
+    within a website
+*   Distribute a Wasm module for WebSQL, allowing developers to us it across
+    browsers and opening the door to removing the unsupported API from Chrome
+*   Allow a music production website to operate on large amounts of media, by
+    relying on the new surface's performance and direct buffered access
+    to offload sound segments to disk instead of holding them in memory
+*   Provide a persistent [Emscripten](https://emscripten.org/) filesystem that
+    outperforms
+    [IDBFS](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-idbfs)
+    and has a simpler implementation
+
+## Non-goals
+
+This proposal is focused only on additions to the
+[Origin Private File System](https://wicg.github.io/file-system-access/#sandboxed-filesystem),
+and doesn't currently consider changes to the rest of File System Access API or
+how files in the host machine are accessed.
+
+## Proposed API
+
+### New data access surface
+
+```javascript
+//In all contexts
+const handle = await file.createAccessHandle();
+await handle.writable.getWriter().write(buffer);
+const reader = handle.readable.getReader({mode: "byob"});
+//Assumes seekable streams are available
+var {value: buffer, done} = await reader.read(buffer, {at: 1});
+
+//Only in a worker context
+const handle = file.createSyncAccessHandle();
+var writtenBytes = handle.write(buffer);
+var readBytes = handle.read(buffer {at: 1});
+```
+
+A new *createAccessHandle()* (a placeholder name) method would be added.
+*createAccessHandle()* would return an object that contains a duplex stream,
+offering a readable/writable pair that communicates with the same backing file,
+allowing the user to read unflushed contents. Another new method,
+*createSyncAccessHandle()*, would be only exposed on Worker threads. This method
+would offer a more buffer based surface for read and write. An IDL description
+of the new interface can be found in the [Appendix](#appendix).
+
+The reason for offering a Worker-only synchronous interface, is that consuming
+asynchronous APIs from Wasm has severe performance implications (more details
+[here](https://docs.google.com/document/d/1lsQhTsfcVIeOW80dr467Auud_VCeAUv2ZOkC63oSyKo)).
+We've opted for slightly different interfaces between the async and sync
+versions, because there currently isn’t support for synchronous streams. The
+amount of effort that would be required to spec them in a way that makes them
+compatible with asynchronous streams would be prohibitively high, and likely
+not worth it to support a single API.  Furthermore, we hope to discourage the
+use of the sync surface unless a developer is dealing with legacy Wasm ports,
+and therefore there is not much benefit to adding them.
+
+This proposal assumes that
+[seekable streams](https://github.com/whatwg/streams/issues/1128) will be
+available. If this doesn’t happen, We can emulate the seeking behavior by
+extending the default reader and writer with a *seek()* method.
+
+### Locking semantics
+
+```javascript
+const handle1 = await file.createAccessHandle();
+try {
+  const handle2 = await file.createAccessHandle();
+} catch(e) {
+  //This catch will always be executed, since there is an open access handle
+}
+await handle1.close();
+
+//Now a new access handle may be created
+```
+
+In order to avoid multiple contexts modifying a file at the same time, locking
+semantics would be added to the new surface. At any given time, and across
+execution contexts, there would only either be a single AccessHandle per
+FileHandle, or potentially multiple Writables created through
+*createWritable()*.
+
+When creating an AccessHandle, a lock will be taken. This lock will be released
+when the AccessHandle is closed or destroyed. When a Writable is created, a
+lock is taken if there are no other open Writables. This lock will be released
+once the last Writable closed or destroyed. Only one lock may be taken at a
+given time for a given FileHandle.
+
+There are some important edge cases to mention:
+
+*   Locks acquired by creating a sync handle also prevent the creation of async handles.
+*   Creating a File through *getFile()* is possible when a lock is in place. The
+    returned File behaves as it currently does in OPFS i.e. it is invalidated
+    if file contents change after it was created.  In our particular case this
+    means that Files created while there is an active handle will be invalidated
+    when a flush is executed (either explicitly through flush() or implicitly by
+    the OS). It also means that these Files could be used to observe flushed
+    changes done through the new API, even if a lock is still being held.)
+
+## Open Questions
+
+### Naming
+
+The exact name of the new methods hasn’t been defined. The current placeholder
+for data access is createAccessHandle() and createSyncAccessHandle().
+createUnflushedStreams() and createDuplexStream() have been suggested.
+
+### Assurances on non-awaited consistency
+
+It would be possible to clearly specify the behavior of an immediate async read
+after a non-awaited write, by serializing file operations (as is currently done
+in Storage Foundation API). We should decide if this is convenient, both from a
+specification and performance point of view.
+
+## Appendix
+
+### AccessHandle IDL
+
+```webidl
+interface FileSystemFileHandle : FileSystemHandle {
+  Promise<File> getFile();
+  Promise<FileSystemWritableFileStream> createWritable(optional FileSystemCreateWritableOptions options = {});
+
+  Promise<FileSystemAccessHandle> createAccessHandle();
+  [Exposed=DedicatedWorker]
+  Promise<FileSystemSyncAccessHandle> createSyncAccessHandle();
+};
+
+interface FileSystemAccessHandle {
+  //Assumes seekable streams are available. The
+  //Seekable extended attribute is ad-hoc notation for this proposal.
+  [Seekable] readonly attribute WritableStream writable;
+  [Seekable] readonly attribute ReadableStream readable;
+
+  //Resizes the file to be size bytes long. If size is larger than the current
+  //size the file is padded with null bytes, otherwise it is truncated.
+  Promise<undefined> truncate([EnforceRange] unsigned long long size);
+  //Returns the current size of the file.
+  Promise<unsigned long long> getSize();
+  //Persists the changes that have been written to disk
+  Promise<undefined> flush();
+  //Cancels the streams and releases the lock on the file
+  Promise<undefined> close();
+};
+
+[Exposed=DedicatedWorker]
+interface FileSystemSyncAccessHandle {
+  unsigned long long read([AllowShared] BufferSource buffer,
+                             FilesystemReadWriteOptions options);
+  unsigned long long write([AllowShared] BufferSource buffer,
+                              FilesystemReadWriteOptions options);
+
+  Promise<undefined> truncate([EnforceRange] unsigned long long size);
+  Promise<unsigned long long> getSize();
+  Promise<undefined> flush(); 
+  Promise<undefined> close();
+};
+
+dictionary FilesystemReadWriteOptions {
+  [EnforceRange] unsigned long long at;
+};
+```
+
+## Stakeholder Feedback / Opposition
+
+* Chrome : Positive, authoring this explainer
+* Gecko : No signals
+* WebKit : No signals
+* Web developers : Positive, frequently requested (See #85, #144, #94 and #80.)
+
+## References & acknowledgements
+
+Many thanks for valuable feedback and advice from:
+
+Domenic Denicola, Marijn Kruisselbrink, Victor Costan

--- a/index.bs
+++ b/index.bs
@@ -473,7 +473,7 @@ Advisement: In the Origin Trial as available in Chrome 82, createWritable replac
   :: Returns a {{FileSystemWritableFileStream}} that can be used to write to the file. Any changes made through
      |stream| won't be reflected in the file represented by |fileHandle| until the stream has been closed.
      User agents try to ensure that no partial writes happen, i.e. the file represented by
-     |fileHandle| will either contains its old contents or it will contain whatever data was written
+     |fileHandle| will either contain its old contents or it will contain whatever data was written
      through |stream| up until the stream has been closed.
 
      This is typically implemented by writing data to a temporary file, and only replacing the file


### PR DESCRIPTION
This PR adds the proposal document for AccessHandles. AccessHandles are a new proposed surface that allows us to support [Storage Foundation API's](https://github.com/WICG/storage-foundation-api-explainer) use cases through the Origin Private File System.

Further details on the origins of this proposal, and alternatives considered, can be found in the following documents: [Merging Storage Foundation API and the Origin Private File System](https://docs.google.com/document/d/121OZpRk7bKSF7qU3kQLqAEUVSNxqREnE98malHYwWec), [Recommendation for Augmented OPFS](https://docs.google.com/document/d/1g7ZCqZ5NdiU7oqyCpsc2iZ7rRAY1ZXO-9VoG4LfP7fM).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/pull/310.html" title="Last updated on Jul 27, 2021, 5:51 PM UTC (e88a265)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/310/3309115...e88a265.html" title="Last updated on Jul 27, 2021, 5:51 PM UTC (e88a265)">Diff</a>