### PR TITLE
Fix code samples

### DIFF
--- a/AccessHandle.md
+++ b/AccessHandle.md
@@ -116,16 +116,16 @@ API](https://docs.google.com/document/d/1cOdnvuNIWWyJHz1uu8K_9DEgntMtedxfCzShI7d
 // In all contexts
 // For details on the `mode` parameter see "Exposing AccessHandles on all
 // filesystems" below
-const handle = await file.createAccessHandle({ mode: 'in-place' });
+const handle = await file.createAccessHandle({ mode: "in-place" });
 await handle.writable.getWriter().write(buffer);
-const reader = handle.readable.getReader({mode: "byob"});
+const reader = handle.readable.getReader({ mode: "byob" });
 // Assumes seekable streams, and SharedArrayBuffer support are available
-await reader.read(buffer, {at: 1});
+await reader.read(buffer, { at: 1 });
 
 // Only in a worker context
 const handle = await file.createSyncAccessHandle();
-var writtenBytes = handle.write(buffer);
-var readBytes = handle.read(buffer {at: 1});
+const writtenBytes = handle.write(buffer);
+const readBytes = handle.read(buffer, { at: 1 });
 ```
 
 As mentioned above, a new *createAccessHandle()* method would be added to
@@ -150,10 +150,10 @@ default reader and writer with a *seek()* method.
 ### Locking semantics
 
 ```javascript
-const handle1 = await file.createAccessHandle({ mode: 'in-place' });
+const handle1 = await file.createAccessHandle({ mode: "in-place" });
 try {
-  const handle2 = await file.createAccessHandle({ mode: 'in-place' });
-} catch(e) {
+  const handle2 = await file.createAccessHandle({ mode: "in-place" });
+} catch (e) {
   // This catch will always be executed, since there is an open access handle
 }
 await handle1.close();


### PR DESCRIPTION
Fix a syntax error (missing `,`) and improved consistency.