### PR TITLE
Add AccessHandles to spec

### DIFF
--- a/AccessHandle.md
+++ b/AccessHandle.md
@@ -22,7 +22,7 @@
   - [New data access surface](#new-data-access-surface)
   - [Locking semantics](#locking-semantics)
 - [Open Questions](#open-questions)
-  - [Naming](#naming)
+  - [Exposing AccessHandles on all filesystems](#exposing-accessHandles-on-all-filesystems)
   - [Assurances on non-awaited consistency](#assurances-on-non-awaited-consistency)
 - [Appendix](#appendix)
   - [AccessHandle IDL](#accesshandle-idl)
@@ -183,12 +183,6 @@ after it was created. It is worth noting that these Files could be used to
 observe changes done through the new API, even if a lock is still being held.
 
 ## Open Questions
-
-### Naming
-
-The exact name of the new methods hasn’t been defined. The current placeholder
-for data access is *createAccessHandle()* and *createSyncAccessHandle()*.
-*createUnflushedStreams()* and *createDuplexStream()* have been suggested.
 
 ### Exposing AccessHandles on all filesystems
 

--- a/AccessHandle.md
+++ b/AccessHandle.md
@@ -22,7 +22,7 @@
   - [New data access surface](#new-data-access-surface)
   - [Locking semantics](#locking-semantics)
 - [Open Questions](#open-questions)
-  - [Exposing AccessHandles on all filesystems](#exposing-accessHandles-on-all-filesystems)
+  - [Exposing AccessHandles on all filesystems](#exposing-accesshandles-on-all-filesystems)
   - [Assurances on non-awaited consistency](#assurances-on-non-awaited-consistency)
 - [Appendix](#appendix)
   - [AccessHandle IDL](#accesshandle-idl)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Today, if a web site wants to create experiences involving local files (document
 	- Clean up if necessary (`URL.revokeObjectURL(a.href)`)
 
   This is also the approach taken in the
-  [browser-nativefs](https://github.com/GoogleChromeLabs/browser-nativefs)
+  [browser-fs-access](https://github.com/GoogleChromeLabs/browser-fs-access)
   support library.
 - Setting `window.location` to `'data:application/octet-stream' + data_stream`.
 - Hidden Flash controls to display a “save as” dialog.

--- a/index.bs
+++ b/index.bs
@@ -84,8 +84,6 @@ is similar to the temporary file system as defined in earlier drafts of
 
 ## Concepts ## {#concepts}
 
-// TODO(fivedots): add concept of locks here.
-
 An <dfn>entry</dfn> is either a [=file entry=] or a [=directory entry=].
 
 Each [=/entry=] has an associated <dfn for=entry>name</dfn> (a [=string=]).
@@ -111,8 +109,44 @@ majority of file extensions are purely alphanumeric, but compound extensions (su
 hence the inclusion of + and . as allowed code points.
 
 A <dfn lt="file|file entry">file entry</dfn> additionally consists of
-<dfn for="file entry">binary data</dfn> (a [=byte sequence=]) and a
-<dfn for="file entry">modification timestamp</dfn> (a number representing the number of milliseconds since the <a spec=FileAPI>Unix Epoch</a>).
+<dfn for="file entry">binary data</dfn> (a [=byte sequence=]), a
+<dfn for="file entry">modification timestamp</dfn> (a number representing the number of milliseconds since the <a spec=FileAPI>Unix Epoch</a>)
+and a <dfn for="file entry">lock</dfn>. A lock is a string that may exclusively be "open", "taken-exclusive" and "taken-shared".
+
+<div algorithm>
+To <dfn for="file entry/lock">take</dfn> a [=lock=] with a |value| of "exclusive" or "shared", for a given |file|,
+run the following steps:
+
+1. Let |result| be [=a new promise=].
+1. Let |lock| be the |file|'s associated [=lock=]
+1. Run the following steps [=in parallel=]:
+  1. If |value| is "exclusive":
+     1. If |lock| is "open":
+       1. Set lock to "taken-exclusive".
+       1. [=/resolve=] |result|.
+     1. Else [=/reject=] |result|.
+  1. If |value| is "shared":
+     1. If |lock| is "open":
+       1. Set lock to "taken-exclusive".
+       1. [=/resolve=] |result|.
+     1. Else if |lock| is "taken-shared":
+       1. [=/resolve=] |result|.
+     1. Else [=/reject=] |result|.
+1. Return |result|.
+
+</div>
+
+<div algorithm>
+To <dfn for="file entry/lock">release</dfn> a [=lock=] for a given |file|,
+run the following steps:
+
+1. Let |lock| be the |file|'s associated [=lock=]
+1. Set lock to "open".
+
+</div>
+
+Note: Locks help prevent concurrent modifications to a file. A {{FileSystemWritableFileStream}}
+requires a shared lock, while a {{FileSystemSyncAccessHandle}} requires an exclusive one.
 
 A <dfn lt="directory|directory entry">directory entry</dfn> additionally consists of a [=/set=] of
 <dfn for="directory entry">children</dfn>, which are themselves [=/entries=]. Each member is either a [=/file=] or a [=directory=].
@@ -278,7 +312,7 @@ the {{FileSystemHandle}} interface can all be associated with the same [=/entry=
 <div algorithm="serialization steps">
 {{FileSystemHandle}} objects are [=serializable objects=].
 
-Advisement: In the Origin Trial as available in Chrome 78, these objects are not yet serializable. 
+Advisement: In the Origin Trial as available in Chrome 78, these objects are not yet serializable.
 In Chrome 82 they are.
 
 Their [=serialization steps=], given |value|, |serialized| and <var ignore>forStorage</var> are:
@@ -477,7 +511,6 @@ The <dfn method for=FileSystemFileHandle>getFile()</dfn> method, when invoked, m
 
 Advisement: In the Origin Trial as available in Chrome 82, createWritable replaces the createWriter method.
 
-// TODO(fivedots): Add info on shared locks.
 <div class="note domintro">
   : |stream| = await |fileHandle| . {{FileSystemFileHandle/createWritable()}}
   : |stream| = await |fileHandle| . {{FileSystemFileHandle/createWritable()|createWritable}}({ {{FileSystemCreateWritableOptions/keepExistingData}}: true/false })
@@ -493,6 +526,10 @@ Advisement: In the Origin Trial as available in Chrome 82, createWritable replac
      If {{FileSystemCreateWritableOptions/keepExistingData}} is `false` or not specified,
      the temporary file starts out empty,
      otherwise the existing file is first copied to this temporary file.
+
+    Creating a {{FileSystemWritableFileStream}} [=file entry/lock/take|takes a shared lock=] on the
+    [=FileSystemHandle/entry=] associated with |fileHandle|. This prevents the creation of
+    {{FileSystemSyncAccessHandle|FileSystemSyncAccessHandles}} for the entry, until the stream is closed.
 </div>
 
 Issue(67): There has been some discussion around and desire for a "inPlace" mode for createWritable
@@ -501,6 +538,8 @@ example to support in-place modification of large files or things like databases
 currently implemented in Chrome. Implementing this is currently blocked on figuring out how to
 combine the desire to run malware checks with the desire to let websites make fast in-place
 modifications to existing large files.
+
+// TODO(fivedots): release lock once the stream is closed.
 
 <div algorithm>
 The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method, when invoked, must run these steps:
@@ -513,6 +552,9 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method,
   1. If |permissionStatus| is not {{PermissionState/"granted"}},
      reject |result| with a {{NotAllowedError}} and abort.
   1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
+  1. Let |lockValue| be "shared".
+  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=] with |lockValue| on |entry|.
+     If that throws an exception, [=reject=] |result| with a {{NoModificationAllowedError}} and abort.
   1. Let |stream| be the result of [=create a new FileSystemWritableFileStream|creating a new FileSystemWritableFileStream=]
      for |entry| in <b>[=this=]</b>'s [=relevant realm=].
   1. If |options|.{{FileSystemCreateWritableOptions/keepExistingData}} is `true`:
@@ -530,6 +572,11 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method,
      Changes made through |handle| might be immediately reflected in the file represented by |fileHandle|.
      To ensure the changes are reflected in this file, the handle must be flushed or closed.
 
+    Creating a {{FileSystemSyncAccessHandle}} [=file entry/lock/take|takes an exclusive lock=] on the
+    [=FileSystemHandle/entry=] associated with |fileHandle|. This prevents the creation of
+    further {{FileSystemSyncAccessHandle|FileSystemSyncAccessHandles}} or {{FileSystemWritableFileStream|FileSystemWritableFileStreams}}
+    for the entry, until the access handle is closed.
+
     The returned {{FileSystemSyncAccessHandle}} offers synchronous {{FileSystemFileHandle/read()}} and
     {{FileSystemFileHandle/write()}} methods. This allows for higher performance for critical methods on
     contexts where asynchronous operations come with high overhead i.e., WebAssembly.
@@ -538,8 +585,6 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method,
     [=origin private file system=]. Also temporarily, the {{FileSystemFileHandleCreateAccessHandleOptions/mode}} parameter
     must be set to "in-place". This prevents us from setting a default behavior and allows us to bring access handles to
     other filesytems in the future.
-
-// TODO(fivedots): Mention that an exclusive lock will be taken.
 
 </div>
 
@@ -556,6 +601,9 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle(|options|)</dfn>
   1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
   1. If |entry| does not represent an [=/entry=] in an [=origin private file system=],
      reject |result| with a {{InvalidStateError}} and abort.
+  1. Let |lockValue| be "exclusive".
+  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=] with |lockValue| on |entry|.
+     If that throws an exception, [=reject=] |result| with a {{NoModificationAllowedError}} and abort.
   1. Let |handle| be the result of [=create a new FileSystemSyncAccessHandle|creating a new FileSystemSyncAccessHandle=]
      for |entry| in <b>[=this=]</b>'s [=relevant realm=].
   1. [=/Resolve=] |result| with |handle|.
@@ -596,7 +644,7 @@ A {{FileSystemDirectoryHandle}}'s associated [=FileSystemHandle/entry=] must be 
 {{FileSystemDirectoryHandle}} objects are [=serializable objects=]. Their [=serialization steps=] and
 [=deserialization steps=] are the same as those for {{FileSystemHandle}}.
 
-Advisement: In the Origin Trial as available in Chrome 78, these objects are not yet serializable. 
+Advisement: In the Origin Trial as available in Chrome 78, these objects are not yet serializable.
 In Chrome 82 they are.
 
 Advisement: In Chrome versions upto Chrome 85 `getFileHandle` and `getDirectoryHandle` where
@@ -1246,17 +1294,15 @@ in a [=/Realm=] |realm|, perform the following steps:
   :: Reads the contents of the file associated with |handle| into |buffer|, with |position| as the offset.
 </div>
 
-// TODO(fivedots): does this algorithm need to check that the access handle has not been closed?
 <div algorithm>
 The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)</dfn> method, when invoked, must run
 these steps:
 
-// TODO(fivedots): fill in.
+// TODO(fivedots): fill in. Does this algorithm need to check that the access handle has not been closed?
 
 </div>
 
 ### The {{FileSystemSyncAccessHandle/write()}} method ### {#api-filesystemsyncaccesshandle-write}
-// TODO(fivedots): do we need to explicit interact with storage quota here?
 
 <div class="note domintro">
   : |handle| . {{FileSystemSyncAccessHandle/write()|write}}(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)
@@ -1267,7 +1313,7 @@ these steps:
 The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)</dfn> method, when invoked, must run
 these steps:
 
-// TODO(fivedots): fill in.
+// TODO(fivedots): fill in. Does this algorithm need to explicitly interact with storage quota?
 
 </div>
 
@@ -1303,7 +1349,6 @@ these steps:
 
 ### The {{FileSystemSyncAccessHandle/flush()}} method ### {#api-filesystemsyncaccesshandle-flush}
 
-// TODO(fivedots): does the definition of flush require the introduction of a buffer for the access handle, which is optinally flushed on read/write, but mandatorily so with flush?
 <div class="note domintro">
   : |handle| . {{FileSystemSyncAccessHandle/flush()}}
   :: Ensures that the contents of the file associated with |handle| contain all the modifications done through {{FileSystemSyncAccessHandle/read()}} and {{FileSystemSyncAccessHandle/write()}}.
@@ -1318,11 +1363,11 @@ these steps:
 </div>
 
 ### The {{FileSystemSyncAccessHandle/close()}} method ### {#api-filesystemsyncaccesshandle-close}
-// TODO(fivedots): |entry| is used here, it likely needs to be defined above when discussing locks, and as a contructor parameter for access handles.
 
 <div class="note domintro">
   : |handle| . {{FileSystemSyncAccessHandle/close()}}
-  :: Flushes the access handle and then closes it. Closing an access handle disables any further operations on it and releases the lock associated with the |entry|.
+  :: Flushes the access handle and then closes it. Closing an access handle disables any further operations on it and
+     [=file entry/lock/release|releases the lock=] on the [=FileSystemHandle/entry=] associated with |handle|.
 </div>
 
 <div algorithm>
@@ -1955,10 +2000,10 @@ respectively.
 The <dfn method for=DataTransferItem>getAsFileSystemHandle()</dfn> method steps are:
 
 1. If the {{DataTransferItem}} object is not in the <a spec=html>read/write
-    mode</a> or the <a spec=html>read-only mode</a>, return 
+    mode</a> or the <a spec=html>read-only mode</a>, return
     [=a promise resolved with=] `null`.
 
-1. If the <a spec=html>the drag data item kind</a> is not <em>File</em>, 
+1. If the <a spec=html>the drag data item kind</a> is not <em>File</em>,
     then return [=a promise resolved with=] `null`.
 
 1. Let |p| be [=a new promise=].

--- a/index.bs
+++ b/index.bs
@@ -579,7 +579,7 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method,
 
     The returned {{FileSystemSyncAccessHandle}} offers synchronous {{FileSystemFileHandle/read()}} and
     {{FileSystemFileHandle/write()}} methods. This allows for higher performance for critical methods on
-    contexts where asynchronous operations come with high overhead i.e., WebAssembly.
+    contexts where asynchronous operations come with high overhead, i.e., WebAssembly.
 
     For the time being, this method will only succeed when the |fileHandle| belongs to the
     [=origin private file system=]. Also temporarily, the {{FileSystemFileHandleCreateAccessHandleOptions/mode}} parameter

--- a/index.bs
+++ b/index.bs
@@ -415,10 +415,18 @@ dictionary FileSystemCreateWritableOptions {
   boolean keepExistingData = false;
 };
 
+enum AccessHandleMode { "in-place" };
+
+dictionary FileSystemFileHandleCreateAccessHandleOptions {
+  required AccessHandleMode mode;
+};
+
 [Exposed=(Window,Worker), SecureContext, Serializable]
 interface FileSystemFileHandle : FileSystemHandle {
   Promise<File> getFile();
   Promise<FileSystemWritableFileStream> createWritable(optional FileSystemCreateWritableOptions options = {});
+  [Exposed=DedicatedWorker]
+  Promise<FileSystemSyncAccessHandle> createSyncAccessHandle(optional FileSystemFileHandleCreateAccessHandleOptions options = {});
 };
 </xmp>
 
@@ -427,7 +435,7 @@ A {{FileSystemFileHandle}}'s associated [=FileSystemHandle/entry=] must be a [=f
 {{FileSystemFileHandle}} objects are [=serializable objects=]. Their [=serialization steps=] and
 [=deserialization steps=] are the same as those for {{FileSystemHandle}}.
 
-Advisement: In the Origin Trial as available in Chrome 78, these objects are not yet serializable. 
+Advisement: In the Origin Trial as available in Chrome 78, these objects are not yet serializable.
 In Chrome 82 they are.
 
 ### The {{FileSystemFileHandle/getFile()}} method ### {#api-filesystemfilehandle-getfile}
@@ -467,6 +475,7 @@ The <dfn method for=FileSystemFileHandle>getFile()</dfn> method, when invoked, m
 
 Advisement: In the Origin Trial as available in Chrome 82, createWritable replaces the createWriter method.
 
+// TODO(fivedots): Add info on shared locks.
 <div class="note domintro">
   : |stream| = await |fileHandle| . {{FileSystemFileHandle/createWritable()}}
   : |stream| = await |fileHandle| . {{FileSystemFileHandle/createWritable()|createWritable}}({ {{FileSystemCreateWritableOptions/keepExistingData}}: true/false })
@@ -507,6 +516,34 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method,
   1. If |options|.{{FileSystemCreateWritableOptions/keepExistingData}} is `true`:
     1. Set |stream|.[=[[buffer]]=] to a copy of |entry|'s [=file entry/binary data=].
   1. [=/Resolve=] |result| with |stream|.
+1. Return |result|.
+
+</div>
+
+### The {{FileSystemFileHandle/createSyncAccessHandle()}} method ### {#api-filesystemfilehandle-createsyncaccesshandle}
+
+<div class="note domintro">
+  : |stream| = await |fileHandle| . {{FileSystemFileHandle/createSyncAccessHandle()|createSyncAccessHandle}}({ {{FileSystemFileHandleCreateAccessHandleOptions/mode}}: "in-place" })
+  :: Returns a {{FileSystemSyncAccessHandle}}
+
+// TODO(fivedots): Add description, mentioning direct modifications of the file, locking, only OPFS, mode flag being there for future development, the syncyness of it.
+
+</div>
+
+<div algorithm>
+The <dfn method for=FileSystemFileHandle>createSyncAccessHandle(|options|)</dfn> method, when invoked, must run these steps:
+
+1. Let |result| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+  1. Let |permissionStatus| be the result of [=requesting file system permission=]
+     given <b>[=this=]</b> and {{"readwrite"}}.
+     If that throws an exception, [=reject=] |result| with that exception and abort.
+  1. If |permissionStatus| is not {{PermissionState/"granted"}},
+     reject |result| with a {{NotAllowedError}} and abort.
+  1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
+  1. Let |handle| be the result of [=create a new FileSystemSyncAccessHandle|creating a new FileSystemSyncAccessHandle=]
+     for |entry| in <b>[=this=]</b>'s [=relevant realm=].
+  1. [=/Resolve=] |result| with |handle|.
 1. Return |result|.
 
 </div>
@@ -1138,6 +1175,139 @@ steps:
     |size| ]».
 1. [=WritableStreamDefaultWriter/Release=] |writer|.
 1. Return |result|.
+
+</div>
+
+## The {{FileSystemSyncAccessHandle}} interface ## {#api-filesystemsyncaccesshandle}
+
+<xmp class=idl>
+
+dictionary FilesystemReadWriteOptions {
+  [EnforceRange] unsigned long long at;
+}
+
+[Exposed=DedicatedWorker, SecureContext]
+interface FileSystemSyncAccessHandle {
+  unsigned long long read([AllowShared] BufferSource buffer,
+                             FilesystemReadWriteOptions options);
+  unsigned long long write([AllowShared] BufferSource buffer,
+                              FilesystemReadWriteOptions options);
+
+  Promise<undefined> truncate([EnforceRange] unsigned long long size);
+  Promise<unsigned long long> getSize();
+  Promise<undefined> flush();
+  Promise<undefined> close();
+};
+
+</xmp>
+
+A {{FileSystemSyncAccessHandle}} has an associated <dfn for=FileSystemSyncAccessHandle>\[[file]]</dfn> (a [=file entry=]).
+
+<div class="note domintro">
+// TODO(fivedots): update.
+</div>
+
+<div algorithm>
+To <dfn>create a new FileSystemSyncAccessHandle</dfn> given a [=file entry=] |file|
+in a [=/Realm=] |realm|, perform the following steps:
+
+1. Let |handle| be a [=new=] {{FileSystemSyncAccessHandle}} in |realm|.
+1. Set |handle|.[=FileSystemSyncAccessHandle/[[file]]=] to |file|.
+1. Return |handle|.
+
+</div>
+
+### The {{FileSystemSyncAccessHandle/write()}} method ### {#api-filesystemsyncaccesshandle-write}
+// TODO(fivedots): do we need to explicit interact with storage quota here?
+
+<div class="note domintro">
+  : |handle| . {{FileSystemSyncAccessHandle/write()|write}}(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)
+  :: Writes the content of |buffer| into the file associated with |handle| with |position| as the offset.
+</div>
+
+<div algorithm>
+The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)</dfn> method, when invoked, must run
+these steps:
+
+// TODO(fivedots): fill in.
+
+</div>
+
+### The {{FileSystemSyncAccessHandle/read()}} method ### {#api-filesystemsyncaccesshandle-read}
+
+<div class="note domintro">
+  : |handle| . {{FileSystemSyncAccessHandle/read()|read}}(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)
+  :: Reads the contents of the file associated with |handle| into |buffer|, with |position| as the offset.
+</div>
+
+// TODO(fivedots): does this algorithm need to check that the access handle has not been closed?
+<div algorithm>
+The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)</dfn> method, when invoked, must run
+these steps:
+
+// TODO(fivedots): fill in.
+
+</div>
+
+### The {{FileSystemSyncAccessHandle/truncate()}} method ### {#api-filesystemsyncaccesshandle-truncate}
+
+<div class="note domintro">
+  : |handle| . {{FileSystemSyncAccessHandle/truncate()|truncate}}(|size|)
+  :: Resizes the file associated with stream to be size bytes long. If size is larger than the current file size this pads the file with null bytes, otherwise it truncates the file.
+</div>
+
+<div algorithm>
+The <dfn method for=FileSystemSyncAccessHandle>truncate(|size|)</dfn> method, when invoked, must run
+these steps:
+
+// TODO(fivedots): fill in.
+
+</div>
+
+### The {{FileSystemSyncAccessHandle/getSize()}} method ### {#api-filesystemsyncaccesshandle-getsize}
+
+<div class="note domintro">
+  : |handle| . {{FileSystemSyncAccessHandle/getSize()}}
+  :: Returns the size of the file associated with |handle| in bytes.
+</div>
+
+<div algorithm>
+The <dfn method for=FileSystemSyncAccessHandle>getSize()</dfn> method, when invoked, must run
+these steps:
+
+// TODO(fivedots): fill in.
+
+</div>
+
+### The {{FileSystemSyncAccessHandle/flush()}} method ### {#api-filesystemsyncaccesshandle-flush}
+
+// TODO(fivedots): does the definition of flush require the introduction of a buffer for the access handle, which is optinally flushed on read/write, but mandatorily so with flush?
+<div class="note domintro">
+  : |handle| . {{FileSystemSyncAccessHandle/flush()}}
+  :: Ensures that the contents of the file associated with |handle| contain all the modifications done through {{FileSystemSyncAccessHandle/read()}} and {{FileSystemSyncAccessHandle/write()}}.
+</div>
+
+<div algorithm>
+The <dfn method for=FileSystemSyncAccessHandle>flush()</dfn> method, when invoked, must run
+these steps:
+
+// TODO(fivedots): fill in.
+
+</div>
+
+### The {{FileSystemSyncAccessHandle/close()}} method ### {#api-filesystemsyncaccesshandle-close}
+// TODO(fivedots): |entry| is used here, it likely needs to be defined above when discussing locks, and as a contructor parameter for access handles.
+
+<div class="note domintro">
+  : |handle| . {{FileSystemSyncAccessHandle/close()}}
+  :: Flushes the access handle and then closes it. Closing an access handle disables any further operations on it and releases the lock associated with the |entry|.
+</div>
+
+<div algorithm>
+The <dfn method for=FileSystemSyncAccessHandle>close()</dfn> method, when invoked, must run
+these steps:
+
+// TODO(fivedots): fill in.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -451,18 +451,12 @@ dictionary FileSystemCreateWritableOptions {
   boolean keepExistingData = false;
 };
 
-enum AccessHandleMode { "in-place" };
-
-dictionary FileSystemFileHandleCreateAccessHandleOptions {
-  required AccessHandleMode mode;
-};
-
 [Exposed=(Window,Worker), SecureContext, Serializable]
 interface FileSystemFileHandle : FileSystemHandle {
   Promise<File> getFile();
   Promise<FileSystemWritableFileStream> createWritable(optional FileSystemCreateWritableOptions options = {});
   [Exposed=DedicatedWorker]
-  Promise<FileSystemSyncAccessHandle> createSyncAccessHandle(FileSystemFileHandleCreateAccessHandleOptions options);
+  Promise<FileSystemSyncAccessHandle> createSyncAccessHandle();
 };
 </xmp>
 
@@ -565,7 +559,7 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method,
 ### The {{FileSystemFileHandle/createSyncAccessHandle()}} method ### {#api-filesystemfilehandle-createsyncaccesshandle}
 
 <div class="note domintro">
-  : |handle| = await |fileHandle| . {{FileSystemFileHandle/createSyncAccessHandle()|createSyncAccessHandle}}({ {{FileSystemFileHandleCreateAccessHandleOptions/mode}}: "in-place" })
+  : |handle| = await |fileHandle| . {{FileSystemFileHandle/createSyncAccessHandle()|createSyncAccessHandle}}()
   :: Returns a {{FileSystemSyncAccessHandle}} that can be used to read/write from/to the file.
      Changes made through |handle| might be immediately reflected in the file represented by |fileHandle|.
      To ensure the changes are reflected in this file, the handle must be flushed or closed.
@@ -580,14 +574,11 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method,
     contexts where asynchronous operations come with high overhead, i.e., WebAssembly.
 
     For the time being, this method will only succeed when the |fileHandle| belongs to the
-    [=origin private file system=]. Also temporarily, the {{FileSystemFileHandleCreateAccessHandleOptions/mode}} parameter
-    must be set to "in-place". This prevents us from setting a default behavior and allows us to bring access handles to
-    other filesytems in the future.
-
+    [=origin private file system=].
 </div>
 
 <div algorithm>
-The <dfn method for=FileSystemFileHandle>createSyncAccessHandle(|options|)</dfn> method, when invoked, must run these steps:
+The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method, when invoked, must run these steps:
 
 1. Let |result| be [=a new promise=].
 1. Run the following steps [=in parallel=]:

--- a/index.bs
+++ b/index.bs
@@ -584,7 +584,7 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method, 
      reject |result| with a {{NotAllowedError}} and abort.
   1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
   1. If |entry| does not represent an [=/entry=] in an [=origin private file system=],
-     reject |result| with an {{InvalidStateError}} and abort.
+     reject |result| with an {{NotAllowedError}} and abort.
   1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=] with  "`exclusive`" on |entry|.
   1. If |lockResult| is `false`, [=reject=] |result| with a {{NoModificationAllowedError}} and abort.
   1. Let |handle| be the result of [=create a new FileSystemSyncAccessHandle|creating a new FileSystemSyncAccessHandle=]
@@ -1292,13 +1292,16 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
 these steps:
 
 1. If [=this=].[=[[state]]=] is "`closed`", throw an {{InvalidStateError}}.
-1. Let |readPosition| be |options|.{{FileSystemReadWriteOptions/at}}.
-1. Let |size| be |buffer|'s [=byte length=].
-1. Let |result| be |size|.
-1. Let |bytes| be a [=byte sequence=] containing the bytes from |readPosition|
-   to |readPosition| + (|size| &minus; 1) of [=this=].[=[[file]]=]'s [=file entry/binary data=].
-1. If the operations reading from [=this=].[=[[file]]=]'s [=file entry/binary data=] in the previous steps
-   failed:
+1. Let |bufferSize| be |buffer|'s [=byte length=].
+1. Let |fileContents| be [=this=].[=[[file]]=]'s [=file entry/binary data=].
+1. Let |fileSize| be |fileContents|'s [=byte sequence/length=].
+1. Let |readStart| be |options|.{{FileSystemReadWriteOptions/at}}.
+1. If |readStart| is larger than |fileSize|, return 0.
+1. Let |readEnd| be |readStart| + (|bufferSize| &minus; 1).
+1. If |readEnd| is larger than |fileSize|, set |readEnd| to |fileSize|.
+1. Let |result| be |bufferSize|.
+1. Let |bytes| be a [=byte sequence=] containing the bytes from |readStart| to |readEnd| of |fileContents|.
+1. If the operations reading from |fileContents| in the previous steps failed:
     1. If there were partial reads  and the number of modified bytes in |bytes|  is known,
        set |result| to the number of modified bytes.
     1. Else set |result| to 0.
@@ -1316,6 +1319,7 @@ these steps:
   :: Writes the content of |buffer| into the file associated with |handle|, optionally at a given offset.
 </div>
 
+// TODO(fivedots): Figure out how to properly check the available storage quota (in this method and others) by passing the right storage shelf.
 // TODO(fivedots): Figure out mechanism to prevent concurrent IO operations e.g. doing write() while a truncate() is executing in parallel.
 <div algorithm>
 The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadWriteOptions}}: |options|)</dfn> method, when invoked, must run
@@ -1326,6 +1330,13 @@ these steps:
 1. Let |fileContents| be a copy of [=this=].[=[[file]]=]'s [=file entry/binary data=].
 1. Let |oldSize| be |fileContents|'s [=byte sequence/length=].
 1. Let |data| be [=get a copy of the buffer source|a copy of=] |buffer|.
+
+   Note: The objective of this copy is to prevent concurrent modifications of the buffer
+   from being reflected in the file. Depending on the implementation, a copy
+   of non-shared ArrayBuffers may not be needed in a synchronous call like this one.
+   It might also be possible to do a buffer copy at an earlier time or through a
+   different mechanism.
+
 1. If |writePosition| is larger than |oldSize|,
    append |writePosition| &minus; |oldSize| `0x00` (NUL) bytes to the end of |fileContents|.
 
@@ -1373,9 +1384,13 @@ these steps:
      1. Set [=this=].[=[[file]]=]'s to a [=byte sequence=] formed by concatenating
         |fileContents| with a [=byte sequence=]
         containing |newSize| &minus; |oldSize| `0x00` bytes.
+     1. If the operations modifying the [=this=].[=[[file]]=]'s [=file entry/binary data=] in the previous steps
+        failed, [=/reject=] |p| with a {{InvalidStateError}} and abort.
   1. Else if |newSize| is smaller than |oldSize|:
      1. Set [=this=].[=[[file]]=]'s to a [=byte sequence=] containing the first |newSize| bytes
         in |fileContents|.
+     1. If the operations modifying the [=this=].[=[[file]]=]'s [=file entry/binary data=] in the previous steps
+        failed, [=/reject=] |p| with a {{InvalidStateError}} and abort.
   1. [=/Resolve=] |p|.
 1. Return |p|.
 

--- a/index.bs
+++ b/index.bs
@@ -539,8 +539,6 @@ currently implemented in Chrome. Implementing this is currently blocked on figur
 combine the desire to run malware checks with the desire to let websites make fast in-place
 modifications to existing large files.
 
-// TODO(fivedots): release lock once the stream is closed.
-
 <div algorithm>
 The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method, when invoked, must run these steps:
 
@@ -1038,13 +1036,17 @@ in a [=/Realm=] |realm|, perform the following steps:
 
          Note: It is expected that this atomically updates the contents of the file on disk
          being written to.
+      1. [=file entry/lock/release|Release the lock=] on |stream|.[=FileSystemWritableFileStream/[[file]]=].
       1. [=/Resolve=] |closeResult| with `undefined`.
    1. Return |closeResult|.
+1. Let |abortAlgorithm| be the following step:
+      1. [=file entry/lock/release|Release the lock=] on |stream|.[=FileSystemWritableFileStream/[[file]]=].
 1. Let |highWaterMark| be 1.
 1. Let |sizeAlgorithm| be an algorithm that returns `1`.
 1. [=WritableStream/Set up=] |stream| with <a for="WritableStream/set up"><var
    ignore>writeAlgorithm</var></a> set to |writeAlgorithm|, <a for="WritableStream/set up"><var
    ignore>closeAlgorithm</var></a> set to |closeAlgorithm|, <a for="WritableStream/set up"><var
+   ignore>abortAlgorithm</var></a> set to |abortAlgorithm|, <a for="WritableStream/set up"><var
    ignore>highWaterMark</var></a> set to |highWaterMark|, and <a for="WritableStream/set up"><var
    ignore>sizeAlgorithm</var></a> set to |sizeAlgorithm|.
 1. Return |stream|.
@@ -1246,7 +1248,7 @@ steps:
 <xmp class=idl>
 
 dictionary FilesystemReadWriteOptions {
-  [EnforceRange] unsigned long long at;
+  [EnforceRange] required unsigned long long at;
 }
 
 [Exposed=DedicatedWorker, SecureContext]
@@ -1264,7 +1266,11 @@ interface FileSystemSyncAccessHandle {
 
 </xmp>
 
-A {{FileSystemSyncAccessHandle}} has an associated <dfn for=FileSystemSyncAccessHandle>\[[file]]</dfn> (a [=file entry=]).
+A {{FileSystemSyncAccessHandle}} has an associated <dfn for=FileSystemSyncAccessHandle>\[[file]]</dfn>
+(a [=file entry=]).
+
+A {{FileSystemSyncAccessHandle}} has an associated <dfn for=FileSystemSyncAccessHandle>\[[state]]</dfn>,
+a string that may exclusively be "open" or "closed".
 
 <div class="note domintro">
 
@@ -1283,6 +1289,7 @@ in a [=/Realm=] |realm|, perform the following steps:
 
 1. Let |handle| be a [=new=] {{FileSystemSyncAccessHandle}} in |realm|.
 1. Set |handle|.[=FileSystemSyncAccessHandle/[[file]]=] to |file|.
+1. Set |handle|.[=FileSystemSyncAccessHandle/[[state]]=] to "open".
 1. Return |handle|.
 
 </div>
@@ -1290,30 +1297,73 @@ in a [=/Realm=] |realm|, perform the following steps:
 ### The {{FileSystemSyncAccessHandle/read()}} method ### {#api-filesystemsyncaccesshandle-read}
 
 <div class="note domintro">
-  : |handle| . {{FileSystemSyncAccessHandle/read()|read}}(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)
-  :: Reads the contents of the file associated with |handle| into |buffer|, with |position| as the offset.
+  : |handle| . {{FileSystemSyncAccessHandle/read()|read}}(|buffer|, {{FilesystemReadWriteOptions}}: |options|
+  :: Reads the contents of the file associated with |handle| into |buffer|, with |options|.{{FilesystemReadWriteOptions/at}} as the offset.
 </div>
 
+// TODO(fivedots): Is there a more formal way to describe the resutl of partial reads from the OS?
 <div algorithm>
-The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)</dfn> method, when invoked, must run
+The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FilesystemReadWriteOptions}}: |options|)</dfn> method, when invoked, must run
 these steps:
 
-// TODO(fivedots): fill in. Does this algorithm need to check that the access handle has not been closed?
+1. If [=this=].[=[[state]]=] is "closed", throw a {{InvalidStateError}}.
+1. Let |readPosition| be |options|.{{FilesystemReadWriteOptions/at}}.
+1. Let |size| be |buffer|'s [=byte length=].
+1. Let |result| be |size|.
+1. Let |bytes| be a [=byte sequence=] containing the bytes from |readPosition|
+   to |readPosition| + (|size| - 1) of [=this=].[=[[file]]=]'s [=file entry/binary data=].
+1. If the operations reading from [=this=].[=[[file]]=]'s [=file entry/binary data=] in the previous steps
+   failed:
+    1. If there were partial reads  and the number of modified bytes in |bytes|  is known,
+       set |result| to the number of modified bytes.
+    1. Else set |result| to 0.
+1. Let |arrayBuffer| be |buffer|'s [=underlying buffer=].
+1. [=write|Write=] |bytes| into |arrayBuffer|.
+1. Return |result|.
 
 </div>
 
 ### The {{FileSystemSyncAccessHandle/write()}} method ### {#api-filesystemsyncaccesshandle-write}
 
 <div class="note domintro">
-  : |handle| . {{FileSystemSyncAccessHandle/write()|write}}(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)
-  :: Writes the content of |buffer| into the file associated with |handle| with |position| as the offset.
+  : |handle| . {{FileSystemSyncAccessHandle/write()|write}}(|buffer|, {{FilesystemReadWriteOptions}}: |options|)
+  :: Writes the content of |buffer| into the file associated with |handle| with |options|.{{FilesystemReadWriteOptions/at}} as the offset.
 </div>
 
+// TODO(fivedots): Is there a more formal way to describe the resutl of partial writes from the OS?
+
+// TODO(fivedots): Figure out mechanism to prevent concurrent IO operations e.g. doing write() while a truncate() is executing in parallel.
 <div algorithm>
-The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)</dfn> method, when invoked, must run
+The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FilesystemReadWriteOptions}}: |options|)</dfn> method, when invoked, must run
 these steps:
 
-// TODO(fivedots): fill in. Does this algorithm need to explicitly interact with storage quota?
+1. If [=this=].[=[[state]]=] is "closed", throw a {{InvalidStateError}}.
+1. Let |writePosition| be |options|.{{FilesystemReadWriteOptions/at}}.
+1. Let |fileContents| be a copy of [=this=].[=[[file]]=]'s [=file entry/binary data=].
+1. Let |oldSize| be |fileContents|'s [=byte sequence/length=].
+1. Let |data| be [=get a copy of the buffer source|a copy of=] |buffer|.
+1. If |writePosition| is larger than |oldSize|,
+   append |writePosition| - |oldSize| `0x00` (NUL) bytes to the end of |fileContents|.
+
+   Note: Implementations are expected to behave as if the skipped over file contents
+   are indeed filled with NUL bytes. That doesn't mean these bytes have to actually be
+   written to disk and take up disk space. Instead most file systems support so called
+   sparse files, where these NUL bytes don't take up actual disk space.
+
+1. Let |head| be a [=byte sequence=] containing the first |writePosition| bytes of |fileContents|.
+1. Let |tail| be an empty [=byte sequence=].
+1. If |writePosition| + |data|.[=byte sequence/length=] is smaller than |oldSize|:
+   1. Let |tail| be a [=byte sequence=] containing the last
+      |oldSize| - (|writePosition| + |data|.[=byte sequence/length=]) bytes of |fileContents|.
+1. Let |newSize| be the [=byte sequence/length=] of the concatenation of |head|, |data| and |tail|.
+1. If |newSize| - |oldSize| exceeds the available [=storage quota=], throw a {{QuotaExceededError}}.
+1. Set [=this=].[=[[file]]=]'s [=file entry/binary data=] to the concatenation of |head|, |data| and |tail|.
+1. If the operations modifying the [=this=].[=[[file]]=]'s [=file entry/binary data=] in the previous steps
+   failed:
+    1. If there were partial modifications and the number of modified bytes is known,
+       return the number of modified bytes.
+    1. Else return 0.
+1. Return |data|.[=byte sequence/length=].
 
 </div>
 
@@ -1324,6 +1374,7 @@ these steps:
   :: Resizes the file associated with stream to be size bytes long. If size is larger than the current file size this pads the file with null bytes, otherwise it truncates the file.
 </div>
 
+//TODO(fivedots):Make sure negative lengths are not allowed.
 <div algorithm>
 The <dfn method for=FileSystemSyncAccessHandle>truncate(|size|)</dfn> method, when invoked, must run
 these steps:
@@ -1351,7 +1402,7 @@ these steps:
 
 <div class="note domintro">
   : |handle| . {{FileSystemSyncAccessHandle/flush()}}
-  :: Ensures that the contents of the file associated with |handle| contain all the modifications done through {{FileSystemSyncAccessHandle/read()}} and {{FileSystemSyncAccessHandle/write()}}.
+  :: Ensures that the contents of the file associated with |handle| contain all the modifications done through {{FileSystemSyncAccessHandle/write()}}.
 </div>
 
 <div algorithm>
@@ -1364,19 +1415,22 @@ these steps:
 
 ### The {{FileSystemSyncAccessHandle/close()}} method ### {#api-filesystemsyncaccesshandle-close}
 
-// TODO(fivedots): |fileHandle| is not properly defined here, consider adding an attribute to |handle|.
-
 <div class="note domintro">
   : |handle| . {{FileSystemSyncAccessHandle/close()}}
   :: Flushes the access handle and then closes it. Closing an access handle disables any further operations on it and
-     [=file entry/lock/release|releases the lock=] on the [=FileSystemHandle/entry=] associated with |fileHandle|.
+     [=file entry/lock/release|releases the lock=] on the [=FileSystemHandle/entry=] associated with |handle|.
 </div>
 
+//TODO(fivedots): Figure out language to describe flushing the file at the OS level before closing the handle.
 <div algorithm>
 The <dfn method for=FileSystemSyncAccessHandle>close()</dfn> method, when invoked, must run
 these steps:
 
-// TODO(fivedots): fill in.
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+  1. Set [=this=].[=[[state]]=] to "closed".
+  1. [=/Resolve=] |p|.
+1. Return |p|
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2035,20 +2035,19 @@ elem.addEventListener('dragover', (e) => {
   // Prevent navigation.
   e.preventDefault();
 });
+
 elem.addEventListener('drop', async (e) => {
-  // Prevent navigation.
   e.preventDefault();
 
-  // Process all of the items.
-  for (const item of e.dataTransfer.items) {
-    // kind will be 'file' for file/directory entries.
-    if (item.kind === 'file') {
-      const entry = await item.getAsFileSystemHandle();
-      if (entry.kind === 'file') {
-        handleFileEntry(entry);
-      } else if (entry.kind === 'directory') {
-        handleDirectoryEntry(entry);
-      }
+  const fileHandlesPromises = [...e.dataTransfer.items]
+    .filter(item => item.kind === 'file')
+    .map(item => item.getAsFileSystemHandle());
+
+  for await (const handle of fileHandlesPromises) {
+    if (handle.kind === 'directory') {
+      console.log(`Directory: ${handle.name}`);
+    } else {
+      console.log(`File: ${handle.name}`);
     }
   }
 });

--- a/index.bs
+++ b/index.bs
@@ -1364,10 +1364,12 @@ these steps:
 
 ### The {{FileSystemSyncAccessHandle/close()}} method ### {#api-filesystemsyncaccesshandle-close}
 
+// TOOD(fivedots): |fileHandle| is not properly defined here, consider adding an attribute to |handle|.
+
 <div class="note domintro">
   : |handle| . {{FileSystemSyncAccessHandle/close()}}
   :: Flushes the access handle and then closes it. Closing an access handle disables any further operations on it and
-     [=file entry/lock/release|releases the lock=] on the [=FileSystemHandle/entry=] associated with |handle|.
+     [=file entry/lock/release|releases the lock=] on the [=FileSystemHandle/entry=] associated with |fileHandle|.
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -1364,7 +1364,7 @@ these steps:
 
 ### The {{FileSystemSyncAccessHandle/close()}} method ### {#api-filesystemsyncaccesshandle-close}
 
-// TOOD(fivedots): |fileHandle| is not properly defined here, consider adding an attribute to |handle|.
+// TODO(fivedots): |fileHandle| is not properly defined here, consider adding an attribute to |handle|.
 
 <div class="note domintro">
   : |handle| . {{FileSystemSyncAccessHandle/close()}}

--- a/index.bs
+++ b/index.bs
@@ -462,7 +462,7 @@ interface FileSystemFileHandle : FileSystemHandle {
   Promise<File> getFile();
   Promise<FileSystemWritableFileStream> createWritable(optional FileSystemCreateWritableOptions options = {});
   [Exposed=DedicatedWorker]
-  Promise<FileSystemSyncAccessHandle> createSyncAccessHandle(optional FileSystemFileHandleCreateAccessHandleOptions options = {});
+  Promise<FileSystemSyncAccessHandle> createSyncAccessHandle(FileSystemFileHandleCreateAccessHandleOptions options);
 };
 </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -1273,7 +1273,7 @@ as well as obtaining and changing the size of, a single file.
 
 The {{FileSystemFileHandle/read()}} and {{FileSystemFileHandle/write()}} methods are synchronous.
 This allows for higher performance for critical methods on contexts where asynchronous
-operations come with high overhead i.e., WebAssembly.
+operations come with high overhead, i.e., WebAssembly.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1232,16 +1232,16 @@ steps:
 
 <xmp class=idl>
 
-dictionary FilesystemReadWriteOptions {
+dictionary FileSystemReadWriteOptions {
   [EnforceRange] required unsigned long long at;
 }
 
 [Exposed=DedicatedWorker, SecureContext]
 interface FileSystemSyncAccessHandle {
   unsigned long long read([AllowShared] BufferSource buffer,
-                             FilesystemReadWriteOptions options);
+                          FileSystemReadWriteOptions options);
   unsigned long long write([AllowShared] BufferSource buffer,
-                              FilesystemReadWriteOptions options);
+                           FileSystemReadWriteOptions options);
 
   Promise<undefined> truncate([EnforceRange] unsigned long long newSize);
   Promise<unsigned long long> getSize();
@@ -1282,21 +1282,21 @@ in a [=/Realm=] |realm|, perform the following steps:
 ### The {{FileSystemSyncAccessHandle/read()}} method ### {#api-filesystemsyncaccesshandle-read}
 
 <div class="note domintro">
-  : |handle| . {{FileSystemSyncAccessHandle/read()|read}}(|buffer|, {{FilesystemReadWriteOptions}}: |options|
-  :: Reads the contents of the file associated with |handle| into |buffer|, with |options|.{{FilesystemReadWriteOptions/at}} as the offset.
+  : |handle| . {{FileSystemSyncAccessHandle/read()|read}}(|buffer|)
+  : |handle| . {{FileSystemSyncAccessHandle/read()|read}}(|buffer|, { {{FileSystemReadWriteOptions/at}} })
+  :: Reads the contents of the file associated with |handle| into |buffer|, optionally at a given offset.
 </div>
 
-// TODO(fivedots): Is there a more formal way to describe the resutl of partial reads from the OS?
 <div algorithm>
-The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FilesystemReadWriteOptions}}: |options|)</dfn> method, when invoked, must run
+The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWriteOptions}}: |options|)</dfn> method, when invoked, must run
 these steps:
 
-1. If [=this=].[=[[state]]=] is "`closed`", throw a {{InvalidStateError}}.
-1. Let |readPosition| be |options|.{{FilesystemReadWriteOptions/at}}.
+1. If [=this=].[=[[state]]=] is "`closed`", throw an {{InvalidStateError}}.
+1. Let |readPosition| be |options|.{{FileSystemReadWriteOptions/at}}.
 1. Let |size| be |buffer|'s [=byte length=].
 1. Let |result| be |size|.
 1. Let |bytes| be a [=byte sequence=] containing the bytes from |readPosition|
-   to |readPosition| + (|size| - 1) of [=this=].[=[[file]]=]'s [=file entry/binary data=].
+   to |readPosition| + (|size| &minus; 1) of [=this=].[=[[file]]=]'s [=file entry/binary data=].
 1. If the operations reading from [=this=].[=[[file]]=]'s [=file entry/binary data=] in the previous steps
    failed:
     1. If there were partial reads  and the number of modified bytes in |bytes|  is known,
@@ -1311,24 +1311,23 @@ these steps:
 ### The {{FileSystemSyncAccessHandle/write()}} method ### {#api-filesystemsyncaccesshandle-write}
 
 <div class="note domintro">
-  : |handle| . {{FileSystemSyncAccessHandle/write()|write}}(|buffer|, {{FilesystemReadWriteOptions}}: |options|)
-  :: Writes the content of |buffer| into the file associated with |handle| with |options|.{{FilesystemReadWriteOptions/at}} as the offset.
+  : |handle| . {{FileSystemSyncAccessHandle/write()|write}}(|buffer|)
+  : |handle| . {{FileSystemSyncAccessHandle/write()|write}}(|buffer|, { {{FileSystemReadWriteOptions/at}} })
+  :: Writes the content of |buffer| into the file associated with |handle|, optionally at a given offset.
 </div>
-
-// TODO(fivedots): Is there a more formal way to describe the resutl of partial writes from the OS?
 
 // TODO(fivedots): Figure out mechanism to prevent concurrent IO operations e.g. doing write() while a truncate() is executing in parallel.
 <div algorithm>
-The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FilesystemReadWriteOptions}}: |options|)</dfn> method, when invoked, must run
+The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadWriteOptions}}: |options|)</dfn> method, when invoked, must run
 these steps:
 
 1. If [=this=].[=[[state]]=] is "`closed`", throw a {{InvalidStateError}}.
-1. Let |writePosition| be |options|.{{FilesystemReadWriteOptions/at}}.
+1. Let |writePosition| be |options|.{{FileSystemReadWriteOptions/at}}.
 1. Let |fileContents| be a copy of [=this=].[=[[file]]=]'s [=file entry/binary data=].
 1. Let |oldSize| be |fileContents|'s [=byte sequence/length=].
 1. Let |data| be [=get a copy of the buffer source|a copy of=] |buffer|.
 1. If |writePosition| is larger than |oldSize|,
-   append |writePosition| - |oldSize| `0x00` (NUL) bytes to the end of |fileContents|.
+   append |writePosition| &minus; |oldSize| `0x00` (NUL) bytes to the end of |fileContents|.
 
    Note: Implementations are expected to behave as if the skipped over file contents
    are indeed filled with NUL bytes. That doesn't mean these bytes have to actually be
@@ -1337,18 +1336,18 @@ these steps:
 
 1. Let |head| be a [=byte sequence=] containing the first |writePosition| bytes of |fileContents|.
 1. Let |tail| be an empty [=byte sequence=].
-1. If |writePosition| + |data|.[=byte sequence/length=] is smaller than |oldSize|:
-   1. Let |tail| be a [=byte sequence=] containing the last
-      |oldSize| - (|writePosition| + |data|.[=byte sequence/length=]) bytes of |fileContents|.
-1. Let |newSize| be the [=byte sequence/length=] of the concatenation of |head|, |data| and |tail|.
-1. If |newSize| - |oldSize| exceeds the available [=storage quota=], throw a {{QuotaExceededError}}.
+1. If |writePosition| + |data|'s [=byte sequence/length=] is smaller than |oldSize|:
+   1. Set |tail| to a [=byte sequence=] containing the last
+      |oldSize| &minus; (|writePosition| + |data|'s [=byte sequence/length=]) bytes of |fileContents|.
+1. Let |newSize| be |head|'s [=byte sequence/length=] + |data|'s [=byte sequence/length=] + |tail|'s [=byte sequence/length=].
+1. If |newSize| &minus; |oldSize| exceeds the available [=storage quota=], throw a {{QuotaExceededError}}.
 1. Set [=this=].[=[[file]]=]'s [=file entry/binary data=] to the concatenation of |head|, |data| and |tail|.
 1. If the operations modifying the [=this=].[=[[file]]=]'s [=file entry/binary data=] in the previous steps
    failed:
-    1. If there were partial modifications and the number of modified bytes is known,
-       return the number of modified bytes.
+    1. If there were partial writes and the number of bytes that were written from |data| is known,
+       return the number of bytes that were written from |data|.
     1. Else return 0.
-1. Return |data|.[=byte sequence/length=].
+1. Return |data|'s [=byte sequence/length=].
 
 </div>
 
@@ -1356,30 +1355,29 @@ these steps:
 
 <div class="note domintro">
   : |handle| . {{FileSystemSyncAccessHandle/truncate()|truncate}}(|newSize|)
-  :: Resizes the file associated with stream to be |newSize| bytes long. If size is larger than the current file size this pads the file with null bytes, otherwise it truncates the file.
+  :: Resizes the file associated with stream to be |newSize| bytes long. If size is larger than the current file size this pads the file with null bytes; otherwise it truncates the file.
 </div>
 
 <div algorithm>
 The <dfn method for=FileSystemSyncAccessHandle>truncate(|newSize|)</dfn> method, when invoked, must run
 these steps:
 
-1. If [=this=].[=[[state]]=] is "`closed`", throw a {{InvalidStateError}}.
-1. If  |newSize| is less than 0, throw a {{InvalidStateError}}.
+1. If [=this=].[=[[state]]=] is "`closed`", return [=a promise rejected with=] an {{InvalidStateError}}.
 1. Let |fileContents| be a copy of [=this=].[=[[file]]=]'s [=file entry/binary data=].
-1. Let |p| be [=a new promise=].
+1. Let |p| be [=a new promise=] created in the [=relevant Realm=] of [=this=].
 1. Run the following steps [=in parallel=]:
   1. Let |oldSize| be the [=byte sequence/length=] of [=this=].[=[[file]]=]'s [=file entry/binary data=].
   1. If |newSize| is larger than |oldSize|:
-     1. If |newSize| - |oldSize| exceeds the available [=storage quota=], [=/reject=] |p|
+     1. If |newSize| &minus; |oldSize| exceeds the available [=storage quota=], [=/reject=] |p|
         with a {{QuotaExceededError}} and abort.
-     1. Set [=this=].[=[[file]]=]'s to a [=byte sequence=] formed by concating
+     1. Set [=this=].[=[[file]]=]'s to a [=byte sequence=] formed by concatenating
         |fileContents| with a [=byte sequence=]
-        containing |newSize|-|oldSize| `0x00` bytes.
+        containing |newSize| &minus; |oldSize| `0x00` bytes.
   1. Else if |newSize| is smaller than |oldSize|:
      1. Set [=this=].[=[[file]]=]'s to a [=byte sequence=] containing the first |newSize| bytes
         in |fileContents|.
   1. [=/Resolve=] |p|.
-1. Return |p|
+1. Return |p|.
 
 </div>
 
@@ -1394,12 +1392,12 @@ these steps:
 The <dfn method for=FileSystemSyncAccessHandle>getSize()</dfn> method, when invoked, must run
 these steps:
 
-1. If [=this=].[=[[state]]=] is "`closed`", throw a {{InvalidStateError}}.
-1. Let |p| be [=a new promise=].
+1. If [=this=].[=[[state]]=] is "`closed`", return [=a promise rejected with=] an {{InvalidStateError}}.
+1. Let |p| be [=a new promise=] created in the [=relevant Realm=] of [=this=].
 1. Run the following steps [=in parallel=]:
   1. Let |size| be the [=byte sequence/length=] of [=this=].[=[[file]]=]'s [=file entry/binary data=].
   1. [=/Resolve=] |p| with |size|.
-1. Return |p|
+1. Return |p|.
 
 
 </div>
@@ -1432,11 +1430,11 @@ these steps:
 The <dfn method for=FileSystemSyncAccessHandle>close()</dfn> method, when invoked, must run
 these steps:
 
-1. Let |p| be [=a new promise=].
+1. Let |p| be [=a new promise=] created in the [=relevant Realm=] of [=this=].
 1. Run the following steps [=in parallel=]:
   1. Set [=this=].[=[[state]]=] to "`closed`".
   1. [=/Resolve=] |p|.
-1. Return |p|
+1. Return |p|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -111,37 +111,33 @@ hence the inclusion of + and . as allowed code points.
 A <dfn lt="file|file entry">file entry</dfn> additionally consists of
 <dfn for="file entry">binary data</dfn> (a [=byte sequence=]), a
 <dfn for="file entry">modification timestamp</dfn> (a number representing the number of milliseconds since the <a spec=FileAPI>Unix Epoch</a>)
-and a <dfn for="file entry">lock</dfn>. A lock is a string that may exclusively be "open", "taken-exclusive", and "taken-shared".
+and a <dfn for="file entry">lock</dfn>. A lock is a string that may exclusively be "`open`", "`taken-exclusive`", and "`taken-shared`".
 
 <div algorithm>
-To <dfn for="file entry/lock">take</dfn> a [=lock=] with a |value| of "exclusive" or "shared", for a given |file|,
+To <dfn for="file entry/lock">take</dfn> a [=file entry/lock=] with a |value| of "`exclusive`" or "`shared`" on a given [=file entry=] |file|,
 run the following steps:
 
-1. Let |result| be [=a new promise=].
-1. Let |lock| be the |file|'s associated [=lock=]
-1. Run the following steps [=in parallel=]:
-  1. If |value| is "exclusive":
-     1. If |lock| is "open":
-       1. Set lock to "taken-exclusive".
-       1. [=/resolve=] |result|.
-     1. Else [=/reject=] |result|.
-  1. If |value| is "shared":
-     1. If |lock| is "open":
-       1. Set lock to "taken-exclusive".
-       1. [=/resolve=] |result|.
-     1. Else if |lock| is "taken-shared":
-       1. [=/resolve=] |result|.
-     1. Else [=/reject=] |result|.
-1. Return |result|.
+1. Let |lock| be the |file|'s [=file entry/lock=].
+1. If |value| is "`exclusive`":
+   1. If |lock| is "`open`":
+     1. Set lock to "`taken-exclusive`".
+     1. Return `true`.
+1. If |value| is "`shared`":
+   1. If |lock| is "`open`":
+     1. Set lock to "`taken-shared`".
+     1. Return `true`.
+   1. Else if |lock| is "`taken-shared`":
+     1. Return `true`.
+1. Return `false`.
 
 </div>
 
 <div algorithm>
-To <dfn for="file entry/lock">release</dfn> a [=lock=] for a given |file|,
+To <dfn for="file entry/lock">release</dfn> a [=file entry/lock=] on a given [=file entry=] |file|,
 run the following steps:
 
-1. Let |lock| be the |file|'s associated [=lock=]
-1. Set lock to "open".
+1. Let |lock| be the |file|'s associated [=file entry/lock=].
+1. Set lock to "`open`".
 
 </div>
 
@@ -544,9 +540,8 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method,
   1. If |permissionStatus| is not {{PermissionState/"granted"}},
      reject |result| with a {{NotAllowedError}} and abort.
   1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
-  1. Let |lockValue| be "shared".
-  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=] with |lockValue| on |entry|.
-     If that throws an exception, [=reject=] |result| with a {{NoModificationAllowedError}} and abort.
+  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=] with "`shared`" on |entry|.
+  1. If |lockResult| is `false`, [=reject=] |result| with a {{NoModificationAllowedError}} and abort.
   1. Let |stream| be the result of [=create a new FileSystemWritableFileStream|creating a new FileSystemWritableFileStream=]
      for |entry| in <b>[=this=]</b>'s [=relevant realm=].
   1. If |options|.{{FileSystemCreateWritableOptions/keepExistingData}} is `true`:
@@ -566,12 +561,12 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method,
 
     Creating a {{FileSystemSyncAccessHandle}} [=file entry/lock/take|takes an exclusive lock=] on the
     [=FileSystemHandle/entry=] associated with |fileHandle|. This prevents the creation of
-    further {{FileSystemSyncAccessHandle|FileSystemSyncAccessHandles}} or {{FileSystemWritableFileStream|FileSystemWritableFileStreams}}
+    further {{FileSystemSyncAccessHandle}}s or {{FileSystemWritableFileStream}}s
     for the entry, until the access handle is closed.
 
-    The returned {{FileSystemSyncAccessHandle}} offers synchronous {{FileSystemFileHandle/read()}} and
-    {{FileSystemFileHandle/write()}} methods. This allows for higher performance for critical methods on
-    contexts where asynchronous operations come with high overhead, i.e., WebAssembly.
+    The returned {{FileSystemSyncAccessHandle}} offers synchronous {{FileSystemSyncAccessHandle/read()}} and
+    {{FileSystemSyncAccessHandle/write()}} methods. This allows for higher performance for critical methods on
+    contexts where asynchronous operations come with high overhead, e.g., WebAssembly.
 
     For the time being, this method will only succeed when the |fileHandle| belongs to the
     [=origin private file system=].
@@ -589,10 +584,9 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method, 
      reject |result| with a {{NotAllowedError}} and abort.
   1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
   1. If |entry| does not represent an [=/entry=] in an [=origin private file system=],
-     reject |result| with a {{InvalidStateError}} and abort.
-  1. Let |lockValue| be "exclusive".
-  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=] with |lockValue| on |entry|.
-     If that throws an exception, [=reject=] |result| with a {{NoModificationAllowedError}} and abort.
+     reject |result| with an {{InvalidStateError}} and abort.
+  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=] with  "`exclusive`" on |entry|.
+  1. If |lockResult| is `false`, [=reject=] |result| with a {{NoModificationAllowedError}} and abort.
   1. Let |handle| be the result of [=create a new FileSystemSyncAccessHandle|creating a new FileSystemSyncAccessHandle=]
      for |entry| in <b>[=this=]</b>'s [=relevant realm=].
   1. [=/Resolve=] |result| with |handle|.
@@ -1261,16 +1255,16 @@ A {{FileSystemSyncAccessHandle}} has an associated <dfn for=FileSystemSyncAccess
 (a [=file entry=]).
 
 A {{FileSystemSyncAccessHandle}} has an associated <dfn for=FileSystemSyncAccessHandle>\[[state]]</dfn>,
-a string that may exclusively be "open" or "closed".
+a string that may exclusively be "`open`" or "`closed`".
 
 <div class="note domintro">
 
 A {{FileSystemSyncAccessHandle}} is an object that is capable of reading/writing from/to,
 as well as obtaining and changing the size of, a single file.
 
-The {{FileSystemFileHandle/read()}} and {{FileSystemFileHandle/write()}} methods are synchronous.
+The {{FileSystemSyncAccessHandle/read()}} and {{FileSystemSyncAccessHandle/write()}} methods are synchronous.
 This allows for higher performance for critical methods on contexts where asynchronous
-operations come with high overhead, i.e., WebAssembly.
+operations come with high overhead, e.g., WebAssembly.
 
 </div>
 
@@ -1280,7 +1274,7 @@ in a [=/Realm=] |realm|, perform the following steps:
 
 1. Let |handle| be a [=new=] {{FileSystemSyncAccessHandle}} in |realm|.
 1. Set |handle|.[=FileSystemSyncAccessHandle/[[file]]=] to |file|.
-1. Set |handle|.[=FileSystemSyncAccessHandle/[[state]]=] to "open".
+1. Set |handle|.[=FileSystemSyncAccessHandle/[[state]]=] to "`open`".
 1. Return |handle|.
 
 </div>
@@ -1297,7 +1291,7 @@ in a [=/Realm=] |realm|, perform the following steps:
 The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FilesystemReadWriteOptions}}: |options|)</dfn> method, when invoked, must run
 these steps:
 
-1. If [=this=].[=[[state]]=] is "closed", throw a {{InvalidStateError}}.
+1. If [=this=].[=[[state]]=] is "`closed`", throw a {{InvalidStateError}}.
 1. Let |readPosition| be |options|.{{FilesystemReadWriteOptions/at}}.
 1. Let |size| be |buffer|'s [=byte length=].
 1. Let |result| be |size|.
@@ -1328,7 +1322,7 @@ these steps:
 The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FilesystemReadWriteOptions}}: |options|)</dfn> method, when invoked, must run
 these steps:
 
-1. If [=this=].[=[[state]]=] is "closed", throw a {{InvalidStateError}}.
+1. If [=this=].[=[[state]]=] is "`closed`", throw a {{InvalidStateError}}.
 1. Let |writePosition| be |options|.{{FilesystemReadWriteOptions/at}}.
 1. Let |fileContents| be a copy of [=this=].[=[[file]]=]'s [=file entry/binary data=].
 1. Let |oldSize| be |fileContents|'s [=byte sequence/length=].
@@ -1369,7 +1363,7 @@ these steps:
 The <dfn method for=FileSystemSyncAccessHandle>truncate(|newSize|)</dfn> method, when invoked, must run
 these steps:
 
-1. If [=this=].[=[[state]]=] is "closed", throw a {{InvalidStateError}}.
+1. If [=this=].[=[[state]]=] is "`closed`", throw a {{InvalidStateError}}.
 1. If  |newSize| is less than 0, throw a {{InvalidStateError}}.
 1. Let |fileContents| be a copy of [=this=].[=[[file]]=]'s [=file entry/binary data=].
 1. Let |p| be [=a new promise=].
@@ -1400,7 +1394,7 @@ these steps:
 The <dfn method for=FileSystemSyncAccessHandle>getSize()</dfn> method, when invoked, must run
 these steps:
 
-1. If [=this=].[=[[state]]=] is "closed", throw a {{InvalidStateError}}.
+1. If [=this=].[=[[state]]=] is "`closed`", throw a {{InvalidStateError}}.
 1. Let |p| be [=a new promise=].
 1. Run the following steps [=in parallel=]:
   1. Let |size| be the [=byte sequence/length=] of [=this=].[=[[file]]=]'s [=file entry/binary data=].
@@ -1440,7 +1434,7 @@ these steps:
 
 1. Let |p| be [=a new promise=].
 1. Run the following steps [=in parallel=]:
-  1. Set [=this=].[=[[state]]=] to "closed".
+  1. Set [=this=].[=[[state]]=] to "`closed`".
   1. [=/Resolve=] |p|.
 1. Return |p|
 

--- a/index.bs
+++ b/index.bs
@@ -111,7 +111,7 @@ hence the inclusion of + and . as allowed code points.
 A <dfn lt="file|file entry">file entry</dfn> additionally consists of
 <dfn for="file entry">binary data</dfn> (a [=byte sequence=]), a
 <dfn for="file entry">modification timestamp</dfn> (a number representing the number of milliseconds since the <a spec=FileAPI>Unix Epoch</a>)
-and a <dfn for="file entry">lock</dfn>. A lock is a string that may exclusively be "open", "taken-exclusive" and "taken-shared".
+and a <dfn for="file entry">lock</dfn>. A lock is a string that may exclusively be "open", "taken-exclusive", and "taken-shared".
 
 <div algorithm>
 To <dfn for="file entry/lock">take</dfn> a [=lock=] with a |value| of "exclusive" or "shared", for a given |file|,

--- a/index.bs
+++ b/index.bs
@@ -84,6 +84,8 @@ is similar to the temporary file system as defined in earlier drafts of
 
 ## Concepts ## {#concepts}
 
+// TODO(fivedots): add concept of locks here.
+
 An <dfn>entry</dfn> is either a [=file entry=] or a [=directory entry=].
 
 Each [=/entry=] has an associated <dfn for=entry>name</dfn> (a [=string=]).
@@ -523,10 +525,21 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method,
 ### The {{FileSystemFileHandle/createSyncAccessHandle()}} method ### {#api-filesystemfilehandle-createsyncaccesshandle}
 
 <div class="note domintro">
-  : |stream| = await |fileHandle| . {{FileSystemFileHandle/createSyncAccessHandle()|createSyncAccessHandle}}({ {{FileSystemFileHandleCreateAccessHandleOptions/mode}}: "in-place" })
-  :: Returns a {{FileSystemSyncAccessHandle}}
+  : |handle| = await |fileHandle| . {{FileSystemFileHandle/createSyncAccessHandle()|createSyncAccessHandle}}({ {{FileSystemFileHandleCreateAccessHandleOptions/mode}}: "in-place" })
+  :: Returns a {{FileSystemSyncAccessHandle}} that can be used to read/write from/to the file.
+     Changes made through |handle| might be immediately reflected in the file represented by |fileHandle|.
+     To ensure the changes are reflected in this file, the handle must be flushed or closed.
 
-// TODO(fivedots): Add description, mentioning direct modifications of the file, locking, only OPFS, mode flag being there for future development, the syncyness of it.
+    The returned {{FileSystemSyncAccessHandle}} offers synchronous {{FileSystemFileHandle/read()}} and
+    {{FileSystemFileHandle/write()}} methods. This allows for higher performance for critical methods on
+    contexts where asynchronous operations come with high overhead i.e., WebAssembly.
+
+    For the time being, this method will only succeed when the |fileHandle| belongs to the
+    [=origin private file system=]. Also temporarily, the {{FileSystemFileHandleCreateAccessHandleOptions/mode}} parameter
+    must be set to "in-place". This prevents us from setting a default behavior and allows us to bring access handles to
+    other filesytems in the future.
+
+// TODO(fivedots): Mention that an exclusive lock will be taken.
 
 </div>
 
@@ -541,6 +554,8 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle(|options|)</dfn>
   1. If |permissionStatus| is not {{PermissionState/"granted"}},
      reject |result| with a {{NotAllowedError}} and abort.
   1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
+  1. If |entry| does not represent an [=/entry=] in an [=origin private file system=],
+     reject |result| with a {{InvalidStateError}} and abort.
   1. Let |handle| be the result of [=create a new FileSystemSyncAccessHandle|creating a new FileSystemSyncAccessHandle=]
      for |entry| in <b>[=this=]</b>'s [=relevant realm=].
   1. [=/Resolve=] |result| with |handle|.
@@ -1204,7 +1219,14 @@ interface FileSystemSyncAccessHandle {
 A {{FileSystemSyncAccessHandle}} has an associated <dfn for=FileSystemSyncAccessHandle>\[[file]]</dfn> (a [=file entry=]).
 
 <div class="note domintro">
-// TODO(fivedots): update.
+
+A {{FileSystemSyncAccessHandle}} is an object that is capable of reading/writing from/to,
+as well as obtaining and changing the size of, a single file.
+
+The {{FileSystemFileHandle/read()}} and {{FileSystemFileHandle/write()}} methods are synchronous.
+This allows for higher performance for critical methods on contexts where asynchronous
+operations come with high overhead i.e., WebAssembly.
+
 </div>
 
 <div algorithm>
@@ -1214,22 +1236,6 @@ in a [=/Realm=] |realm|, perform the following steps:
 1. Let |handle| be a [=new=] {{FileSystemSyncAccessHandle}} in |realm|.
 1. Set |handle|.[=FileSystemSyncAccessHandle/[[file]]=] to |file|.
 1. Return |handle|.
-
-</div>
-
-### The {{FileSystemSyncAccessHandle/write()}} method ### {#api-filesystemsyncaccesshandle-write}
-// TODO(fivedots): do we need to explicit interact with storage quota here?
-
-<div class="note domintro">
-  : |handle| . {{FileSystemSyncAccessHandle/write()|write}}(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)
-  :: Writes the content of |buffer| into the file associated with |handle| with |position| as the offset.
-</div>
-
-<div algorithm>
-The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)</dfn> method, when invoked, must run
-these steps:
-
-// TODO(fivedots): fill in.
 
 </div>
 
@@ -1243,6 +1249,22 @@ these steps:
 // TODO(fivedots): does this algorithm need to check that the access handle has not been closed?
 <div algorithm>
 The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)</dfn> method, when invoked, must run
+these steps:
+
+// TODO(fivedots): fill in.
+
+</div>
+
+### The {{FileSystemSyncAccessHandle/write()}} method ### {#api-filesystemsyncaccesshandle-write}
+// TODO(fivedots): do we need to explicit interact with storage quota here?
+
+<div class="note domintro">
+  : |handle| . {{FileSystemSyncAccessHandle/write()|write}}(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)
+  :: Writes the content of |buffer| into the file associated with |handle| with |position| as the offset.
+</div>
+
+<div algorithm>
+The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FilesystemReadWriteOptions/at}}: |position|)</dfn> method, when invoked, must run
 these steps:
 
 // TODO(fivedots): fill in.

--- a/index.bs
+++ b/index.bs
@@ -1258,7 +1258,7 @@ interface FileSystemSyncAccessHandle {
   unsigned long long write([AllowShared] BufferSource buffer,
                               FilesystemReadWriteOptions options);
 
-  Promise<undefined> truncate([EnforceRange] unsigned long long size);
+  Promise<undefined> truncate([EnforceRange] unsigned long long newSize);
   Promise<unsigned long long> getSize();
   Promise<undefined> flush();
   Promise<undefined> close();
@@ -1370,16 +1370,31 @@ these steps:
 ### The {{FileSystemSyncAccessHandle/truncate()}} method ### {#api-filesystemsyncaccesshandle-truncate}
 
 <div class="note domintro">
-  : |handle| . {{FileSystemSyncAccessHandle/truncate()|truncate}}(|size|)
-  :: Resizes the file associated with stream to be size bytes long. If size is larger than the current file size this pads the file with null bytes, otherwise it truncates the file.
+  : |handle| . {{FileSystemSyncAccessHandle/truncate()|truncate}}(|newSize|)
+  :: Resizes the file associated with stream to be |newSize| bytes long. If size is larger than the current file size this pads the file with null bytes, otherwise it truncates the file.
 </div>
 
-//TODO(fivedots):Make sure negative lengths are not allowed.
 <div algorithm>
-The <dfn method for=FileSystemSyncAccessHandle>truncate(|size|)</dfn> method, when invoked, must run
+The <dfn method for=FileSystemSyncAccessHandle>truncate(|newSize|)</dfn> method, when invoked, must run
 these steps:
 
-// TODO(fivedots): fill in.
+1. If [=this=].[=[[state]]=] is "closed", throw a {{InvalidStateError}}.
+1. If  |newSize| is less than 0, throw a {{InvalidStateError}}.
+1. Let |fileContents| be a copy of [=this=].[=[[file]]=]'s [=file entry/binary data=].
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+  1. Let |oldSize| be the [=byte sequence/length=] of [=this=].[=[[file]]=]'s [=file entry/binary data=].
+  1. If |newSize| is larger than |oldSize|:
+     1. If |newSize| - |oldSize| exceeds the available [=storage quota=], [=/reject=] |p|
+        with a {{QuotaExceededError}} and abort.
+     1. Set [=this=].[=[[file]]=]'s to a [=byte sequence=] formed by concating
+        |fileContents| with a [=byte sequence=]
+        containing |newSize|-|oldSize| `0x00` bytes.
+  1. Else if |newSize| is smaller than |oldSize|:
+     1. Set [=this=].[=[[file]]=]'s to a [=byte sequence=] containing the first |newSize| bytes
+        in |fileContents|.
+  1. [=/Resolve=] |p|.
+1. Return |p|
 
 </div>
 
@@ -1394,7 +1409,13 @@ these steps:
 The <dfn method for=FileSystemSyncAccessHandle>getSize()</dfn> method, when invoked, must run
 these steps:
 
-// TODO(fivedots): fill in.
+1. If [=this=].[=[[state]]=] is "closed", throw a {{InvalidStateError}}.
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+  1. Let |size| be the [=byte sequence/length=] of [=this=].[=[[file]]=]'s [=file entry/binary data=].
+  1. [=/Resolve=] |p| with |size|.
+1. Return |p|
+
 
 </div>
 
@@ -1409,7 +1430,7 @@ these steps:
 The <dfn method for=FileSystemSyncAccessHandle>flush()</dfn> method, when invoked, must run
 these steps:
 
-// TODO(fivedots): fill in.
+// TODO(fivedots): Fill in, after figuring out language to describe flushing at the OS level.
 
 </div>
 

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <title>File System Access</title>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
-  <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version d7036035b, updated Fri Oct 8 17:07:11 2021 -0700" name="generator">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
+  <meta content="Bikeshed version fb1e763a4, updated Tue Mar 1 13:13:50 2022 -0800" name="generator">
   <link href="https://wicg.github.io/file-system-access/" rel="canonical">
 <style>
 .domintro dt {
@@ -660,9 +660,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </style>
  <body class="h-entry">
   <div class="head">
-   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
+   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">File System Access</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2021-11-03">3 November 2021</time></span></h2>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2022-03-17">17 March 2022</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -675,7 +675,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2021 the Contributors to the File System Access Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2022 the Contributors to the File System Access Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
 A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
    <hr title="Separator for header">
   </div>
@@ -845,7 +845,7 @@ U+002B (+), or U+002E (.).</p>
 majority of file extensions are purely alphanumeric, but compound extensions (such as <code>.tar.gz</code>) and extensions such as <code>.c++</code> for C++ source code are also fairly common,
 hence the inclusion of + and . as allowed code points.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="file|file entry" data-noexport id="file">file entry</dfn> additionally consists of <dfn class="dfn-paneled" data-dfn-for="file entry" data-dfn-type="dfn" data-noexport id="file-entry-binary-data">binary data</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence">byte sequence</a>), a <dfn class="dfn-paneled" data-dfn-for="file entry" data-dfn-type="dfn" data-noexport id="file-entry-modification-timestamp">modification timestamp</dfn> (a number representing the number of milliseconds since the <a data-link-type="dfn" href="https://w3c.github.io/FileAPI/#UnixEpoch" id="ref-for-UnixEpoch">Unix Epoch</a>)
-and a <dfn class="dfn-paneled" data-dfn-for="file entry" data-dfn-type="dfn" data-noexport id="file-entry-lock">lock</dfn>. A lock is a string that may exclusively be "open", "taken-exclusive" and "taken-shared".</p>
+and a <dfn class="dfn-paneled" data-dfn-for="file entry" data-dfn-type="dfn" data-noexport id="file-entry-lock">lock</dfn>. A lock is a string that may exclusively be "open", "taken-exclusive", and "taken-shared".</p>
    <div class="algorithm" data-algorithm="take" data-algorithm-for="file entry/lock">
      To <dfn class="dfn-paneled" data-dfn-for="file entry/lock" data-dfn-type="dfn" data-noexport id="file-entry-lock-take">take</dfn> a <a data-link-type="dfn" href="#file-entry-lock" id="ref-for-file-entry-lock">lock</a> with a <var>value</var> of "exclusive" or "shared", for a given <var>file</var>,
 run the following steps: 
@@ -906,7 +906,6 @@ run the following steps:
       <p>Set lock to "open".</p>
     </ol>
    </div>
-    //TODO(fivedots): Define algorithm for releasing a lock. 
    <p class="note" role="note"><span>Note:</span> Locks help prevent concurrent modifications to a file. A <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream">FileSystemWritableFileStream</a></code> requires a shared lock, while a <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle">FileSystemSyncAccessHandle</a></code> requires an exclusive one.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="directory|directory entry" data-noexport id="directory">directory entry</dfn> additionally consists of a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">set</a> of <dfn class="dfn-paneled" data-dfn-for="directory entry" data-dfn-type="dfn" data-noexport id="directory-entry-children">children</dfn>, which are themselves <a data-link-type="dfn" href="#entry" id="ref-for-entry①">entries</a>. Each member is either a <a data-link-type="dfn" href="#file" id="ref-for-file①">file</a> or a <a data-link-type="dfn" href="#directory" id="ref-for-directory①">directory</a>.</p>
    <p>An <a data-link-type="dfn" href="#entry" id="ref-for-entry②">entry</a> <var>entry</var> should be <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contained</a> in the <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children">children</a> of at most one <a data-link-type="dfn" href="#directory" id="ref-for-directory②">directory entry</a>, and that directory entry is also known as <var>entry</var>’s <dfn class="dfn-paneled" data-dfn-for="entry" data-dfn-type="dfn" data-noexport id="entry-parent">parent</dfn>.
@@ -997,20 +996,20 @@ run these steps:
         <p>Let <var>entry</var> be <var>desc</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle">handle</a></code>'s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①">entry</a>.</p>
        <li data-md>
         <p>If <var>entry</var> represents an <a data-link-type="dfn" href="#entry" id="ref-for-entry⑨">entry</a> in an <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system">origin private file system</a>,
-this descriptor’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state">permission state</a> must always be <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted">"granted"</a></code>.</p>
+this descriptor’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state">permission state</a> must always be <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted">"granted"</a></code>.</p>
        <li data-md>
-        <p>Otherwise, if <var>entry</var>’s <a data-link-type="dfn" href="#entry-parent" id="ref-for-entry-parent①">parent</a> is not null, this descriptor’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state①">permission state</a> must be
-equal to the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state②">permission state</a> for a descriptor with the same <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode">mode</a></code>,
+        <p>Otherwise, if <var>entry</var>’s <a data-link-type="dfn" href="#entry-parent" id="ref-for-entry-parent①">parent</a> is not null, this descriptor’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state①">permission state</a> must be
+equal to the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state②">permission state</a> for a descriptor with the same <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode">mode</a></code>,
 and a <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle①">handle</a></code> representing <var>entry</var>’s <a data-link-type="dfn" href="#entry-parent" id="ref-for-entry-parent②">parent</a>.</p>
        <li data-md>
         <p>Otherwise, if <var>desc</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode①">mode</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite">"readwrite"</a></code>:</p>
         <ol>
          <li data-md>
-          <p>Let <var>read state</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state③">permission state</a> for a descriptor
+          <p>Let <var>read state</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state③">permission state</a> for a descriptor
 with the same <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle②">handle</a></code>,
 but <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode②">mode</a></code> = <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read">"read"</a></code>.</p>
          <li data-md>
-          <p>If <var>read state</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①">"granted"</a></code>, this descriptor’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state④">permission state</a> must be equal to <var>read state</var>.</p>
+          <p>If <var>read state</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①">"granted"</a></code>, this descriptor’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state④">permission state</a> must be equal to <var>read state</var>.</p>
         </ol>
       </ol>
      </div>
@@ -1055,7 +1054,7 @@ run these steps:
      <li data-md>
       <p>Set <var>desc</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode③">mode</a></code> to <var>mode</var>.</p>
      <li data-md>
-      <p>Return <var>desc</var>’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state⑤">permission state</a>.</p>
+      <p>Return <var>desc</var>’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state⑤">permission state</a>.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="requesting file system permission">
@@ -1074,25 +1073,24 @@ run these steps:
      <li data-md>
       <p>Run the <a data-link-type="dfn" href="https://wicg.github.io/permissions-request/#permission-request-algorithm" id="ref-for-permission-request-algorithm①">permission request algorithm</a> for the <code class="idl"><a data-link-type="idl" href="#dom-permissionname-file-system" id="ref-for-dom-permissionname-file-system②">"file-system"</a></code> feature, given <var>desc</var> and <var>status</var>.</p>
      <li data-md>
-      <p>Return <var>desc</var>’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state⑥">permission state</a>.</p>
+      <p>Return <var>desc</var>’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state⑥">permission state</a>.</p>
     </ol>
    </div>
    <p class="issue" id="issue-7fc2f5c7"><a class="self-link" href="#issue-7fc2f5c7"></a> Currently <code class="idl"><a data-link-type="idl" href="#enumdef-filesystempermissionmode" id="ref-for-enumdef-filesystempermissionmode③">FileSystemPermissionMode</a></code> can only be <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read①">"read"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite①">"readwrite"</a></code>. In
 the future we might want to add a "write" mode as well to support write-only handles. <a href="https://github.com/wicg/file-system-access/issues/119">[Issue #119]</a></p>
    <h3 class="heading settled" data-level="2.3" id="api-filesystemhandle"><span class="secno">2.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#filesystemhandle" id="ref-for-filesystemhandle③">FileSystemHandle</a></code> interface</span><a class="self-link" href="#api-filesystemhandle"></a></h3>
    <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <button class="mdn-anno-btn"><span>MDN</span></button>
     <div class="feature">
      <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle" title="The FileSystemHandle interface of the File System Access API is an object which represents a file or directory entry. Multiple handles can represent the same entry. For the most part you do not work with FileSystemHandle directly but rather its child interfaces FileSystemFileHandle and FileSystemDirectoryHandle.">FileSystemHandle</a></p>
-     <p class="less-than-two-engines-text">In only one current engine.</p>
      <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
       <hr>
       <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
       <hr>
       <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
       <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
      </div>
     </div>
    </div>
@@ -1145,18 +1143,17 @@ In Chrome 82 they are.</strong></p>
     <dl>
      <dt data-md>
       <div class="mdn-anno wrapped">
-       <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+       <button class="mdn-anno-btn"><span>MDN</span></button>
        <div class="feature">
         <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/kind" title="The kind read-only property of the FileSystemHandle interface returns the type of entry. This is &apos;file&apos; if the associated entry is a file or &apos;directory&apos;. It is used to distinguish files from directories when iterating over the contents of a directory.">FileSystemHandle/kind</a></p>
-        <p class="less-than-two-engines-text">In only one current engine.</p>
         <div class="support">
-         <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+         <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
          <hr>
          <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
          <hr>
          <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
          <hr>
-         <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+         <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
         </div>
        </div>
       </div>
@@ -1168,18 +1165,17 @@ In Chrome 82 they are.</strong></p>
  of a directory.</p>
      <dt data-md>
       <div class="mdn-anno wrapped">
-       <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+       <button class="mdn-anno-btn"><span>MDN</span></button>
        <div class="feature">
         <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/name" title="The name read-only property of the FileSystemHandle interface returns the name of the entry represented by handle.">FileSystemHandle/name</a></p>
-        <p class="less-than-two-engines-text">In only one current engine.</p>
         <div class="support">
-         <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+         <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
          <hr>
          <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
          <hr>
          <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
          <hr>
-         <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+         <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
         </div>
        </div>
       </div>
@@ -1195,18 +1191,17 @@ and return <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle
 associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry⑤">entry</a>.</p>
    <h4 class="heading settled" data-level="2.3.1" id="api-filesystemhandle-issameentry"><span class="secno">2.3.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-issameentry" id="ref-for-dom-filesystemhandle-issameentry①">isSameEntry()</a></code> method</span><a class="self-link" href="#api-filesystemhandle-issameentry"></a></h4>
    <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <button class="mdn-anno-btn"><span>MDN</span></button>
     <div class="feature">
      <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/isSameEntry" title="The isSameEntry() method of the FileSystemHandle interface compares two handles to see if the associated entries (either a file or directory) match.">FileSystemHandle/isSameEntry</a></p>
-     <p class="less-than-two-engines-text">In only one current engine.</p>
      <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
       <hr>
       <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
       <hr>
       <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
       <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
      </div>
     </div>
    </div>
@@ -1348,18 +1343,17 @@ associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-fi
    </div>
    <h3 class="heading settled" data-level="2.4" id="api-filesystemfilehandle"><span class="secno">2.4. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①">FileSystemFileHandle</a></code> interface</span><a class="self-link" href="#api-filesystemfilehandle"></a></h3>
    <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <button class="mdn-anno-btn"><span>MDN</span></button>
     <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle" title="The FileSystemFileHandle interface of the File System Access API represents a handle to a file system entry. The interface is accessed thought the window.showOpenFilePicker() method.">FileSystemFileHandle</a></p>
-     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle" title="The FileSystemFileHandle interface of the File System Access API represents a handle to a file system entry. The interface is accessed through the window.showOpenFilePicker() method.">FileSystemFileHandle</a></p>
      <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
       <hr>
       <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
       <hr>
       <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
       <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
      </div>
     </div>
    </div>
@@ -1378,7 +1372,7 @@ associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-fi
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise③"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-file" id="ref-for-dfn-file"><c- n>File</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-getfile" id="ref-for-dom-filesystemfilehandle-getfile"><c- g>getFile</c-></a>();
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise④"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream①"><c- n>FileSystemWritableFileStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createwritable" id="ref-for-dom-filesystemfilehandle-createwritable"><c- g>createWritable</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemcreatewritableoptions" id="ref-for-dictdef-filesystemcreatewritableoptions"><c- n>FileSystemCreateWritableOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemFileHandle/createWritable(options), FileSystemFileHandle/createWritable()" data-dfn-type="argument" data-export id="dom-filesystemfilehandle-createwritable-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemfilehandle-createwritable-options-options"></a></dfn> = {});
   [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed②"><c- g>Exposed</c-></a>=<c- n>DedicatedWorker</c->]
-  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑤"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle①"><c- n>FileSystemSyncAccessHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createsyncaccesshandle" id="ref-for-dom-filesystemfilehandle-createsyncaccesshandle"><c- g>createSyncAccessHandle</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemfilehandlecreateaccesshandleoptions" id="ref-for-dictdef-filesystemfilehandlecreateaccesshandleoptions"><c- n>FileSystemFileHandleCreateAccessHandleOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemFileHandle/createSyncAccessHandle(options), FileSystemFileHandle/createSyncAccessHandle()" data-dfn-type="argument" data-export id="dom-filesystemfilehandle-createsyncaccesshandle-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemfilehandle-createsyncaccesshandle-options-options"></a></dfn> = {});
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑤"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle①"><c- n>FileSystemSyncAccessHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createsyncaccesshandle" id="ref-for-dom-filesystemfilehandle-createsyncaccesshandle"><c- g>createSyncAccessHandle</c-></a>(<a data-link-type="idl-name" href="#dictdef-filesystemfilehandlecreateaccesshandleoptions" id="ref-for-dictdef-filesystemfilehandlecreateaccesshandleoptions"><c- n>FileSystemFileHandleCreateAccessHandleOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemFileHandle/createSyncAccessHandle(options)" data-dfn-type="argument" data-export id="dom-filesystemfilehandle-createsyncaccesshandle-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemfilehandle-createsyncaccesshandle-options-options"></a></dfn>);
 };
 </pre>
    <p>A <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle②">FileSystemFileHandle</a></code>'s associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry⑧">entry</a> must be a <a data-link-type="dfn" href="#file" id="ref-for-file③">file entry</a>.</p>
@@ -1387,18 +1381,17 @@ associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-fi
 In Chrome 82 they are.</strong></p>
    <h4 class="heading settled" data-level="2.4.1" id="api-filesystemfilehandle-getfile"><span class="secno">2.4.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-getfile" id="ref-for-dom-filesystemfilehandle-getfile①">getFile()</a></code> method</span><a class="self-link" href="#api-filesystemfilehandle-getfile"></a></h4>
    <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <button class="mdn-anno-btn"><span>MDN</span></button>
     <div class="feature">
      <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle/getFile" title="The getFile() method of the FileSystemFileHandle interface returns a Promise which resolves to a File object representing the state on disk of the entry represented by the handle.">FileSystemFileHandle/getFile</a></p>
-     <p class="less-than-two-engines-text">In only one current engine.</p>
      <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
       <hr>
       <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
       <hr>
       <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
       <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
      </div>
     </div>
    </div>
@@ -1448,12 +1441,11 @@ In Chrome 82 they are.</strong></p>
    </div>
    <h4 class="heading settled" data-level="2.4.2" id="api-filesystemfilehandle-createwritable"><span class="secno">2.4.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-createwritable" id="ref-for-dom-filesystemfilehandle-createwritable①">createWritable()</a></code> method</span><a class="self-link" href="#api-filesystemfilehandle-createwritable"></a></h4>
    <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <button class="mdn-anno-btn"><span>MDN</span></button>
     <div class="feature">
      <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle/createWritable" title="The createWritable() method of the FileSystemFileHandle interface creates a FileSystemWritableFileStream that can be used to write to a file. The method returns a Promise which resolves to this created stream.">FileSystemFileHandle/createWritable</a></p>
-     <p class="less-than-two-engines-text">In only one current engine.</p>
      <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>preview+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
       <hr>
       <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
       <hr>
@@ -1486,7 +1478,6 @@ example to support in-place modification of large files or things like databases
 currently implemented in Chrome. Implementing this is currently blocked on figuring out how to
 combine the desire to run malware checks with the desire to let websites make fast in-place
 modifications to existing large files. <a href="https://github.com/wicg/file-system-access/issues/67">[Issue #67]</a></p>
-   <p>// TODO(fivedots): release lock once the stream is closed.</p>
    <div class="algorithm" data-algorithm="createWritable(options)" data-algorithm-for="FileSystemFileHandle">
      The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemFileHandle" data-dfn-type="method" data-export data-lt="createWritable(options)|createWritable()" id="dom-filesystemfilehandle-createwritable"><code>createWritable(<var>options</var>)</code></dfn> method, when invoked, must run these steps: 
     <ol>
@@ -1534,14 +1525,14 @@ modifications to existing large files. <a href="https://github.com/wicg/file-sys
       <p>Creating a <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle④">FileSystemSyncAccessHandle</a></code> <a data-link-type="dfn" href="#file-entry-lock-take" id="ref-for-file-entry-lock-take②">takes an exclusive lock</a> on the <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①②">entry</a> associated with <var>fileHandle</var>. This prevents the creation of
 further <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑤">FileSystemSyncAccessHandles</a></code> or <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream④">FileSystemWritableFileStreams</a></code> for the entry, until the access handle is closed.</p>
       <p>The returned <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑥">FileSystemSyncAccessHandle</a></code> offers synchronous <code class="idl"><a data-link-type="idl">read()</a></code> and <code class="idl"><a data-link-type="idl">write()</a></code> methods. This allows for higher performance for critical methods on
-contexts where asynchronous operations come with high overhead i.e., WebAssembly.</p>
+contexts where asynchronous operations come with high overhead, i.e., WebAssembly.</p>
       <p>For the time being, this method will only succeed when the <var>fileHandle</var> belongs to the <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system①">origin private file system</a>. Also temporarily, the <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandlecreateaccesshandleoptions-mode" id="ref-for-dom-filesystemfilehandlecreateaccesshandleoptions-mode①">mode</a></code> parameter
 must be set to "in-place". This prevents us from setting a default behavior and allows us to bring access handles to
 other filesytems in the future.</p>
     </dl>
    </div>
    <div class="algorithm" data-algorithm="createSyncAccessHandle(options)" data-algorithm-for="FileSystemFileHandle">
-     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemFileHandle" data-dfn-type="method" data-export data-lt="createSyncAccessHandle(options)|createSyncAccessHandle()" id="dom-filesystemfilehandle-createsyncaccesshandle"><code>createSyncAccessHandle(<var>options</var>)</code></dfn> method, when invoked, must run these steps: 
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemFileHandle" data-dfn-type="method" data-export id="dom-filesystemfilehandle-createsyncaccesshandle"><code>createSyncAccessHandle(<var>options</var>)</code></dfn> method, when invoked, must run these steps: 
     <ol>
      <li data-md>
       <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑦">a new promise</a>.</p>
@@ -1575,18 +1566,17 @@ other filesytems in the future.</p>
    </div>
    <h3 class="heading settled" data-level="2.5" id="api-filesystemdirectoryhandle"><span class="secno">2.5. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①">FileSystemDirectoryHandle</a></code> interface</span><a class="self-link" href="#api-filesystemdirectoryhandle"></a></h3>
    <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <button class="mdn-anno-btn"><span>MDN</span></button>
     <div class="feature">
      <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle" title="The FileSystemDirectoryHandle interface of the File System Access API provides a handle to a file system directory. The interface is accessed via the window.showDirectoryPicker() method.">FileSystemDirectoryHandle</a></p>
-     <p class="less-than-two-engines-text">In only one current engine.</p>
      <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
       <hr>
       <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
       <hr>
       <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
       <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
      </div>
     </div>
    </div>
@@ -1702,18 +1692,17 @@ support for example recursive iteration. <a href="https://github.com/wicg/file-s
    </div>
    <h4 class="heading settled" data-level="2.5.2" id="api-filesystemdirectoryhandle-getfilehandle"><span class="secno">2.5.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-getfilehandle" id="ref-for-dom-filesystemdirectoryhandle-getfilehandle①">getFileHandle()</a></code> method</span><a class="self-link" href="#api-filesystemdirectoryhandle-getfilehandle"></a></h4>
    <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <button class="mdn-anno-btn"><span>MDN</span></button>
     <div class="feature">
      <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/getFileHandle" title="The getFileHandle() method of the FileSystemDirectoryHandle interface returns a FileSystemFileHandle for a file with the specified name, within the directory the method is called.">FileSystemDirectoryHandle/getFileHandle</a></p>
-     <p class="less-than-two-engines-text">In only one current engine.</p>
      <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
       <hr>
       <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
       <hr>
       <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
       <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
      </div>
     </div>
    </div>
@@ -1810,18 +1799,17 @@ must run these steps:
    </div>
    <h4 class="heading settled" data-level="2.5.3" id="api-filesystemdirectoryhandle-getdirectoryhandle"><span class="secno">2.5.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-getdirectoryhandle" id="ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle①">getDirectoryHandle()</a></code> method</span><a class="self-link" href="#api-filesystemdirectoryhandle-getdirectoryhandle"></a></h4>
    <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <button class="mdn-anno-btn"><span>MDN</span></button>
     <div class="feature">
      <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/getDirectoryHandle" title="The getDirectoryHandle() method of the FileSystemDirectoryHandle interface returns a FileSystemDirectoryHandle for a subdirectory with the specified name within the directory handle on which the method is called.">FileSystemDirectoryHandle/getDirectoryHandle</a></p>
-     <p class="less-than-two-engines-text">In only one current engine.</p>
      <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
       <hr>
       <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
       <hr>
       <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
       <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
      </div>
     </div>
    </div>
@@ -1914,18 +1902,17 @@ invoked, must run these steps:
    </div>
    <h4 class="heading settled" data-level="2.5.4" id="api-filesystemdirectoryhandle-removeentry"><span class="secno">2.5.4. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-removeentry" id="ref-for-dom-filesystemdirectoryhandle-removeentry①">removeEntry()</a></code> method</span><a class="self-link" href="#api-filesystemdirectoryhandle-removeentry"></a></h4>
    <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <button class="mdn-anno-btn"><span>MDN</span></button>
     <div class="feature">
      <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/removeEntry" title="The removeEntry() method of the FileSystemDirectoryHandle interface attempts to remove an entry if the directory handle contains a file or directory called the name specified.">FileSystemDirectoryHandle/removeEntry</a></p>
-     <p class="less-than-two-engines-text">In only one current engine.</p>
      <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
       <hr>
       <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
       <hr>
       <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
       <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
      </div>
     </div>
    </div>
@@ -2002,18 +1989,17 @@ these steps:
    </div>
    <h4 class="heading settled" data-level="2.5.5" id="api-filesystemdirectoryhandle-resolve"><span class="secno">2.5.5. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-resolve" id="ref-for-dom-filesystemdirectoryhandle-resolve①">resolve()</a></code> method</span><a class="self-link" href="#api-filesystemdirectoryhandle-resolve"></a></h4>
    <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <button class="mdn-anno-btn"><span>MDN</span></button>
     <div class="feature">
      <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/resolve" title="The resolve() method of the FileSystemDirectoryHandle interface returns an Array of directory names from the parent handle to the specified child entry, with the name of the child entry as the last array item.">FileSystemDirectoryHandle/resolve</a></p>
-     <p class="less-than-two-engines-text">In only one current engine.</p>
      <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
       <hr>
       <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
       <hr>
       <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
       <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
      </div>
     </div>
    </div>
@@ -2147,7 +2133,7 @@ When using <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritab
         <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①①">in parallel</a>:</p>
         <ol>
          <li data-md>
-          <p>Let <var>permissionStatus</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state⑦">permission state</a> for a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor⑤">FileSystemPermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑧">handle</a></code> representing <var>stream</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file">[[file]]</a>,
+          <p>Let <var>permissionStatus</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state⑦">permission state</a> for a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor⑤">FileSystemPermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑧">handle</a></code> representing <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file①">[[file]]</a>,
  and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode⑥">mode</a></code> = <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite①⓪">"readwrite"</a></code>.</p>
          <li data-md>
           <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①⓪">"granted"</a></code>,
@@ -2156,10 +2142,12 @@ When using <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritab
           <p>Perform user agent-specific <a data-link-type="dfn" href="#wellknowndirectory-malware-scans-and-safe-browsing-checks" id="ref-for-wellknowndirectory-malware-scans-and-safe-browsing-checks">malware scans and safe browsing checks</a>.
  If these checks fail, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②②">reject</a> <var>closeResult</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror">AbortError</a></code> and abort.</p>
          <li data-md>
-          <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file①">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data④">binary data</a> to <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①">[[buffer]]</a>.
+          <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data④">binary data</a> to <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①">[[buffer]]</a>.
  If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②③">reject</a> <var>closeResult</var> with that exception and abort.</p>
           <p class="note" role="note"><span>Note:</span> It is expected that this atomically updates the contents of the file on disk
  being written to.</p>
+         <li data-md>
+          <p><a data-link-type="dfn" href="#file-entry-lock-release" id="ref-for-file-entry-lock-release">Release the lock</a> on <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file②">[[file]]</a>.</p>
          <li data-md>
           <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⓪">Resolve</a> <var>closeResult</var> with <code>undefined</code>.</p>
         </ol>
@@ -2167,11 +2155,17 @@ When using <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritab
         <p>Return <var>closeResult</var>.</p>
       </ol>
      <li data-md>
+      <p>Let <var>abortAlgorithm</var> be the following step:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#file-entry-lock-release" id="ref-for-file-entry-lock-release①">Release the lock</a> on <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file③">[[file]]</a>.</p>
+      </ol>
+     <li data-md>
       <p>Let <var>highWaterMark</var> be 1.</p>
      <li data-md>
       <p>Let <var>sizeAlgorithm</var> be an algorithm that returns <code>1</code>.</p>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up" id="ref-for-writablestream-set-up">Set up</a> <var>stream</var> with <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up-writealgorithm" id="ref-for-writablestream-set-up-writealgorithm"><var>writeAlgorithm</var></a> set to <var>writeAlgorithm</var>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up-closealgorithm" id="ref-for-writablestream-set-up-closealgorithm"><var>closeAlgorithm</var></a> set to <var>closeAlgorithm</var>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up-highwatermark" id="ref-for-writablestream-set-up-highwatermark"><var>highWaterMark</var></a> set to <var>highWaterMark</var>, and <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up-sizealgorithm" id="ref-for-writablestream-set-up-sizealgorithm"><var>sizeAlgorithm</var></a> set to <var>sizeAlgorithm</var>.</p>
+      <p><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up" id="ref-for-writablestream-set-up">Set up</a> <var>stream</var> with <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up-writealgorithm" id="ref-for-writablestream-set-up-writealgorithm"><var>writeAlgorithm</var></a> set to <var>writeAlgorithm</var>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up-closealgorithm" id="ref-for-writablestream-set-up-closealgorithm"><var>closeAlgorithm</var></a> set to <var>closeAlgorithm</var>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up-abortalgorithm" id="ref-for-writablestream-set-up-abortalgorithm"><var>abortAlgorithm</var></a> set to <var>abortAlgorithm</var>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up-highwatermark" id="ref-for-writablestream-set-up-highwatermark"><var>highWaterMark</var></a> set to <var>highWaterMark</var>, and <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up-sizealgorithm" id="ref-for-writablestream-set-up-sizealgorithm"><var>sizeAlgorithm</var></a> set to <var>sizeAlgorithm</var>.</p>
      <li data-md>
       <p>Return <var>stream</var>.</p>
     </ol>
@@ -2190,7 +2184,7 @@ runs these steps:
       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①②">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>permissionStatus</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state⑧">permission state</a> for a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor⑥">FileSystemPermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑨">handle</a></code> representing <var>stream</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file②">[[file]]</a>,
+        <p>Let <var>permissionStatus</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state⑧">permission state</a> for a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor⑥">FileSystemPermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑨">handle</a></code> representing <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file④">[[file]]</a>,
   and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode⑦">mode</a></code> = <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite①①">"readwrite"</a></code>.</p>
        <li data-md>
         <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①①">"granted"</a></code>,
@@ -2458,7 +2452,7 @@ steps:
    </div>
    <h3 class="heading settled" data-level="2.7" id="api-filesystemsyncaccesshandle"><span class="secno">2.7. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑦">FileSystemSyncAccessHandle</a></code> interface</span><a class="self-link" href="#api-filesystemsyncaccesshandle"></a></h3>
 <pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystemreadwriteoptions"><code><c- g>FilesystemReadWriteOptions</c-></code></dfn> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange" id="ref-for-EnforceRange"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long④"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FilesystemReadWriteOptions" data-dfn-type="dict-member" data-export data-type="unsigned long long " id="dom-filesystemreadwriteoptions-at"><code><c- g>at</c-></code></dfn>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange" id="ref-for-EnforceRange"><c- g>EnforceRange</c-></a>] <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long④"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FilesystemReadWriteOptions" data-dfn-type="dict-member" data-export data-type="unsigned long long " id="dom-filesystemreadwriteoptions-at"><code><c- g>at</c-></code></dfn>;
 }
 
 [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed⑤"><c- g>Exposed</c-></a>=<c- n>DedicatedWorker</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext" id="ref-for-SecureContext④"><c- g>SecureContext</c-></a>]
@@ -2468,7 +2462,7 @@ steps:
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑥"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export data-lt="write(buffer, options)" id="dom-filesystemsyncaccesshandle-write"><code><c- g>write</c-></code></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#AllowShared" id="ref-for-AllowShared①"><c- g>AllowShared</c-></a>] <a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#BufferSource" id="ref-for-BufferSource④"><c- n>BufferSource</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/write(buffer, options)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-write-buffer-options-buffer"><code><c- g>buffer</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-write-buffer-options-buffer"></a></dfn>,
                               <a data-link-type="idl-name" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions①"><c- n>FilesystemReadWriteOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/write(buffer, options)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-write-buffer-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-write-buffer-options-options"></a></dfn>);
 
-  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①③"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined④"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-truncate" id="ref-for-dom-filesystemsyncaccesshandle-truncate"><c- g>truncate</c-></a>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange" id="ref-for-EnforceRange①"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑦"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/truncate(size)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-truncate-size-size"><code><c- g>size</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-truncate-size-size"></a></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①③"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined④"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-truncate" id="ref-for-dom-filesystemsyncaccesshandle-truncate"><c- g>truncate</c-></a>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange" id="ref-for-EnforceRange①"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑦"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/truncate(newSize)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-truncate-newsize-newsize"><code><c- g>newSize</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-truncate-newsize-newsize"></a></dfn>);
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①④"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑧"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-getsize" id="ref-for-dom-filesystemsyncaccesshandle-getsize"><c- g>getSize</c-></a>();
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①⑤"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined⑤"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-flush" id="ref-for-dom-filesystemsyncaccesshandle-flush"><c- g>flush</c-></a>();
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①⑥"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined⑥"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-close" id="ref-for-dom-filesystemsyncaccesshandle-close"><c- g>close</c-></a>();
@@ -2476,20 +2470,24 @@ steps:
 
 </pre>
    <p>A <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑧">FileSystemSyncAccessHandle</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="dfn" data-noexport id="filesystemsyncaccesshandle-file">[[file]]</dfn> (a <a data-link-type="dfn" href="#file" id="ref-for-file⑨">file entry</a>).</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑨">FileSystemSyncAccessHandle</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="dfn" data-noexport id="filesystemsyncaccesshandle-state">[[state]]</dfn>,
+a string that may exclusively be "open" or "closed".</p>
    <div class="note domintro" role="note">
-    <p>A <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑨">FileSystemSyncAccessHandle</a></code> is an object that is capable of reading/writing from/to,
+    <p>A <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle①⓪">FileSystemSyncAccessHandle</a></code> is an object that is capable of reading/writing from/to,
 as well as obtaining and changing the size of, a single file.</p>
     <p>The <code class="idl"><a data-link-type="idl">read()</a></code> and <code class="idl"><a data-link-type="idl">write()</a></code> methods are synchronous.
 This allows for higher performance for critical methods on contexts where asynchronous
-operations come with high overhead i.e., WebAssembly.</p>
+operations come with high overhead, i.e., WebAssembly.</p>
    </div>
    <div class="algorithm" data-algorithm="create a new FileSystemSyncAccessHandle">
      To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="create-a-new-filesystemsyncaccesshandle">create a new FileSystemSyncAccessHandle</dfn> given a <a data-link-type="dfn" href="#file" id="ref-for-file①⓪">file entry</a> <var>file</var> in a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#realm" id="ref-for-realm①">Realm</a> <var>realm</var>, perform the following steps: 
     <ol>
      <li data-md>
-      <p>Let <var>handle</var> be a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new①">new</a> <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle①⓪">FileSystemSyncAccessHandle</a></code> in <var>realm</var>.</p>
+      <p>Let <var>handle</var> be a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new①">new</a> <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle①①">FileSystemSyncAccessHandle</a></code> in <var>realm</var>.</p>
      <li data-md>
-      <p>Set <var>handle</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file③">[[file]]</a> to <var>file</var>.</p>
+      <p>Set <var>handle</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file①">[[file]]</a> to <var>file</var>.</p>
+     <li data-md>
+      <p>Set <var>handle</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state">[[state]]</a> to "open".</p>
      <li data-md>
       <p>Return <var>handle</var>.</p>
     </ol>
@@ -2497,41 +2495,151 @@ operations come with high overhead i.e., WebAssembly.</p>
    <h4 class="heading settled" data-level="2.7.1" id="api-filesystemsyncaccesshandle-read"><span class="secno">2.7.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read">read()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-read"></a></h4>
    <div class="note domintro" role="note">
     <dl>
-     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read①">read</a></code>(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at">at</a></code>: <var>position</var>)
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read①">read</a></code>(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions②">FilesystemReadWriteOptions</a></code>: <var>options</var>
      <dd data-md>
-      <p>Reads the contents of the file associated with <var>handle</var> into <var>buffer</var>, with <var>position</var> as the offset.</p>
+      <p>Reads the contents of the file associated with <var>handle</var> into <var>buffer</var>, with <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at">at</a></code> as the offset.</p>
     </dl>
    </div>
-   <div class="algorithm" data-algorithm="read(buffer, at: position)" data-algorithm-for="FileSystemSyncAccessHandle">
-     The <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-read-buffer-at-position"><code>read(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at①">at</a></code>: <var>position</var>)</code><a class="self-link" href="#dom-filesystemsyncaccesshandle-read-buffer-at-position"></a></dfn> method, when invoked, must run
+   <p>// TODO(fivedots): Is there a more formal way to describe the resutl of partial reads from the OS?</p>
+   <div class="algorithm" data-algorithm="read(buffer, FilesystemReadWriteOptions: options)" data-algorithm-for="FileSystemSyncAccessHandle">
+     The <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-read-buffer-filesystemreadwriteoptions-options"><code>read(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions③">FilesystemReadWriteOptions</a></code>: <var>options</var>)</code><a class="self-link" href="#dom-filesystemsyncaccesshandle-read-buffer-filesystemreadwriteoptions-options"></a></dfn> method, when invoked, must run
 these steps: 
-    <p>// TODO(fivedots): fill in. Does this algorithm need to check that the access handle has not been closed?</p>
+    <ol>
+     <li data-md>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②④">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state①">[[state]]</a> is "closed", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>.</p>
+     <li data-md>
+      <p>Let <var>readPosition</var> be <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at①">at</a></code>.</p>
+     <li data-md>
+      <p>Let <var>size</var> be <var>buffer</var>’s <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#buffersource-byte-length" id="ref-for-buffersource-byte-length">byte length</a>.</p>
+     <li data-md>
+      <p>Let <var>result</var> be <var>size</var>.</p>
+     <li data-md>
+      <p>Let <var>bytes</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑨">byte sequence</a> containing the bytes from <var>readPosition</var> to <var>readPosition</var> + (<var>size</var> - 1) of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑤">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file②">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑤">binary data</a>.</p>
+     <li data-md>
+      <p>If the operations reading from <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑥">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑤">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑥">binary data</a> in the previous steps
+ failed:</p>
+      <ol>
+       <li data-md>
+        <p>If there were partial reads  and the number of modified bytes in <var>bytes</var> is known,
+ set <var>result</var> to the number of modified bytes.</p>
+       <li data-md>
+        <p>Else set <var>result</var> to 0.</p>
+      </ol>
+     <li data-md>
+      <p>Let <var>arrayBuffer</var> be <var>buffer</var>’s <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#buffersource-underlying-buffer" id="ref-for-buffersource-underlying-buffer">underlying buffer</a>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#arraybuffer-write" id="ref-for-arraybuffer-write">Write</a> <var>bytes</var> into <var>arrayBuffer</var>.</p>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
    </div>
    <h4 class="heading settled" data-level="2.7.2" id="api-filesystemsyncaccesshandle-write"><span class="secno">2.7.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write">write()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-write"></a></h4>
    <div class="note domintro" role="note">
     <dl>
-     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write①">write</a></code>(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at②">at</a></code>: <var>position</var>)
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write①">write</a></code>(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions④">FilesystemReadWriteOptions</a></code>: <var>options</var>)
      <dd data-md>
-      <p>Writes the content of <var>buffer</var> into the file associated with <var>handle</var> with <var>position</var> as the offset.</p>
+      <p>Writes the content of <var>buffer</var> into the file associated with <var>handle</var> with <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at②">at</a></code> as the offset.</p>
     </dl>
    </div>
-   <div class="algorithm" data-algorithm="write(buffer, at: position)" data-algorithm-for="FileSystemSyncAccessHandle">
-     The <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-write-buffer-at-position"><code>write(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at③">at</a></code>: <var>position</var>)</code><a class="self-link" href="#dom-filesystemsyncaccesshandle-write-buffer-at-position"></a></dfn> method, when invoked, must run
+   <p>// TODO(fivedots): Is there a more formal way to describe the resutl of partial writes from the OS?</p>
+   <p>// TODO(fivedots): Figure out mechanism to prevent concurrent IO operations e.g. doing write() while a truncate() is executing in parallel.</p>
+   <div class="algorithm" data-algorithm="write(buffer, FilesystemReadWriteOptions: options)" data-algorithm-for="FileSystemSyncAccessHandle">
+     The <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-write-buffer-filesystemreadwriteoptions-options"><code>write(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions⑤">FilesystemReadWriteOptions</a></code>: <var>options</var>)</code><a class="self-link" href="#dom-filesystemsyncaccesshandle-write-buffer-filesystemreadwriteoptions-options"></a></dfn> method, when invoked, must run
 these steps: 
-    <p>// TODO(fivedots): fill in. Does this algorithm need to explicitly interact with storage quota?</p>
+    <ol>
+     <li data-md>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑦">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state②">[[state]]</a> is "closed", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror②">InvalidStateError</a></code>.</p>
+     <li data-md>
+      <p>Let <var>writePosition</var> be <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at③">at</a></code>.</p>
+     <li data-md>
+      <p>Let <var>fileContents</var> be a copy of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑧">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file③">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑦">binary data</a>.</p>
+     <li data-md>
+      <p>Let <var>oldSize</var> be <var>fileContents</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑤">length</a>.</p>
+     <li data-md>
+      <p>Let <var>data</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy" id="ref-for-dfn-get-buffer-source-copy①">a copy of</a> <var>buffer</var>.</p>
+     <li data-md>
+      <p>If <var>writePosition</var> is larger than <var>oldSize</var>,
+ append <var>writePosition</var> - <var>oldSize</var> <code>0x00</code> (NUL) bytes to the end of <var>fileContents</var>.</p>
+      <p class="note" role="note"><span>Note:</span> Implementations are expected to behave as if the skipped over file contents
+ are indeed filled with NUL bytes. That doesn’t mean these bytes have to actually be
+ written to disk and take up disk space. Instead most file systems support so called
+ sparse files, where these NUL bytes don’t take up actual disk space.</p>
+     <li data-md>
+      <p>Let <var>head</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①⓪">byte sequence</a> containing the first <var>writePosition</var> bytes of <var>fileContents</var>.</p>
+     <li data-md>
+      <p>Let <var>tail</var> be an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①①">byte sequence</a>.</p>
+     <li data-md>
+      <p>If <var>writePosition</var> + <var>data</var>.<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑥">length</a> is smaller than <var>oldSize</var>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>tail</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①②">byte sequence</a> containing the last <var>oldSize</var> - (<var>writePosition</var> + <var>data</var>.<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑦">length</a>) bytes of <var>fileContents</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Let <var>newSize</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑧">length</a> of the concatenation of <var>head</var>, <var>data</var> and <var>tail</var>.</p>
+     <li data-md>
+      <p>If <var>newSize</var> - <var>oldSize</var> exceeds the available <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota④">storage quota</a>, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror②">QuotaExceededError</a></code>.</p>
+     <li data-md>
+      <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑨">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑥">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑧">binary data</a> to the concatenation of <var>head</var>, <var>data</var> and <var>tail</var>.</p>
+     <li data-md>
+      <p>If the operations modifying the <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⓪">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file④">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑨">binary data</a> in the previous steps
+ failed:</p>
+      <ol>
+       <li data-md>
+        <p>If there were partial modifications and the number of modified bytes is known,
+ return the number of modified bytes.</p>
+       <li data-md>
+        <p>Else return 0.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>data</var>.<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑨">length</a>.</p>
+    </ol>
    </div>
    <h4 class="heading settled" data-level="2.7.3" id="api-filesystemsyncaccesshandle-truncate"><span class="secno">2.7.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-truncate" id="ref-for-dom-filesystemsyncaccesshandle-truncate①">truncate()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-truncate"></a></h4>
    <div class="note domintro" role="note">
     <dl>
-     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-truncate" id="ref-for-dom-filesystemsyncaccesshandle-truncate②">truncate</a></code>(<var>size</var>)
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-truncate" id="ref-for-dom-filesystemsyncaccesshandle-truncate②">truncate</a></code>(<var>newSize</var>)
      <dd data-md>
-      <p>Resizes the file associated with stream to be size bytes long. If size is larger than the current file size this pads the file with null bytes, otherwise it truncates the file.</p>
+      <p>Resizes the file associated with stream to be <var>newSize</var> bytes long. If size is larger than the current file size this pads the file with null bytes, otherwise it truncates the file.</p>
     </dl>
    </div>
-   <div class="algorithm" data-algorithm="truncate(size)" data-algorithm-for="FileSystemSyncAccessHandle">
-     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-truncate"><code>truncate(<var>size</var>)</code></dfn> method, when invoked, must run
+   <div class="algorithm" data-algorithm="truncate(newSize)" data-algorithm-for="FileSystemSyncAccessHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-truncate"><code>truncate(<var>newSize</var>)</code></dfn> method, when invoked, must run
 these steps: 
-    <p>// TODO(fivedots): fill in.</p>
+    <ol>
+     <li data-md>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③①">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state③">[[state]]</a> is "closed", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror③">InvalidStateError</a></code>.</p>
+     <li data-md>
+      <p>If <var>newSize</var> is less than 0, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror④">InvalidStateError</a></code>.</p>
+     <li data-md>
+      <p>Let <var>fileContents</var> be a copy of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③②">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑤">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①⓪">binary data</a>.</p>
+     <li data-md>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①④">a new promise</a>.</p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①③">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>oldSize</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①⓪">length</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③③">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑦">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①①">binary data</a>.</p>
+       <li data-md>
+        <p>If <var>newSize</var> is larger than <var>oldSize</var>:</p>
+        <ol>
+         <li data-md>
+          <p>If <var>newSize</var> - <var>oldSize</var> exceeds the available <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota⑤">storage quota</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑨">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror③">QuotaExceededError</a></code> and abort.</p>
+         <li data-md>
+          <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③④">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑧">[[file]]</a>'s to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①③">byte sequence</a> formed by concating <var>fileContents</var> with a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①④">byte sequence</a> containing <var>newSize</var>-<var>oldSize</var> <code>0x00</code> bytes.</p>
+        </ol>
+       <li data-md>
+        <p>Else if <var>newSize</var> is smaller than <var>oldSize</var>:</p>
+        <ol>
+         <li data-md>
+          <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑤">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑨">[[file]]</a>'s to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①⑤">byte sequence</a> containing the first <var>newSize</var> bytes
+  in <var>fileContents</var>.</p>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②④">Resolve</a> <var>p</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>p</var></p>
+    </ol>
    </div>
    <h4 class="heading settled" data-level="2.7.4" id="api-filesystemsyncaccesshandle-getsize"><span class="secno">2.7.4. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-getsize" id="ref-for-dom-filesystemsyncaccesshandle-getsize①">getSize()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-getsize"></a></h4>
    <div class="note domintro" role="note">
@@ -2544,33 +2652,62 @@ these steps:
    <div class="algorithm" data-algorithm="getSize()" data-algorithm-for="FileSystemSyncAccessHandle">
      The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-getsize"><code>getSize()</code></dfn> method, when invoked, must run
 these steps: 
-    <p>// TODO(fivedots): fill in.</p>
+    <ol>
+     <li data-md>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑥">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state④">[[state]]</a> is "closed", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror⑤">InvalidStateError</a></code>.</p>
+     <li data-md>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑤">a new promise</a>.</p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①④">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>size</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①①">length</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑦">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file①⓪">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①②">binary data</a>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑤">Resolve</a> <var>p</var> with <var>size</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>p</var></p>
+    </ol>
    </div>
    <h4 class="heading settled" data-level="2.7.5" id="api-filesystemsyncaccesshandle-flush"><span class="secno">2.7.5. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-flush" id="ref-for-dom-filesystemsyncaccesshandle-flush①">flush()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-flush"></a></h4>
    <div class="note domintro" role="note">
     <dl>
      <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-flush" id="ref-for-dom-filesystemsyncaccesshandle-flush②">flush()</a></code>
      <dd data-md>
-      <p>Ensures that the contents of the file associated with <var>handle</var> contain all the modifications done through <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read②">read()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write②">write()</a></code>.</p>
+      <p>Ensures that the contents of the file associated with <var>handle</var> contain all the modifications done through <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write②">write()</a></code>.</p>
     </dl>
    </div>
    <div class="algorithm" data-algorithm="flush()" data-algorithm-for="FileSystemSyncAccessHandle">
      The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-flush"><code>flush()</code></dfn> method, when invoked, must run
 these steps: 
-    <p>// TODO(fivedots): fill in.</p>
+    <p>// TODO(fivedots): Fill in, after figuring out language to describe flushing at the OS level.</p>
    </div>
    <h4 class="heading settled" data-level="2.7.6" id="api-filesystemsyncaccesshandle-close"><span class="secno">2.7.6. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-close" id="ref-for-dom-filesystemsyncaccesshandle-close①">close()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-close"></a></h4>
    <div class="note domintro" role="note">
     <dl>
      <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-close" id="ref-for-dom-filesystemsyncaccesshandle-close②">close()</a></code>
      <dd data-md>
-      <p>Flushes the access handle and then closes it. Closing an access handle disables any further operations on it and <a data-link-type="dfn" href="#file-entry-lock-release" id="ref-for-file-entry-lock-release">releases the lock</a> on the <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②⑤">entry</a> associated with <var>handle</var>.</p>
+      <p>Flushes the access handle and then closes it. Closing an access handle disables any further operations on it and <a data-link-type="dfn" href="#file-entry-lock-release" id="ref-for-file-entry-lock-release②">releases the lock</a> on the <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②⑤">entry</a> associated with <var>handle</var>.</p>
     </dl>
    </div>
+   <p>//TODO(fivedots): Figure out language to describe flushing the file at the OS level before closing the handle.</p>
    <div class="algorithm" data-algorithm="close()" data-algorithm-for="FileSystemSyncAccessHandle">
      The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-close"><code>close()</code></dfn> method, when invoked, must run
 these steps: 
-    <p>// TODO(fivedots): fill in.</p>
+    <ol>
+     <li data-md>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑥">a new promise</a>.</p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑤">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑧">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state⑤">[[state]]</a> to "closed".</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑥">Resolve</a> <var>p</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>p</var></p>
+    </ol>
    </div>
    <h2 class="heading settled" data-level="3" id="local-filesystem"><span class="secno">3. </span><span class="content">Accessing Local File System</span><a class="self-link" href="#local-filesystem"></a></h2>
 <pre class="idl highlight def"><c- b>enum</c-> <a class="idl-code" data-link-type="enum" href="#enumdef-wellknowndirectory" id="ref-for-enumdef-wellknowndirectory"><c- g>WellKnownDirectory</c-></a> {
@@ -2626,9 +2763,9 @@ file pickers will also let you pick files and directories on Google Drive.</p>
    <h3 class="heading settled" data-level="3.1" id="local-file-system-permissions"><span class="secno">3.1. </span><span class="content">Local File System Permissions</span><a class="self-link" href="#local-file-system-permissions"></a></h3>
    <p>The fact that the user picked the specific files returned by the <a data-link-type="dfn" href="#local-file-system-handle-factories" id="ref-for-local-file-system-handle-factories②">local file system handle factories</a> in a prompt
 should be treated by the user agent as the user intending to grant read access to the website
-for the returned files. As such, at the time the promise returned by one of the <a data-link-type="dfn" href="#local-file-system-handle-factories" id="ref-for-local-file-system-handle-factories③">local file system handle factories</a> resolves, <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state⑨">permission state</a> for a descriptor with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle①⓪">handle</a></code> set to the returned handle,
+for the returned files. As such, at the time the promise returned by one of the <a data-link-type="dfn" href="#local-file-system-handle-factories" id="ref-for-local-file-system-handle-factories③">local file system handle factories</a> resolves, <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state⑨">permission state</a> for a descriptor with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle①⓪">handle</a></code> set to the returned handle,
 and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode⑧">mode</a></code> set to <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read⑨">"read"</a></code> should be <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①②">"granted"</a></code>.</p>
-   <p>Additionally for calls to <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker②">showSaveFilePicker</a></code> the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state①⓪">permission state</a> for a descriptor with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle①①">handle</a></code> set to the returned handle,
+   <p>Additionally for calls to <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker②">showSaveFilePicker</a></code> the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state①⓪">permission state</a> for a descriptor with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle①①">handle</a></code> set to the returned handle,
 and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode⑨">mode</a></code> set to <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite①②">readwrite</a></code> should be <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①③">"granted"</a></code>.</p>
    <div class="algorithm" data-algorithm="is allowed to show a file picker">
      To verify that an <var>environment</var> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="is-allowed-to-show-a-file-picker">is allowed to show a file picker</dfn>, run these steps: 
@@ -2866,31 +3003,30 @@ User agents should allow at least 16 entries to be stored in a <a data-link-type
 directories. The exact paths the various values of this enum map to is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#implementation-defined" id="ref-for-implementation-defined">implementation-defined</a> (and in some cases these might not even represent actual paths on disk).
 The following list describes the meaning of each of the values, and gives possible example paths on different operating systems:</p>
    <dl>
-    <dl>
-     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-desktop"><code>"desktop"</code></dfn>
-     <dd data-md>
-      <p>The user’s Desktop directory, if such a thing exists. For example this could be <code>C:\Documents and Settings\username\Desktop</code>, <code>/Users/username/Desktop</code>, or <code>/home/username/Desktop</code>.</p>
-     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-documents"><code>"documents"</code></dfn>
-     <dd data-md>
-      <p>Directory in which documents created by the user would typically be stored.
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-desktop"><code>"desktop"</code></dfn>
+    <dd data-md>
+     <p>The user’s Desktop directory, if such a thing exists. For example this could be <code>C:\Documents and Settings\username\Desktop</code>, <code>/Users/username/Desktop</code>, or <code>/home/username/Desktop</code>.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-documents"><code>"documents"</code></dfn>
+    <dd data-md>
+     <p>Directory in which documents created by the user would typically be stored.
  For example <code>C:\Documents and Settings\username\My Documents</code>, <code>/Users/username/Documents</code>, or <code>/home/username/Documents</code>.</p>
-     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-downloads"><code>"downloads"</code></dfn>
-     <dd data-md>
-      <p>Directory where downloaded files would typically be stored.
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-downloads"><code>"downloads"</code></dfn>
+    <dd data-md>
+     <p>Directory where downloaded files would typically be stored.
  For example <code>C:\Documents and Settings\username\Downloads</code>, <code>/Users/username/Downloads</code>, or <code>/home/username/Downloads</code>.</p>
-     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-music"><code>"music"</code></dfn>
-     <dd data-md>
-      <p>Directory where audio files would typically be stored.
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-music"><code>"music"</code></dfn>
+    <dd data-md>
+     <p>Directory where audio files would typically be stored.
  For example <code>C:\Documents and Settings\username\My Documents\My Music</code>, <code>/Users/username/Music</code>, or <code>/home/username/Music</code>.</p>
-     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-pictures"><code>"pictures"</code></dfn>
-     <dd data-md>
-      <p>Directory where photos and other still images would typically be stored.
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-pictures"><code>"pictures"</code></dfn>
+    <dd data-md>
+     <p>Directory where photos and other still images would typically be stored.
  For example <code>C:\Documents and Settings\username\My Documents\My Pictures</code>, <code>/Users/username/Pictures</code>, or <code>/home/username/Pictures</code>.</p>
-     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-videos"><code>"videos"</code></dfn>
-     <dd data-md>
-      <p>Directory where videos/movies would typically be stored.
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-videos"><code>"videos"</code></dfn>
+    <dd data-md>
+     <p>Directory where videos/movies would typically be stored.
  For example <code>C:\Documents and Settings\username\My Documents\My Videos</code>, <code>/Users/username/Movies</code>, or <code>/home/username/Videos</code>.</p>
-    </dl>
+    </dd>
     <div class="algorithm" data-algorithm="determine the directory the picker will start in">
       To <dfn class="dfn-paneled" data-dfn-for="WellKnownDirectory" data-dfn-type="dfn" data-noexport id="wellknowndirectory-determine-the-directory-the-picker-will-start-in">determine the directory the picker will start in</dfn>, given an optional <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> <var>id</var>,
 an optional <code class="idl"><a data-link-type="idl" href="#typedefdef-startindirectory" id="ref-for-typedefdef-startindirectory②">StartInDirectory</a></code> <var>startIn</var> and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object">environment settings object</a> <var>environment</var>,
@@ -2989,27 +3125,25 @@ run the following steps:
      </div>
     </div>
     <div class="note domintro" role="note">
-     <dl>
-      <dt data-md>[ <var>handle</var> ] = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker④">showOpenFilePicker()</a></code>
-      <dt data-md>[ <var>handle</var> ] = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker⑤">showOpenFilePicker</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-openfilepickeroptions-multiple" id="ref-for-dom-openfilepickeroptions-multiple">multiple</a></code>: false })
-      <dd data-md>
-       <p>Shows a file picker that lets a user select a single existing file, returning a handle for
+     <dt data-md>[ <var>handle</var> ] = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker④">showOpenFilePicker()</a></code>
+     <dt data-md>[ <var>handle</var> ] = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker⑤">showOpenFilePicker</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-openfilepickeroptions-multiple" id="ref-for-dom-openfilepickeroptions-multiple">multiple</a></code>: false })
+     <dd data-md>
+      <p>Shows a file picker that lets a user select a single existing file, returning a handle for
 the selected file.</p>
-      <dt data-md>handles = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker⑥">showOpenFilePicker</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-openfilepickeroptions-multiple" id="ref-for-dom-openfilepickeroptions-multiple①">multiple</a></code>: true })
-      <dd data-md>
-       <p>Shows a file picker that lets a user select multiple existing files, returning handles for
+     <dt data-md>handles = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker⑥">showOpenFilePicker</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-openfilepickeroptions-multiple" id="ref-for-dom-openfilepickeroptions-multiple①">multiple</a></code>: true })
+     <dd data-md>
+      <p>Shows a file picker that lets a user select multiple existing files, returning handles for
 the selected files.</p>
-       <p>Additional options can be passed to <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker⑦">showOpenFilePicker()</a></code> to indicate the types of files
+      <p>Additional options can be passed to <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker⑦">showOpenFilePicker()</a></code> to indicate the types of files
 the website wants the user to select and the directory in which the
 file picker will open. See <a href="#api-filepickeroptions">§ 3.2 File picker options</a> for details.</p>
-     </dl>
     </div>
     <div class="algorithm" data-algorithm="showOpenFilePicker(options)" data-algorithm-for="Window">
       The <dfn class="dfn-paneled idl-code" data-dfn-for="Window" data-dfn-type="method" data-export data-lt="showOpenFilePicker(options)|showOpenFilePicker()" id="dom-window-showopenfilepicker"><code>showOpenFilePicker(<var>options</var>)</code></dfn> method, when invoked, must run
 these steps: 
      <ol>
       <li data-md>
-       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②④">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object③">relevant settings object</a>.</p>
+       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑨">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object③">relevant settings object</a>.</p>
       <li data-md>
        <p>Let <var>accepts options</var> be the result of <a data-link-type="dfn" href="#process-accept-types" id="ref-for-process-accept-types">processing accept types</a> given <var>options</var>.</p>
       <li data-md>
@@ -3019,9 +3153,9 @@ these steps:
       <li data-md>
        <p>Verify that <var>environment</var> <a data-link-type="dfn" href="#is-allowed-to-show-a-file-picker" id="ref-for-is-allowed-to-show-a-file-picker">is allowed to show a file picker</a>.</p>
       <li data-md>
-       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①④">a new promise</a>.</p>
+       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑦">a new promise</a>.</p>
       <li data-md>
-       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①③">in parallel</a>:</p>
+       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑥">in parallel</a>:</p>
        <ol>
         <li data-md>
          <p>Optionally, wait until any prior execution of this algorithm has terminated.</p>
@@ -3035,7 +3169,7 @@ these steps:
         <li data-md>
          <p>Wait for the user to have made their selection.</p>
         <li data-md>
-         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑨">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror①">AbortError</a></code> and abort.</p>
+         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③⓪">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror①">AbortError</a></code> and abort.</p>
         <li data-md>
          <p>Let <var>entries</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> of <a data-link-type="dfn" href="#file" id="ref-for-file①②">file entries</a> representing the selected files or directories.</p>
         <li data-md>
@@ -3050,8 +3184,8 @@ these steps:
              <p>Inform the user that the selected files or directories can’t be exposed to this website.</p>
             <li data-md>
              <p>At the discretion of the user agent,
- either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①④">in parallel</a> steps,
- or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③⓪">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror②">AbortError</a></code> and abort.</p>
+ either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑦">in parallel</a> steps,
+ or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③①">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror②">AbortError</a></code> and abort.</p>
            </ol>
           <li data-md>
            <p>Add a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①①">FileSystemFileHandle</a></code> associated with <var>entry</var> to <var>result</var>.</p>
@@ -3063,7 +3197,7 @@ these steps:
          <p class="note" role="note"><span>Note:</span> This lets a website immediately perform operations on the returned handles that
  might require user activation, such as requesting more permissions.</p>
         <li data-md>
-         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②④">Resolve</a> <var>p</var> with <var>result</var>.</p>
+         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑦">Resolve</a> <var>p</var> with <var>result</var>.</p>
        </ol>
       <li data-md>
        <p>Return <var>p</var>.</p>
@@ -3087,20 +3221,18 @@ these steps:
      </div>
     </div>
     <div class="note domintro" role="note">
-     <dl>
-      <dt data-md><var>handle</var> = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker⑤">showSaveFilePicker</a></code>( <var>options</var> )
-      <dd data-md>
-       <p>Shows a file picker that lets a user select a single file, returning a handle for
+     <dt data-md><var>handle</var> = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker⑤">showSaveFilePicker</a></code>( <var>options</var> )
+     <dd data-md>
+      <p>Shows a file picker that lets a user select a single file, returning a handle for
 the selected file. The selected file does not have to exist already. If the selected
 file does not exist a new empty file is created before this method returns, otherwise
 the existing file is cleared before this method returned.</p>
-      <dt data-md><var>handle</var> = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker⑥">showSaveFilePicker</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-savefilepickeroptions-suggestedname" id="ref-for-dom-savefilepickeroptions-suggestedname">suggestedName</a></code>: "README.md" })
-      <dd data-md>
-       <p>Shows a file picker with the suggested "README.md" file name pre-filled as the default file name to save as.</p>
-       <p>Additional <var>options</var> can be passed to <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker⑦">showSaveFilePicker()</a></code> to indicate the types of files
+     <dt data-md><var>handle</var> = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker⑥">showSaveFilePicker</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-savefilepickeroptions-suggestedname" id="ref-for-dom-savefilepickeroptions-suggestedname">suggestedName</a></code>: "README.md" })
+     <dd data-md>
+      <p>Shows a file picker with the suggested "README.md" file name pre-filled as the default file name to save as.</p>
+      <p>Additional <var>options</var> can be passed to <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker⑦">showSaveFilePicker()</a></code> to indicate the types of files
 the website wants the user to select and the directory in which the
 file picker will open. See <a href="#api-filepickeroptions">§ 3.2 File picker options</a> for details.</p>
-     </dl>
     </div>
     <p><strong class="advisement"> The <code class="idl"><a data-link-type="idl" href="#dom-savefilepickeroptions-suggestedname" id="ref-for-dom-savefilepickeroptions-suggestedname①">suggestedName</a></code> option was first introduced in Chrome 91.</strong></p>
     <div class="algorithm" data-algorithm="showSaveFilePicker(options)" data-algorithm-for="Window">
@@ -3108,7 +3240,7 @@ file picker will open. See <a href="#api-filepickeroptions">§ 3.2 File picker
 these steps: 
      <ol>
       <li data-md>
-       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑤">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object④">relevant settings object</a>.</p>
+       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④⓪">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object④">relevant settings object</a>.</p>
       <li data-md>
        <p>Let <var>accepts options</var> be the result of <a data-link-type="dfn" href="#process-accept-types" id="ref-for-process-accept-types①">processing accept types</a> given <var>options</var>.</p>
       <li data-md>
@@ -3118,9 +3250,9 @@ these steps:
       <li data-md>
        <p>Verify that <var>environment</var> <a data-link-type="dfn" href="#is-allowed-to-show-a-file-picker" id="ref-for-is-allowed-to-show-a-file-picker①">is allowed to show a file picker</a>.</p>
       <li data-md>
-       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑤">a new promise</a>.</p>
+       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑧">a new promise</a>.</p>
       <li data-md>
-       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑤">in parallel</a>:</p>
+       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑧">in parallel</a>:</p>
        <ol>
         <li data-md>
          <p>Optionally, wait until any prior execution of this algorithm has terminated.</p>
@@ -3140,7 +3272,7 @@ these steps:
         <li data-md>
          <p>Wait for the user to have made their selection.</p>
         <li data-md>
-         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③①">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror③">AbortError</a></code> and abort.</p>
+         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③②">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror③">AbortError</a></code> and abort.</p>
         <li data-md>
          <p>Let <var>entry</var> be a <a data-link-type="dfn" href="#file" id="ref-for-file①③">file entry</a> representing the selected file.</p>
         <li data-md>
@@ -3150,11 +3282,11 @@ these steps:
            <p>Inform the user that the selected files or directories can’t be exposed to this website.</p>
           <li data-md>
            <p>At the discretion of the user agent,
- either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑥">in parallel</a> steps,
- or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③②">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror④">AbortError</a></code> and abort.</p>
+ either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑨">in parallel</a> steps,
+ or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③③">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror④">AbortError</a></code> and abort.</p>
          </ol>
         <li data-md>
-         <p>Set <var>entry</var>’s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑤">binary data</a> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑨">byte sequence</a>.</p>
+         <p>Set <var>entry</var>’s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①③">binary data</a> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①⑥">byte sequence</a>.</p>
         <li data-md>
          <p>Set <var>result</var> to a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①②">FileSystemFileHandle</a></code> associated with <var>entry</var>.</p>
         <li data-md>
@@ -3164,7 +3296,7 @@ these steps:
          <p class="note" role="note"><span>Note:</span> This lets a website immediately perform operations on the returned handles that
  might require user activation, such as requesting more permissions.</p>
         <li data-md>
-         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑤">Resolve</a> <var>p</var> with <var>result</var>.</p>
+         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑧">Resolve</a> <var>p</var> with <var>result</var>.</p>
        </ol>
       <li data-md>
        <p>Return <var>p</var>.</p>
@@ -3188,12 +3320,11 @@ these steps:
      </div>
     </div>
     <div class="note domintro" role="note">
-     <dl>
-      <dt data-md><var>handle</var> = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showdirectorypicker" id="ref-for-dom-window-showdirectorypicker③">showDirectoryPicker()</a></code>
-      <dd data-md>
-       <p>Shows a directory picker that lets the user select a single directory, returning a handle for
+     <dt data-md><var>handle</var> = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showdirectorypicker" id="ref-for-dom-window-showdirectorypicker③">showDirectoryPicker()</a></code>
+     <dd data-md>
+      <p>Shows a directory picker that lets the user select a single directory, returning a handle for
 the selected directory.</p>
-     </dl>
+     </dd>
      <p>The <code class="idl"><a data-link-type="idl" href="#dom-directorypickeroptions-id" id="ref-for-dom-directorypickeroptions-id">id</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-directorypickeroptions-startin" id="ref-for-dom-directorypickeroptions-startin">startIn</a></code> fields behave
   identically to the <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id①⑥">id</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-startin" id="ref-for-dom-filepickeroptions-startin①①">startIn</a></code> fields, respectively.
   See <a href="#api-filepickeroptions-starting-directory">§ 3.2.2 Starting Directory</a> for details on how to use these fields.</p>
@@ -3203,7 +3334,7 @@ the selected directory.</p>
 these steps: 
      <ol>
       <li data-md>
-       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑥">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object⑤">relevant settings object</a>.</p>
+       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④①">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object⑤">relevant settings object</a>.</p>
       <li data-md>
        <p>Let <var>starting directory</var> be the result of <a data-link-type="dfn" href="#wellknowndirectory-determine-the-directory-the-picker-will-start-in" id="ref-for-wellknowndirectory-determine-the-directory-the-picker-will-start-in②">determining the directory the picker will start in</a> given <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-directorypickeroptions-id" id="ref-for-dom-directorypickeroptions-id①">id</a></code>, <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-directorypickeroptions-startin" id="ref-for-dom-directorypickeroptions-startin①">startIn</a></code> and <var>environment</var>.</p>
       <li data-md>
@@ -3211,9 +3342,9 @@ these steps:
       <li data-md>
        <p>Verify that <var>environment</var> <a data-link-type="dfn" href="#is-allowed-to-show-a-file-picker" id="ref-for-is-allowed-to-show-a-file-picker②">is allowed to show a file picker</a>.</p>
       <li data-md>
-       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑥">a new promise</a>.</p>
+       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑨">a new promise</a>.</p>
       <li data-md>
-       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑦">in parallel</a>:</p>
+       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②⓪">in parallel</a>:</p>
        <ol>
         <li data-md>
          <p>Optionally, wait until any prior execution of this algorithm has terminated.</p>
@@ -3223,7 +3354,7 @@ these steps:
         <li data-md>
          <p>Wait for the user to have made their selection.</p>
         <li data-md>
-         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③③">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror⑤">AbortError</a></code> and abort.</p>
+         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③④">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror⑤">AbortError</a></code> and abort.</p>
         <li data-md>
          <p>Let <var>entry</var> be a <a data-link-type="dfn" href="#directory" id="ref-for-directory⑨">directory entry</a> representing the selected directory.</p>
         <li data-md>
@@ -3233,8 +3364,8 @@ these steps:
            <p>Inform the user that the selected files or directories can’t be exposed to this website.</p>
           <li data-md>
            <p>At the discretion of the user agent,
- either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑧">in parallel</a> steps,
- or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③④">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror⑥">AbortError</a></code> and abort.</p>
+ either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②①">in parallel</a> steps,
+ or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③⑤">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror⑥">AbortError</a></code> and abort.</p>
          </ol>
         <li data-md>
          <p>Set <var>result</var> to a new <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①③">FileSystemDirectoryHandle</a></code> associated with <var>entry</var>.</p>
@@ -3247,7 +3378,7 @@ these steps:
          <p class="issue" id="issue-923f3009"><a class="self-link" href="#issue-923f3009"></a> Rather than requiring the website to prompt separately for a writable directory,
  we should provide some kind of API to request a writable directory in one step. <a href="https://github.com/wicg/file-system-access/issues/89">[Issue #89]</a></p>
         <li data-md>
-         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑥">Resolve</a> <var>p</var> with <var>result</var>.</p>
+         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑨">Resolve</a> <var>p</var> with <var>result</var>.</p>
        </ol>
       <li data-md>
        <p>Return <var>p</var>.</p>
@@ -3261,11 +3392,9 @@ these steps:
     <p>During a <em>drag-and-drop operation</em>, dragged file and
 directory items are associated with <a data-link-type="dfn" href="#file" id="ref-for-file①④">file entries</a> and <a data-link-type="dfn" href="#directory" id="ref-for-directory①⓪">directory entries</a> respectively.</p>
     <div class="note domintro" role="note">
-     <dl>
-      <dt data-md><var>handle</var> = await item . <code class="idl"><a data-link-type="idl" href="#dom-datatransferitem-getasfilesystemhandle" id="ref-for-dom-datatransferitem-getasfilesystemhandle①">getAsFileSystemHandle()</a></code>
-      <dd data-md>
-       <p>Returns a <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①③">FileSystemFileHandle</a></code> object if the dragged item is a file and a <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①④">FileSystemDirectoryHandle</a></code> object if the dragged item is a directory.</p>
-     </dl>
+     <dt data-md><var>handle</var> = await item . <code class="idl"><a data-link-type="idl" href="#dom-datatransferitem-getasfilesystemhandle" id="ref-for-dom-datatransferitem-getasfilesystemhandle①">getAsFileSystemHandle()</a></code>
+     <dd data-md>
+      <p>Returns a <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①③">FileSystemFileHandle</a></code> object if the dragged item is a file and a <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①④">FileSystemDirectoryHandle</a></code> object if the dragged item is a directory.</p>
     </div>
     <div class="algorithm" data-algorithm="getAsFileSystemHandle()" data-algorithm-for="DataTransferItem">
      <div class="mdn-anno wrapped">
@@ -3293,9 +3422,9 @@ directory items are associated with <a data-link-type="dfn" href="#file" id="ref
        <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-item-kind" id="ref-for-the-drag-data-item-kind">the drag data item kind</a> is not <em>File</em>,
   then return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-resolved-with" id="ref-for-a-promise-resolved-with①">a promise resolved with</a> <code>null</code>.</p>
       <li data-md>
-       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑦">a new promise</a>.</p>
+       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise②⓪">a new promise</a>.</p>
       <li data-md>
-       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑨">in parallel</a>:</p>
+       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②②">in parallel</a>:</p>
        <ol>
         <li data-md>
          <p>Let <var>entry</var> be the <a data-link-type="dfn" href="#entry" id="ref-for-entry①⑦">entry</a> representing the dragged file or directory.</p>
@@ -3312,7 +3441,7 @@ directory items are associated with <a data-link-type="dfn" href="#file" id="ref
            <p>Let <var>handle</var> be a <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①⑤">FileSystemDirectoryHandle</a></code> associated with <var>entry</var>.</p>
          </ol>
         <li data-md>
-         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑦">Resolve</a> <var>p</var> with <var>entry</var>.</p>
+         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve③⓪">Resolve</a> <var>p</var> with <var>entry</var>.</p>
        </ol>
       <li data-md>
        <p>Return <var>p</var>.</p>
@@ -3324,20 +3453,19 @@ directory items are associated with <a data-link-type="dfn" href="#file" id="ref
   <c- c1>// Prevent navigation.</c->
   e<c- p>.</c->preventDefault<c- p>();</c->
 <c- p>});</c->
+
 elem<c- p>.</c->addEventListener<c- p>(</c-><c- t>'drop'</c-><c- p>,</c-> <c- k>async</c-> <c- p>(</c->e<c- p>)</c-> <c- p>=></c-> <c- p>{</c->
-  <c- c1>// Prevent navigation.</c->
   e<c- p>.</c->preventDefault<c- p>();</c->
 
-  <c- c1>// Process all of the items.</c->
-  <c- k>for</c-> <c- p>(</c-><c- a>const</c-> item <c- k>of</c-> e<c- p>.</c->dataTransfer<c- p>.</c->items<c- p>)</c-> <c- p>{</c->
-    <c- c1>// kind will be 'file' for file/directory entries.</c->
-    <c- k>if</c-> <c- p>(</c->item<c- p>.</c->kind <c- o>===</c-> <c- t>'file'</c-><c- p>)</c-> <c- p>{</c->
-      <c- a>const</c-> entry <c- o>=</c-> <c- k>await</c-> item<c- p>.</c->getAsFileSystemHandle<c- p>();</c->
-      <c- k>if</c-> <c- p>(</c->entry<c- p>.</c->kind <c- o>===</c-> <c- t>'file'</c-><c- p>)</c-> <c- p>{</c->
-        handleFileEntry<c- p>(</c->entry<c- p>);</c->
-      <c- p>}</c-> <c- k>else</c-> <c- k>if</c-> <c- p>(</c->entry<c- p>.</c->kind <c- o>===</c-> <c- t>'directory'</c-><c- p>)</c-> <c- p>{</c->
-        handleDirectoryEntry<c- p>(</c->entry<c- p>);</c->
-      <c- p>}</c->
+  <c- a>const</c-> fileHandlesPromises <c- o>=</c-> <c- p>[...</c->e<c- p>.</c->dataTransfer<c- p>.</c->items<c- p>]</c->
+    <c- p>.</c->filter<c- p>(</c->item <c- p>=></c-> item<c- p>.</c->kind <c- o>===</c-> <c- t>'file'</c-><c- p>)</c->
+    <c- p>.</c->map<c- p>(</c->item <c- p>=></c-> item<c- p>.</c->getAsFileSystemHandle<c- p>());</c->
+
+  <c- k>for</c-> <c- k>await</c-> <c- p>(</c-><c- a>const</c-> handle <c- k>of</c-> fileHandlesPromises<c- p>)</c-> <c- p>{</c->
+    <c- k>if</c-> <c- p>(</c->handle<c- p>.</c->kind <c- o>===</c-> <c- t>'directory'</c-><c- p>)</c-> <c- p>{</c->
+      console<c- p>.</c->log<c- p>(</c-><c- o>&lt;</c->code data<c- o>-</c->opaque bs<c- o>-</c->autolink<c- o>-</c->syntax<c- o>=</c-><c- t>'`Directory: ${handle.name}`'</c-><c- o>></c->Directory<c- o>:</c-> $<c- p>{</c->handle<c- p>.</c->name<c- p>}</c-><c- o>&lt;</c->/code>);
+    <c- p>}</c-> <c- k>else</c-> <c- p>{</c->
+      console<c- p>.</c->log<c- p>(</c-><c- o>&lt;</c->code data<c- o>-</c->opaque bs<c- o>-</c->autolink<c- o>-</c->syntax<c- o>=</c-><c- t>'`File: ${handle.name}`'</c-><c- o>></c->File<c- o>:</c-> $<c- p>{</c->handle<c- p>.</c->name<c- p>}</c-><c- o>&lt;</c->/code>);
     <c- p>}</c->
   <c- p>}</c->
 <c- p>});</c->
@@ -3362,11 +3490,9 @@ matching the names of children of the <a data-link-type="dfn" href="#wellknowndi
     <p><strong class="advisement"> In Chrome this functionality was previously exposed as <code>FileSystemDirectoryHandle.getSystemDirectory({type: "sandbox"})</code>.
 This new method is available as of Chrome 85.</strong></p>
     <div class="note domintro" role="note">
-     <dl>
-      <dt data-md><var>directoryHandle</var> = await navigator . storage . <code class="idl"><a data-link-type="idl" href="#dom-storagemanager-getdirectory" id="ref-for-dom-storagemanager-getdirectory③">getDirectory()</a></code>
-      <dd data-md>
-       <p>Returns the root directory of the origin private file system.</p>
-     </dl>
+     <dt data-md><var>directoryHandle</var> = await navigator . storage . <code class="idl"><a data-link-type="idl" href="#dom-storagemanager-getdirectory" id="ref-for-dom-storagemanager-getdirectory③">getDirectory()</a></code>
+     <dd data-md>
+      <p>Returns the root directory of the origin private file system.</p>
     </div>
     <div class="algorithm" data-algorithm="getDirectory()" data-algorithm-for="StorageManager">
       The <dfn class="dfn-paneled idl-code" data-dfn-for="StorageManager" data-dfn-type="method" data-export id="dom-storagemanager-getdirectory"><code>getDirectory()</code></dfn> method, when
@@ -3487,10 +3613,10 @@ Additionally user agents can grant write access to files at whatever granularity
 appropriate.</p>
     <h3 class="heading settled" data-level="7.3" id="filling-up-disk"><span class="secno">7.3. </span><span class="content">Filling up a users disk</span><a class="self-link" href="#filling-up-disk"></a></h3>
     <p>Other than files in the <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system⑧">origin private file system</a>, files written by this API are not subject
-to <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota④">storage quota</a>. As such websites can fill up a users disk without being limited by
+to <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota⑥">storage quota</a>. As such websites can fill up a users disk without being limited by
 quota, which could leave a users device in a bad state (do note that even with storage that is
-subject to <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota⑤">storage quota</a> it is still possible to fill up, or come close to filling up, a users
-disk, since <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota⑥">storage quota</a> in general is not dependent on the amount of available disk
+subject to <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota⑦">storage quota</a> it is still possible to fill up, or come close to filling up, a users
+disk, since <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota⑧">storage quota</a> in general is not dependent on the amount of available disk
 space).</p>
     <p>Without this API websites can write data to disk not subject to quota limitations already
 by triggering downloads of large files (potentially created client side, to not incur any network
@@ -3545,7 +3671,7 @@ use this API to write to disk.</p>
     and are not intended to be performant.
     Implementers are encouraged to optimize. </p>
   </div>
-<script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+<script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
@@ -3564,7 +3690,6 @@ use this API to write to disk.</p>
     </ul>
    <li><a href="#create-a-new-filesystemsyncaccesshandle">create a new FileSystemSyncAccessHandle</a><span>, in § 2.7</span>
    <li><a href="#create-a-new-filesystemwritablefilestream">create a new FileSystemWritableFileStream</a><span>, in § 2.6</span>
-   <li><a href="#dom-filesystemfilehandle-createsyncaccesshandle">createSyncAccessHandle()</a><span>, in § 2.4.3</span>
    <li><a href="#dom-filesystemfilehandle-createsyncaccesshandle">createSyncAccessHandle(options)</a><span>, in § 2.4.3</span>
    <li><a href="#dom-filesystemfilehandle-createwritable">createWritable()</a><span>, in § 2.4.2</span>
    <li><a href="#dom-filesystemfilehandle-createwritable">createWritable(options)</a><span>, in § 2.4.2</span>
@@ -3666,7 +3791,7 @@ use this API to write to disk.</p>
    <li><a href="#dom-filesystemhandle-querypermission">queryPermission()</a><span>, in § 2.3.2</span>
    <li><a href="#dom-filesystemhandle-querypermission">queryPermission(descriptor)</a><span>, in § 2.3.2</span>
    <li><a href="#dom-filesystempermissionmode-read">"read"</a><span>, in § 2.2</span>
-   <li><a href="#dom-filesystemsyncaccesshandle-read-buffer-at-position">read(buffer, at: position)</a><span>, in § 2.7.1</span>
+   <li><a href="#dom-filesystemsyncaccesshandle-read-buffer-filesystemreadwriteoptions-options">read(buffer, FilesystemReadWriteOptions: options)</a><span>, in § 2.7.1</span>
    <li><a href="#dom-filesystemsyncaccesshandle-read">read(buffer, options)</a><span>, in § 2.7</span>
    <li><a href="#dom-filesystempermissionmode-readwrite">"readwrite"</a><span>, in § 2.2</span>
    <li><a href="#recently-picked-directory-map">recently picked directory map</a><span>, in § 3.2.2</span>
@@ -3699,17 +3824,14 @@ use this API to write to disk.</p>
      <li><a href="#dom-filepickeroptions-startin">dict-member for FilePickerOptions</a><span>, in § 3</span>
     </ul>
    <li><a href="#typedefdef-startindirectory">StartInDirectory</a><span>, in § 3</span>
+   <li><a href="#filesystemsyncaccesshandle-state">[[state]]</a><span>, in § 2.7</span>
    <li><a href="#dom-savefilepickeroptions-suggestedname">suggestedName</a><span>, in § 3</span>
    <li><a href="#file-entry-lock-take">take</a><span>, in § 2.1</span>
    <li><a href="#entry-the-same-as">the same as</a><span>, in § 2.1</span>
    <li><a href="#wellknowndirectory-too-sensitive-or-dangerous">too sensitive or dangerous</a><span>, in § 6.1</span>
    <li><a href="#dom-writecommandtype-truncate">"truncate"</a><span>, in § 2.6</span>
-   <li>
-    truncate(size)
-    <ul>
-     <li><a href="#dom-filesystemsyncaccesshandle-truncate">method for FileSystemSyncAccessHandle</a><span>, in § 2.7.3</span>
-     <li><a href="#dom-filesystemwritablefilestream-truncate">method for FileSystemWritableFileStream</a><span>, in § 2.6.3</span>
-    </ul>
+   <li><a href="#dom-filesystemsyncaccesshandle-truncate">truncate(newSize)</a><span>, in § 2.7.3</span>
+   <li><a href="#dom-filesystemwritablefilestream-truncate">truncate(size)</a><span>, in § 2.6.3</span>
    <li><a href="#dom-writeparams-type">type</a><span>, in § 2.6</span>
    <li><a href="#dom-filepickeroptions-types">types</a><span>, in § 3</span>
    <li><a href="#validate-a-suffix">validate a suffix</a><span>, in § 3.2.1</span>
@@ -3720,7 +3842,7 @@ use this API to write to disk.</p>
    <li><a href="#enumdef-wellknowndirectory">WellKnownDirectory</a><span>, in § 3.2.2</span>
    <li><a href="#dom-writecommandtype-write">"write"</a><span>, in § 2.6</span>
    <li><a href="#write-a-chunk">write a chunk</a><span>, in § 2.6</span>
-   <li><a href="#dom-filesystemsyncaccesshandle-write-buffer-at-position">write(buffer, at: position)</a><span>, in § 2.7.2</span>
+   <li><a href="#dom-filesystemsyncaccesshandle-write-buffer-filesystemreadwriteoptions-options">write(buffer, FilesystemReadWriteOptions: options)</a><span>, in § 2.7.2</span>
    <li><a href="#dom-filesystemsyncaccesshandle-write">write(buffer, options)</a><span>, in § 2.7</span>
    <li><a href="#enumdef-writecommandtype">WriteCommandType</a><span>, in § 2.6</span>
    <li><a href="#dom-filesystemwritablefilestream-write">write(data)</a><span>, in § 2.6.1</span>
@@ -3875,10 +3997,13 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-in-parallel⑨">2.5.3. The getDirectoryHandle() method</a>
     <li><a href="#ref-for-in-parallel①⓪">2.5.4. The removeEntry() method</a>
     <li><a href="#ref-for-in-parallel①①">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-in-parallel①②">(2)</a>
-    <li><a href="#ref-for-in-parallel①③">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-in-parallel①④">(2)</a>
-    <li><a href="#ref-for-in-parallel①⑤">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-in-parallel①⑥">(2)</a>
-    <li><a href="#ref-for-in-parallel①⑦">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-in-parallel①⑧">(2)</a>
-    <li><a href="#ref-for-in-parallel①⑨">3.6. Drag and Drop</a>
+    <li><a href="#ref-for-in-parallel①③">2.7.3. The truncate() method</a>
+    <li><a href="#ref-for-in-parallel①④">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-in-parallel①⑤">2.7.6. The close() method</a>
+    <li><a href="#ref-for-in-parallel①⑥">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-in-parallel①⑦">(2)</a>
+    <li><a href="#ref-for-in-parallel①⑧">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-in-parallel①⑨">(2)</a>
+    <li><a href="#ref-for-in-parallel②⓪">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-in-parallel②①">(2)</a>
+    <li><a href="#ref-for-in-parallel②②">3.6. Drag and Drop</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-event-messageerror">
@@ -4003,7 +4128,10 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-byte-sequence">2.1. Concepts</a>
     <li><a href="#ref-for-byte-sequence①">2.5.2. The getFileHandle() method</a>
     <li><a href="#ref-for-byte-sequence②">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-byte-sequence③">(2)</a> <a href="#ref-for-byte-sequence④">(3)</a> <a href="#ref-for-byte-sequence⑤">(4)</a> <a href="#ref-for-byte-sequence⑥">(5)</a> <a href="#ref-for-byte-sequence⑦">(6)</a> <a href="#ref-for-byte-sequence⑧">(7)</a>
-    <li><a href="#ref-for-byte-sequence⑨">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-byte-sequence⑨">2.7.1. The read() method</a>
+    <li><a href="#ref-for-byte-sequence①⓪">2.7.2. The write() method</a> <a href="#ref-for-byte-sequence①①">(2)</a> <a href="#ref-for-byte-sequence①②">(3)</a>
+    <li><a href="#ref-for-byte-sequence①③">2.7.3. The truncate() method</a> <a href="#ref-for-byte-sequence①④">(2)</a> <a href="#ref-for-byte-sequence①⑤">(3)</a>
+    <li><a href="#ref-for-byte-sequence①⑥">3.4. The showSaveFilePicker() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-code-point">
@@ -4201,12 +4329,12 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-dfn-permission-descriptor-type">2.2. Permissions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-state">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="term-for-dfn-state">
+   <a href="https://w3c.github.io/permissions/#dfn-state">https://w3c.github.io/permissions/#dfn-state</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-permission-state">2.2. Permissions</a> <a href="#ref-for-dfn-permission-state①">(2)</a> <a href="#ref-for-dfn-permission-state②">(3)</a> <a href="#ref-for-dfn-permission-state③">(4)</a> <a href="#ref-for-dfn-permission-state④">(5)</a> <a href="#ref-for-dfn-permission-state⑤">(6)</a> <a href="#ref-for-dfn-permission-state⑥">(7)</a>
-    <li><a href="#ref-for-dfn-permission-state⑦">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dfn-permission-state⑧">(2)</a>
-    <li><a href="#ref-for-dfn-permission-state⑨">3.1. Local File System Permissions</a> <a href="#ref-for-dfn-permission-state①⓪">(2)</a>
+    <li><a href="#ref-for-dfn-state">2.2. Permissions</a> <a href="#ref-for-dfn-state①">(2)</a> <a href="#ref-for-dfn-state②">(3)</a> <a href="#ref-for-dfn-state③">(4)</a> <a href="#ref-for-dfn-state④">(5)</a> <a href="#ref-for-dfn-state⑤">(6)</a> <a href="#ref-for-dfn-state⑥">(7)</a>
+    <li><a href="#ref-for-dfn-state⑦">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dfn-state⑧">(2)</a>
+    <li><a href="#ref-for-dfn-state⑨">3.1. Local File System Permissions</a> <a href="#ref-for-dfn-state①⓪">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-permission-state-constraints">
@@ -4298,7 +4426,9 @@ use this API to write to disk.</p>
    <a href="https://storage.spec.whatwg.org/#storage-quota">https://storage.spec.whatwg.org/#storage-quota</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-quota">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-storage-quota①">(2)</a> <a href="#ref-for-storage-quota②">(3)</a> <a href="#ref-for-storage-quota③">(4)</a>
-    <li><a href="#ref-for-storage-quota④">7.3. Filling up a users disk</a> <a href="#ref-for-storage-quota⑤">(2)</a> <a href="#ref-for-storage-quota⑥">(3)</a>
+    <li><a href="#ref-for-storage-quota④">2.7.2. The write() method</a>
+    <li><a href="#ref-for-storage-quota⑤">2.7.3. The truncate() method</a>
+    <li><a href="#ref-for-storage-quota⑥">7.3. Filling up a users disk</a> <a href="#ref-for-storage-quota⑦">(2)</a> <a href="#ref-for-storage-quota⑧">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-storage-endpoint-types">
@@ -4323,6 +4453,12 @@ use this API to write to disk.</p>
    <a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter">https://streams.spec.whatwg.org/#writablestreamdefaultwriter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultwriter">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-writablestream-set-up-abortalgorithm">
+   <a href="https://streams.spec.whatwg.org/#writablestream-set-up-abortalgorithm">https://streams.spec.whatwg.org/#writablestream-set-up-abortalgorithm</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-writablestream-set-up-abortalgorithm">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-writablestream-set-up-closealgorithm">
@@ -4451,6 +4587,10 @@ use this API to write to disk.</p>
    <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-invalidstateerror①">2.7.1. The read() method</a>
+    <li><a href="#ref-for-invalidstateerror②">2.7.2. The write() method</a>
+    <li><a href="#ref-for-invalidstateerror③">2.7.3. The truncate() method</a> <a href="#ref-for-invalidstateerror④">(2)</a>
+    <li><a href="#ref-for-invalidstateerror⑤">2.7.4. The getSize() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-nomodificationallowederror">
@@ -4498,6 +4638,8 @@ use this API to write to disk.</p>
    <a href="https://webidl.spec.whatwg.org/#quotaexceedederror">https://webidl.spec.whatwg.org/#quotaexceedederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quotaexceedederror">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-quotaexceedederror①">(2)</a>
+    <li><a href="#ref-for-quotaexceedederror②">2.7.2. The write() method</a>
+    <li><a href="#ref-for-quotaexceedederror③">2.7.3. The truncate() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-SecureContext">
@@ -4562,10 +4704,13 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-a-new-promise①⓪">2.5.3. The getDirectoryHandle() method</a>
     <li><a href="#ref-for-a-new-promise①①">2.5.4. The removeEntry() method</a>
     <li><a href="#ref-for-a-new-promise①②">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-a-new-promise①③">(2)</a>
-    <li><a href="#ref-for-a-new-promise①④">3.3. The showOpenFilePicker() method</a>
-    <li><a href="#ref-for-a-new-promise①⑤">3.4. The showSaveFilePicker() method</a>
-    <li><a href="#ref-for-a-new-promise①⑥">3.5. The showDirectoryPicker() method</a>
-    <li><a href="#ref-for-a-new-promise①⑦">3.6. Drag and Drop</a>
+    <li><a href="#ref-for-a-new-promise①④">2.7.3. The truncate() method</a>
+    <li><a href="#ref-for-a-new-promise①⑤">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-a-new-promise①⑥">2.7.6. The close() method</a>
+    <li><a href="#ref-for-a-new-promise①⑦">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-a-new-promise①⑧">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-a-new-promise①⑨">3.5. The showDirectoryPicker() method</a>
+    <li><a href="#ref-for-a-new-promise②⓪">3.6. Drag and Drop</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
@@ -4598,10 +4743,17 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-idl-boolean⑤">3. Accessing Local File System</a> <a href="#ref-for-idl-boolean⑥">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-buffersource-byte-length">
+   <a href="https://webidl.spec.whatwg.org/#buffersource-byte-length">https://webidl.spec.whatwg.org/#buffersource-byte-length</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-buffersource-byte-length">2.7.1. The read() method</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy">
    <a href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-buffer-source-copy">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-dfn-get-buffer-source-copy①">2.7.2. The write() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-get-the-next-iteration-result">
@@ -4634,9 +4786,10 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-reject①②">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-reject①③">(2)</a> <a href="#ref-for-reject①④">(3)</a> <a href="#ref-for-reject①⑤">(4)</a> <a href="#ref-for-reject①⑥">(5)</a>
     <li><a href="#ref-for-reject①⑦">2.5.4. The removeEntry() method</a> <a href="#ref-for-reject①⑧">(2)</a> <a href="#ref-for-reject①⑨">(3)</a> <a href="#ref-for-reject②⓪">(4)</a> <a href="#ref-for-reject②①">(5)</a>
     <li><a href="#ref-for-reject②②">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-reject②③">(2)</a> <a href="#ref-for-reject②④">(3)</a> <a href="#ref-for-reject②⑤">(4)</a> <a href="#ref-for-reject②⑥">(5)</a> <a href="#ref-for-reject②⑦">(6)</a> <a href="#ref-for-reject②⑧">(7)</a>
-    <li><a href="#ref-for-reject②⑨">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-reject③⓪">(2)</a>
-    <li><a href="#ref-for-reject③①">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-reject③②">(2)</a>
-    <li><a href="#ref-for-reject③③">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-reject③④">(2)</a>
+    <li><a href="#ref-for-reject②⑨">2.7.3. The truncate() method</a>
+    <li><a href="#ref-for-reject③⓪">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-reject③①">(2)</a>
+    <li><a href="#ref-for-reject③②">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-reject③③">(2)</a>
+    <li><a href="#ref-for-reject③④">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-reject③⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-resolve">
@@ -4654,10 +4807,13 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-resolve①⑦">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-resolve①⑧">(2)</a>
     <li><a href="#ref-for-resolve①⑨">2.5.4. The removeEntry() method</a>
     <li><a href="#ref-for-resolve②⓪">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-resolve②①">(2)</a> <a href="#ref-for-resolve②②">(3)</a> <a href="#ref-for-resolve②③">(4)</a>
-    <li><a href="#ref-for-resolve②④">3.3. The showOpenFilePicker() method</a>
-    <li><a href="#ref-for-resolve②⑤">3.4. The showSaveFilePicker() method</a>
-    <li><a href="#ref-for-resolve②⑥">3.5. The showDirectoryPicker() method</a>
-    <li><a href="#ref-for-resolve②⑦">3.6. Drag and Drop</a>
+    <li><a href="#ref-for-resolve②④">2.7.3. The truncate() method</a>
+    <li><a href="#ref-for-resolve②⑤">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-resolve②⑥">2.7.6. The close() method</a>
+    <li><a href="#ref-for-resolve②⑦">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-resolve②⑧">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-resolve②⑨">3.5. The showDirectoryPicker() method</a>
+    <li><a href="#ref-for-resolve③⓪">3.6. Drag and Drop</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-sequence">
@@ -4683,9 +4839,14 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-this②①">2.6.1. The write() method</a>
     <li><a href="#ref-for-this②②">2.6.2. The seek() method</a>
     <li><a href="#ref-for-this②③">2.6.3. The truncate() method</a>
-    <li><a href="#ref-for-this②④">3.3. The showOpenFilePicker() method</a>
-    <li><a href="#ref-for-this②⑤">3.4. The showSaveFilePicker() method</a>
-    <li><a href="#ref-for-this②⑥">3.5. The showDirectoryPicker() method</a>
+    <li><a href="#ref-for-this②④">2.7.1. The read() method</a> <a href="#ref-for-this②⑤">(2)</a> <a href="#ref-for-this②⑥">(3)</a>
+    <li><a href="#ref-for-this②⑦">2.7.2. The write() method</a> <a href="#ref-for-this②⑧">(2)</a> <a href="#ref-for-this②⑨">(3)</a> <a href="#ref-for-this③⓪">(4)</a>
+    <li><a href="#ref-for-this③①">2.7.3. The truncate() method</a> <a href="#ref-for-this③②">(2)</a> <a href="#ref-for-this③③">(3)</a> <a href="#ref-for-this③④">(4)</a> <a href="#ref-for-this③⑤">(5)</a>
+    <li><a href="#ref-for-this③⑥">2.7.4. The getSize() method</a> <a href="#ref-for-this③⑦">(2)</a>
+    <li><a href="#ref-for-this③⑧">2.7.6. The close() method</a>
+    <li><a href="#ref-for-this③⑨">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-this④⓪">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-this④①">3.5. The showDirectoryPicker() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-undefined">
@@ -4694,6 +4855,12 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-idl-undefined">2.5. The FileSystemDirectoryHandle interface</a>
     <li><a href="#ref-for-idl-undefined①">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-idl-undefined②">(2)</a> <a href="#ref-for-idl-undefined③">(3)</a>
     <li><a href="#ref-for-idl-undefined④">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-idl-undefined⑤">(2)</a> <a href="#ref-for-idl-undefined⑥">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-buffersource-underlying-buffer">
+   <a href="https://webidl.spec.whatwg.org/#buffersource-underlying-buffer">https://webidl.spec.whatwg.org/#buffersource-underlying-buffer</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-buffersource-underlying-buffer">2.7.1. The read() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
@@ -4713,6 +4880,12 @@ use this API to write to disk.</p>
    <a href="https://webidl.spec.whatwg.org/#wait-for-all">https://webidl.spec.whatwg.org/#wait-for-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wait-for-all">2.1. Concepts</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-arraybuffer-write">
+   <a href="https://webidl.spec.whatwg.org/#arraybuffer-write">https://webidl.spec.whatwg.org/#arraybuffer-write</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-arraybuffer-write">2.7.1. The read() method</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -4811,7 +4984,7 @@ use this API to write to disk.</p>
      <li><span class="dfn-paneled" id="term-for-dom-permissionstate-granted">granted</span>
      <li><span class="dfn-paneled" id="term-for-dom-permissiondescriptor-name">name</span>
      <li><span class="dfn-paneled" id="term-for-dfn-permission-descriptor-type">permission descriptor type</span>
-     <li><span class="dfn-paneled" id="term-for-dfn-permission-state">permission state</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-state">permission state</span>
      <li><span class="dfn-paneled" id="term-for-dfn-permission-state-constraints">permission state constraints</span>
      <li><span class="dfn-paneled" id="term-for-dom-navigator-permissions">permissions</span>
      <li><span class="dfn-paneled" id="term-for-dfn-powerful-feature">powerful feature</span>
@@ -4843,6 +5016,7 @@ use this API to write to disk.</p>
      <li><span class="dfn-paneled" id="term-for-readablestream">ReadableStream</span>
      <li><span class="dfn-paneled" id="term-for-writablestream">WritableStream</span>
      <li><span class="dfn-paneled" id="term-for-writablestreamdefaultwriter">WritableStreamDefaultWriter</span>
+     <li><span class="dfn-paneled" id="term-for-writablestream-set-up-abortalgorithm">abortalgorithm</span>
      <li><span class="dfn-paneled" id="term-for-writablestream-set-up-closealgorithm">closealgorithm</span>
      <li><span class="dfn-paneled" id="term-for-ws-get-writer">getWriter()</span>
      <li><span class="dfn-paneled" id="term-for-writablestream-get-a-writer">getting a writer</span>
@@ -4881,6 +5055,7 @@ use this API to write to disk.</p>
      <li><span class="dfn-paneled" id="term-for-a-promise-resolved-with">a promise resolved with</span>
      <li><span class="dfn-paneled" id="term-for-asynchronous-iterator-initialization-steps">asynchronous iterator initialization steps</span>
      <li><span class="dfn-paneled" id="term-for-idl-boolean">boolean</span>
+     <li><span class="dfn-paneled" id="term-for-buffersource-byte-length">byte length</span>
      <li><span class="dfn-paneled" id="term-for-dfn-get-buffer-source-copy">get a copy of the buffer source</span>
      <li><span class="dfn-paneled" id="term-for-dfn-get-the-next-iteration-result">get the next iteration result</span>
      <li><span class="dfn-paneled" id="term-for-new">new</span>
@@ -4890,9 +5065,11 @@ use this API to write to disk.</p>
      <li><span class="dfn-paneled" id="term-for-idl-sequence">sequence</span>
      <li><span class="dfn-paneled" id="term-for-this">this</span>
      <li><span class="dfn-paneled" id="term-for-idl-undefined">undefined</span>
+     <li><span class="dfn-paneled" id="term-for-buffersource-underlying-buffer">underlying buffer</span>
      <li><span class="dfn-paneled" id="term-for-idl-unsigned-long-long">unsigned long long</span>
      <li><span class="dfn-paneled" id="term-for-upon-fulfillment">upon fulfillment</span>
      <li><span class="dfn-paneled" id="term-for-wait-for-all">wait for all</span>
+     <li><span class="dfn-paneled" id="term-for-arraybuffer-write">write</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -4911,7 +5088,7 @@ use this API to write to disk.</p>
    <dt id="biblio-mimesniff">[MIMESNIFF]
    <dd>Gordon P. Hemsley. <a href="https://mimesniff.spec.whatwg.org/"><cite>MIME Sniffing Standard</cite></a>. Living Standard. URL: <a href="https://mimesniff.spec.whatwg.org/">https://mimesniff.spec.whatwg.org/</a>
    <dt id="biblio-permissions">[PERMISSIONS]
-   <dd>Marcos Caceres; Mike Taylor; Jeffrey Yasskin. <a href="https://www.w3.org/TR/permissions/"><cite>Permissions</cite></a>. 28 October 2021. WD. URL: <a href="https://www.w3.org/TR/permissions/">https://www.w3.org/TR/permissions/</a>
+   <dd>Marcos Caceres; Mike Taylor. <a href="https://www.w3.org/TR/permissions/"><cite>Permissions</cite></a>. 11 March 2022. WD. URL: <a href="https://www.w3.org/TR/permissions/">https://www.w3.org/TR/permissions/</a>
    <dt id="biblio-permissions-request">[PERMISSIONS-REQUEST]
    <dd><a href="https://wicg.github.io/permissions-request/"><cite>Requesting Permissions</cite></a>. cg-draft. URL: <a href="https://wicg.github.io/permissions-request/">https://wicg.github.io/permissions-request/</a>
    <dt id="biblio-rfc2119">[RFC2119]
@@ -4976,7 +5153,7 @@ use this API to write to disk.</p>
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-file"><c- n>File</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-getfile"><c- g>getFile</c-></a>();
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemwritablefilestream"><c- n>FileSystemWritableFileStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createwritable"><c- g>createWritable</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemcreatewritableoptions"><c- n>FileSystemCreateWritableOptions</c-></a> <a href="#dom-filesystemfilehandle-createwritable-options-options"><code><c- g>options</c-></code></a> = {});
   [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=<c- n>DedicatedWorker</c->]
-  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemsyncaccesshandle"><c- n>FileSystemSyncAccessHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createsyncaccesshandle"><c- g>createSyncAccessHandle</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemfilehandlecreateaccesshandleoptions"><c- n>FileSystemFileHandleCreateAccessHandleOptions</c-></a> <a href="#dom-filesystemfilehandle-createsyncaccesshandle-options-options"><code><c- g>options</c-></code></a> = {});
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemsyncaccesshandle"><c- n>FileSystemSyncAccessHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createsyncaccesshandle"><c- g>createSyncAccessHandle</c-></a>(<a data-link-type="idl-name" href="#dictdef-filesystemfilehandlecreateaccesshandleoptions"><c- n>FileSystemFileHandleCreateAccessHandleOptions</c-></a> <a href="#dom-filesystemfilehandle-createsyncaccesshandle-options-options"><code><c- g>options</c-></code></a>);
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-filesystemgetfileoptions"><code><c- g>FileSystemGetFileOptions</c-></code></a> {
@@ -5026,7 +5203,7 @@ use this API to write to disk.</p>
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-filesystemreadwriteoptions"><code><c- g>FilesystemReadWriteOptions</c-></code></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a data-type="unsigned long long " href="#dom-filesystemreadwriteoptions-at"><code><c- g>at</c-></code></a>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange"><c- g>EnforceRange</c-></a>] <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a data-type="unsigned long long " href="#dom-filesystemreadwriteoptions-at"><code><c- g>at</c-></code></a>;
 }
 
 [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=<c- n>DedicatedWorker</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext"><c- g>SecureContext</c-></a>]
@@ -5036,7 +5213,7 @@ use this API to write to disk.</p>
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a href="#dom-filesystemsyncaccesshandle-write"><code><c- g>write</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#AllowShared"><c- g>AllowShared</c-></a>] <a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#BufferSource"><c- n>BufferSource</c-></a> <a href="#dom-filesystemsyncaccesshandle-write-buffer-options-buffer"><code><c- g>buffer</c-></code></a>,
                               <a data-link-type="idl-name" href="#dictdef-filesystemreadwriteoptions"><c- n>FilesystemReadWriteOptions</c-></a> <a href="#dom-filesystemsyncaccesshandle-write-buffer-options-options"><code><c- g>options</c-></code></a>);
 
-  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-truncate"><c- g>truncate</c-></a>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a href="#dom-filesystemsyncaccesshandle-truncate-size-size"><code><c- g>size</c-></code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-truncate"><c- g>truncate</c-></a>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a href="#dom-filesystemsyncaccesshandle-truncate-newsize-newsize"><code><c- g>newSize</c-></code></a>);
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-getsize"><c- g>getSize</c-></a>();
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-flush"><c- g>flush</c-></a>();
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-close"><c- g>close</c-></a>();
@@ -5192,7 +5369,11 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-file-entry-binary-data②">2.4.2. The createWritable() method</a>
     <li><a href="#ref-for-file-entry-binary-data③">2.5.2. The getFileHandle() method</a>
     <li><a href="#ref-for-file-entry-binary-data④">2.6. The FileSystemWritableFileStream interface</a>
-    <li><a href="#ref-for-file-entry-binary-data⑤">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-file-entry-binary-data⑤">2.7.1. The read() method</a> <a href="#ref-for-file-entry-binary-data⑥">(2)</a>
+    <li><a href="#ref-for-file-entry-binary-data⑦">2.7.2. The write() method</a> <a href="#ref-for-file-entry-binary-data⑧">(2)</a> <a href="#ref-for-file-entry-binary-data⑨">(3)</a>
+    <li><a href="#ref-for-file-entry-binary-data①⓪">2.7.3. The truncate() method</a> <a href="#ref-for-file-entry-binary-data①①">(2)</a>
+    <li><a href="#ref-for-file-entry-binary-data①②">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-file-entry-binary-data①③">3.4. The showSaveFilePicker() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="file-entry-modification-timestamp">
@@ -5219,7 +5400,8 @@ than being defined here. So merge this into the table there. <a class="issue-ret
   <aside class="dfn-panel" data-for="file-entry-lock-release">
    <b><a href="#file-entry-lock-release">#file-entry-lock-release</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-file-entry-lock-release">2.7.6. The close() method</a>
+    <li><a href="#ref-for-file-entry-lock-release">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-file-entry-lock-release①">(2)</a>
+    <li><a href="#ref-for-file-entry-lock-release②">2.7.6. The close() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="directory">
@@ -5692,7 +5874,11 @@ than being defined here. So merge this into the table there. <a class="issue-ret
   <aside class="dfn-panel" data-for="filesystemwritablefilestream-file">
    <b><a href="#filesystemwritablefilestream-file">#filesystemwritablefilestream-file</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-filesystemwritablefilestream-file">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemwritablefilestream-file①">(2)</a> <a href="#ref-for-filesystemwritablefilestream-file②">(3)</a> <a href="#ref-for-filesystemwritablefilestream-file③">(4)</a> <a href="#ref-for-filesystemwritablefilestream-file④">(5)</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file⑤">2.7.1. The read() method</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file⑥">2.7.2. The write() method</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file⑦">2.7.3. The truncate() method</a> <a href="#ref-for-filesystemwritablefilestream-file⑧">(2)</a> <a href="#ref-for-filesystemwritablefilestream-file⑨">(3)</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file①⓪">2.7.4. The getSize() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="filesystemwritablefilestream-buffer">
@@ -5746,6 +5932,8 @@ than being defined here. So merge this into the table there. <a class="issue-ret
    <b><a href="#dictdef-filesystemreadwriteoptions">#dictdef-filesystemreadwriteoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-filesystemreadwriteoptions">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-dictdef-filesystemreadwriteoptions①">(2)</a>
+    <li><a href="#ref-for-dictdef-filesystemreadwriteoptions②">2.7.1. The read() method</a> <a href="#ref-for-dictdef-filesystemreadwriteoptions③">(2)</a>
+    <li><a href="#ref-for-dictdef-filesystemreadwriteoptions④">2.7.2. The write() method</a> <a href="#ref-for-dictdef-filesystemreadwriteoptions⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-filesystemreadwriteoptions-at">
@@ -5762,14 +5950,13 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-filesystemsyncaccesshandle①">2.4. The FileSystemFileHandle interface</a>
     <li><a href="#ref-for-filesystemsyncaccesshandle②">2.4.2. The createWritable() method</a>
     <li><a href="#ref-for-filesystemsyncaccesshandle③">2.4.3. The createSyncAccessHandle() method</a> <a href="#ref-for-filesystemsyncaccesshandle④">(2)</a> <a href="#ref-for-filesystemsyncaccesshandle⑤">(3)</a> <a href="#ref-for-filesystemsyncaccesshandle⑥">(4)</a>
-    <li><a href="#ref-for-filesystemsyncaccesshandle⑦">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-filesystemsyncaccesshandle⑧">(2)</a> <a href="#ref-for-filesystemsyncaccesshandle⑨">(3)</a> <a href="#ref-for-filesystemsyncaccesshandle①⓪">(4)</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle⑦">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-filesystemsyncaccesshandle⑧">(2)</a> <a href="#ref-for-filesystemsyncaccesshandle⑨">(3)</a> <a href="#ref-for-filesystemsyncaccesshandle①⓪">(4)</a> <a href="#ref-for-filesystemsyncaccesshandle①①">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-filesystemsyncaccesshandle-read">
    <b><a href="#dom-filesystemsyncaccesshandle-read">#dom-filesystemsyncaccesshandle-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemsyncaccesshandle-read">2.7.1. The read() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-read①">(2)</a>
-    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-read②">2.7.5. The flush() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-filesystemsyncaccesshandle-write">
@@ -5782,8 +5969,22 @@ than being defined here. So merge this into the table there. <a class="issue-ret
   <aside class="dfn-panel" data-for="filesystemsyncaccesshandle-file">
    <b><a href="#filesystemsyncaccesshandle-file">#filesystemsyncaccesshandle-file</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemsyncaccesshandle-file①">(2)</a> <a href="#ref-for-filesystemsyncaccesshandle-file②">(3)</a>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file③">2.7. The FileSystemSyncAccessHandle interface</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file①">2.7. The FileSystemSyncAccessHandle interface</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file②">2.7.1. The read() method</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file③">2.7.2. The write() method</a> <a href="#ref-for-filesystemsyncaccesshandle-file④">(2)</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file⑤">2.7.3. The truncate() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="filesystemsyncaccesshandle-state">
+   <b><a href="#filesystemsyncaccesshandle-state">#filesystemsyncaccesshandle-state</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-state">2.7. The FileSystemSyncAccessHandle interface</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-state①">2.7.1. The read() method</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-state②">2.7.2. The write() method</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-state③">2.7.3. The truncate() method</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-state④">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-state⑤">2.7.6. The close() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="create-a-new-filesystemsyncaccesshandle">

--- a/index.html
+++ b/index.html
@@ -662,7 +662,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">File System Access</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2022-04-06">6 April 2022</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2022-04-07">7 April 2022</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -853,8 +853,6 @@ run the following steps:
      <li data-md>
       <p>Let <var>lock</var> be the <var>file</var>’s <a data-link-type="dfn" href="#file-entry-lock" id="ref-for-file-entry-lock①">lock</a>.</p>
      <li data-md>
-      <p>Let <var>result</var> be <code>false</code>.</p>
-     <li data-md>
       <p>If <var>value</var> is "<code>exclusive</code>":</p>
       <ol>
        <li data-md>
@@ -863,7 +861,7 @@ run the following steps:
          <li data-md>
           <p>Set lock to "<code>taken-exclusive</code>".</p>
          <li data-md>
-          <p>Set <var>result</var> to <code>true</code></p>
+          <p>Return <code>true</code>.</p>
         </ol>
       </ol>
      <li data-md>
@@ -875,17 +873,17 @@ run the following steps:
          <li data-md>
           <p>Set lock to "<code>taken-shared</code>".</p>
          <li data-md>
-          <p>Set <var>result</var> to <code>true</code></p>
+          <p>Return <code>true</code>.</p>
         </ol>
        <li data-md>
         <p>Else if <var>lock</var> is "<code>taken-shared</code>":</p>
         <ol>
          <li data-md>
-          <p>Set <var>result</var> to <code>true</code></p>
+          <p>Return <code>true</code>.</p>
         </ol>
       </ol>
      <li data-md>
-      <p>Return <var>result</var>.</p>
+      <p>Return <code>false</code>.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="release" data-algorithm-for="file entry/lock">
@@ -1404,7 +1402,7 @@ modifications to existing large files. <a href="https://github.com/wicg/file-sys
 further <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑤">FileSystemSyncAccessHandle</a></code>s or <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream④">FileSystemWritableFileStream</a></code>s
 for the entry, until the access handle is closed.</p>
       <p>The returned <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑥">FileSystemSyncAccessHandle</a></code> offers synchronous <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read">read()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write">write()</a></code> methods. This allows for higher performance for critical methods on
-contexts where asynchronous operations come with high overhead, i.e., WebAssembly.</p>
+contexts where asynchronous operations come with high overhead, e.g., WebAssembly.</p>
       <p>For the time being, this method will only succeed when the <var>fileHandle</var> belongs to the <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system①">origin private file system</a>.</p>
     </dl>
    </div>
@@ -1426,7 +1424,7 @@ contexts where asynchronous operations come with high overhead, i.e., WebAssembl
         <p>Let <var>entry</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⓪">this</a></b>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①③">entry</a>.</p>
        <li data-md>
         <p>If <var>entry</var> does not represent an <a data-link-type="dfn" href="#entry" id="ref-for-entry①③">entry</a> in an <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system②">origin private file system</a>,
- reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code> and abort.</p>
+ reject <var>result</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code> and abort.</p>
        <li data-md>
         <p>Let <var>lockResult</var> be the result of <a data-link-type="dfn" href="#file-entry-lock-take" id="ref-for-file-entry-lock-take③">taking a lock</a> with  "<code>exclusive</code>" on <var>entry</var>.</p>
        <li data-md>
@@ -2188,16 +2186,16 @@ steps:
     </ol>
    </div>
    <h3 class="heading settled" data-level="2.7" id="api-filesystemsyncaccesshandle"><span class="secno">2.7. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑦">FileSystemSyncAccessHandle</a></code> interface</span><a class="self-link" href="#api-filesystemsyncaccesshandle"></a></h3>
-<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystemreadwriteoptions"><code><c- g>FilesystemReadWriteOptions</c-></code></dfn> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange" id="ref-for-EnforceRange"><c- g>EnforceRange</c-></a>] <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long④"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FilesystemReadWriteOptions" data-dfn-type="dict-member" data-export data-type="unsigned long long " id="dom-filesystemreadwriteoptions-at"><code><c- g>at</c-></code></dfn>;
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystemreadwriteoptions"><code><c- g>FileSystemReadWriteOptions</c-></code></dfn> {
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange" id="ref-for-EnforceRange"><c- g>EnforceRange</c-></a>] <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long④"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemReadWriteOptions" data-dfn-type="dict-member" data-export data-type="unsigned long long " id="dom-filesystemreadwriteoptions-at"><code><c- g>at</c-></code></dfn>;
 }
 
 [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed⑤"><c- g>Exposed</c-></a>=<c- n>DedicatedWorker</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext" id="ref-for-SecureContext④"><c- g>SecureContext</c-></a>]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="filesystemsyncaccesshandle"><code><c- g>FileSystemSyncAccessHandle</c-></code></dfn> {
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑤"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export data-lt="read(buffer, options)" id="dom-filesystemsyncaccesshandle-read"><code><c- g>read</c-></code></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#AllowShared" id="ref-for-AllowShared"><c- g>AllowShared</c-></a>] <a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#BufferSource" id="ref-for-BufferSource③"><c- n>BufferSource</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/read(buffer, options)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-read-buffer-options-buffer"><code><c- g>buffer</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-read-buffer-options-buffer"></a></dfn>,
-                             <a data-link-type="idl-name" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions"><c- n>FilesystemReadWriteOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/read(buffer, options)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-read-buffer-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-read-buffer-options-options"></a></dfn>);
+                          <a data-link-type="idl-name" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions"><c- n>FileSystemReadWriteOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/read(buffer, options)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-read-buffer-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-read-buffer-options-options"></a></dfn>);
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑥"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export data-lt="write(buffer, options)" id="dom-filesystemsyncaccesshandle-write"><code><c- g>write</c-></code></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#AllowShared" id="ref-for-AllowShared①"><c- g>AllowShared</c-></a>] <a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#BufferSource" id="ref-for-BufferSource④"><c- n>BufferSource</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/write(buffer, options)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-write-buffer-options-buffer"><code><c- g>buffer</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-write-buffer-options-buffer"></a></dfn>,
-                              <a data-link-type="idl-name" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions①"><c- n>FilesystemReadWriteOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/write(buffer, options)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-write-buffer-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-write-buffer-options-options"></a></dfn>);
+                           <a data-link-type="idl-name" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions①"><c- n>FileSystemReadWriteOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/write(buffer, options)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-write-buffer-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-write-buffer-options-options"></a></dfn>);
 
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①③"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined④"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-truncate" id="ref-for-dom-filesystemsyncaccesshandle-truncate"><c- g>truncate</c-></a>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange" id="ref-for-EnforceRange①"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑦"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/truncate(newSize)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-truncate-newsize-newsize"><code><c- g>newSize</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-truncate-newsize-newsize"></a></dfn>);
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①④"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑧"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-getsize" id="ref-for-dom-filesystemsyncaccesshandle-getsize"><c- g>getSize</c-></a>();
@@ -2212,9 +2210,9 @@ a string that may exclusively be "<code>open</code>" or "<code>closed</code>".</
    <div class="note domintro" role="note">
     <p>A <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle①⓪">FileSystemSyncAccessHandle</a></code> is an object that is capable of reading/writing from/to,
 as well as obtaining and changing the size of, a single file.</p>
-    <p>The <code class="idl"><a data-link-type="idl">read()</a></code> and <code class="idl"><a data-link-type="idl">write()</a></code> methods are synchronous.
+    <p>The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read①">read()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write①">write()</a></code> methods are synchronous.
 This allows for higher performance for critical methods on contexts where asynchronous
-operations come with high overhead, i.e., WebAssembly.</p>
+operations come with high overhead, e.g., WebAssembly.</p>
    </div>
    <div class="algorithm" data-algorithm="create a new FileSystemSyncAccessHandle">
      To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="create-a-new-filesystemsyncaccesshandle">create a new FileSystemSyncAccessHandle</dfn> given a <a data-link-type="dfn" href="#file" id="ref-for-file①②">file entry</a> <var>file</var> in a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#realm" id="ref-for-realm①">Realm</a> <var>realm</var>, perform the following steps: 
@@ -2229,21 +2227,21 @@ operations come with high overhead, i.e., WebAssembly.</p>
       <p>Return <var>handle</var>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="2.7.1" id="api-filesystemsyncaccesshandle-read"><span class="secno">2.7.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read①">read()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-read"></a></h4>
+   <h4 class="heading settled" data-level="2.7.1" id="api-filesystemsyncaccesshandle-read"><span class="secno">2.7.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read②">read()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-read"></a></h4>
    <div class="note domintro" role="note">
     <dl>
-     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read②">read</a></code>(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions②">FilesystemReadWriteOptions</a></code>: <var>options</var>
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read③">read</a></code>(<var>buffer</var>)
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read④">read</a></code>(<var>buffer</var>, { <code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at">at</a></code> })
      <dd data-md>
-      <p>Reads the contents of the file associated with <var>handle</var> into <var>buffer</var>, with <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at">at</a></code> as the offset.</p>
+      <p>Reads the contents of the file associated with <var>handle</var> into <var>buffer</var>, optionally at a given offset.</p>
     </dl>
    </div>
-   <p>// TODO(fivedots): Is there a more formal way to describe the resutl of partial reads from the OS?</p>
-   <div class="algorithm" data-algorithm="read(buffer, FilesystemReadWriteOptions: options)" data-algorithm-for="FileSystemSyncAccessHandle">
-     The <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-read-buffer-filesystemreadwriteoptions-options"><code>read(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions③">FilesystemReadWriteOptions</a></code>: <var>options</var>)</code><a class="self-link" href="#dom-filesystemsyncaccesshandle-read-buffer-filesystemreadwriteoptions-options"></a></dfn> method, when invoked, must run
+   <div class="algorithm" data-algorithm="read(buffer, FileSystemReadWriteOptions: options)" data-algorithm-for="FileSystemSyncAccessHandle">
+     The <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-read-buffer-filesystemreadwriteoptions-options"><code>read(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions②">FileSystemReadWriteOptions</a></code>: <var>options</var>)</code><a class="self-link" href="#dom-filesystemsyncaccesshandle-read-buffer-filesystemreadwriteoptions-options"></a></dfn> method, when invoked, must run
 these steps: 
     <ol>
      <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②④">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state①">[[state]]</a> is "<code>closed</code>", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>.</p>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②④">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state①">[[state]]</a> is "<code>closed</code>", throw an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>.</p>
      <li data-md>
       <p>Let <var>readPosition</var> be <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at①">at</a></code>.</p>
      <li data-md>
@@ -2251,9 +2249,9 @@ these steps:
      <li data-md>
       <p>Let <var>result</var> be <var>size</var>.</p>
      <li data-md>
-      <p>Let <var>bytes</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑨">byte sequence</a> containing the bytes from <var>readPosition</var> to <var>readPosition</var> + (<var>size</var> - 1) of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑤">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file④">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑤">binary data</a>.</p>
+      <p>Let <var>bytes</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑨">byte sequence</a> containing the bytes from <var>readPosition</var> to <var>readPosition</var> + (<var>size</var> − 1) of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑤">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file④">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑤">binary data</a>.</p>
      <li data-md>
-      <p>If the operations reading from <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑥">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑤">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑥">binary data</a> in the previous steps
+      <p>If the operations reading from <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑥">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file③">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑥">binary data</a> in the previous steps
  failed:</p>
       <ol>
        <li data-md>
@@ -2270,18 +2268,18 @@ these steps:
       <p>Return <var>result</var>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="2.7.2" id="api-filesystemsyncaccesshandle-write"><span class="secno">2.7.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write①">write()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-write"></a></h4>
+   <h4 class="heading settled" data-level="2.7.2" id="api-filesystemsyncaccesshandle-write"><span class="secno">2.7.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write②">write()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-write"></a></h4>
    <div class="note domintro" role="note">
     <dl>
-     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write②">write</a></code>(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions④">FilesystemReadWriteOptions</a></code>: <var>options</var>)
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write③">write</a></code>(<var>buffer</var>)
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write④">write</a></code>(<var>buffer</var>, { <code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at②">at</a></code> })
      <dd data-md>
-      <p>Writes the content of <var>buffer</var> into the file associated with <var>handle</var> with <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at②">at</a></code> as the offset.</p>
+      <p>Writes the content of <var>buffer</var> into the file associated with <var>handle</var>, optionally at a given offset.</p>
     </dl>
    </div>
-   <p>// TODO(fivedots): Is there a more formal way to describe the resutl of partial writes from the OS?</p>
    <p>// TODO(fivedots): Figure out mechanism to prevent concurrent IO operations e.g. doing write() while a truncate() is executing in parallel.</p>
-   <div class="algorithm" data-algorithm="write(buffer, FilesystemReadWriteOptions: options)" data-algorithm-for="FileSystemSyncAccessHandle">
-     The <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-write-buffer-filesystemreadwriteoptions-options"><code>write(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions⑤">FilesystemReadWriteOptions</a></code>: <var>options</var>)</code><a class="self-link" href="#dom-filesystemsyncaccesshandle-write-buffer-filesystemreadwriteoptions-options"></a></dfn> method, when invoked, must run
+   <div class="algorithm" data-algorithm="write(buffer, FileSystemReadWriteOptions: options)" data-algorithm-for="FileSystemSyncAccessHandle">
+     The <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-write-buffer-filesystemreadwriteoptions-options"><code>write(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions③">FileSystemReadWriteOptions</a></code>: <var>options</var>)</code><a class="self-link" href="#dom-filesystemsyncaccesshandle-write-buffer-filesystemreadwriteoptions-options"></a></dfn> method, when invoked, must run
 these steps: 
     <ol>
      <li data-md>
@@ -2289,14 +2287,14 @@ these steps:
      <li data-md>
       <p>Let <var>writePosition</var> be <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at③">at</a></code>.</p>
      <li data-md>
-      <p>Let <var>fileContents</var> be a copy of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑧">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file③">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑦">binary data</a>.</p>
+      <p>Let <var>fileContents</var> be a copy of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑧">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file④">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑦">binary data</a>.</p>
      <li data-md>
       <p>Let <var>oldSize</var> be <var>fileContents</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑤">length</a>.</p>
      <li data-md>
       <p>Let <var>data</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy" id="ref-for-dfn-get-buffer-source-copy①">a copy of</a> <var>buffer</var>.</p>
      <li data-md>
       <p>If <var>writePosition</var> is larger than <var>oldSize</var>,
- append <var>writePosition</var> - <var>oldSize</var> <code>0x00</code> (NUL) bytes to the end of <var>fileContents</var>.</p>
+ append <var>writePosition</var> − <var>oldSize</var> <code>0x00</code> (NUL) bytes to the end of <var>fileContents</var>.</p>
       <p class="note" role="note"><span>Note:</span> Implementations are expected to behave as if the skipped over file contents
  are indeed filled with NUL bytes. That doesn’t mean these bytes have to actually be
  written to disk and take up disk space. Instead most file systems support so called
@@ -2306,29 +2304,29 @@ these steps:
      <li data-md>
       <p>Let <var>tail</var> be an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①①">byte sequence</a>.</p>
      <li data-md>
-      <p>If <var>writePosition</var> + <var>data</var>.<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑥">length</a> is smaller than <var>oldSize</var>:</p>
+      <p>If <var>writePosition</var> + <var>data</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑥">length</a> is smaller than <var>oldSize</var>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>tail</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①②">byte sequence</a> containing the last <var>oldSize</var> - (<var>writePosition</var> + <var>data</var>.<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑦">length</a>) bytes of <var>fileContents</var>.</p>
+        <p>Set <var>tail</var> to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①②">byte sequence</a> containing the last <var>oldSize</var> − (<var>writePosition</var> + <var>data</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑦">length</a>) bytes of <var>fileContents</var>.</p>
       </ol>
      <li data-md>
-      <p>Let <var>newSize</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑧">length</a> of the concatenation of <var>head</var>, <var>data</var> and <var>tail</var>.</p>
+      <p>Let <var>newSize</var> be <var>head</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑧">length</a> + <var>data</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑨">length</a> + <var>tail</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①⓪">length</a>.</p>
      <li data-md>
-      <p>If <var>newSize</var> - <var>oldSize</var> exceeds the available <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota④">storage quota</a>, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror②">QuotaExceededError</a></code>.</p>
+      <p>If <var>newSize</var> − <var>oldSize</var> exceeds the available <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota④">storage quota</a>, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror②">QuotaExceededError</a></code>.</p>
      <li data-md>
-      <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑨">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑥">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑧">binary data</a> to the concatenation of <var>head</var>, <var>data</var> and <var>tail</var>.</p>
+      <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑨">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑤">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑧">binary data</a> to the concatenation of <var>head</var>, <var>data</var> and <var>tail</var>.</p>
      <li data-md>
-      <p>If the operations modifying the <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⓪">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑦">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑨">binary data</a> in the previous steps
+      <p>If the operations modifying the <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⓪">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑥">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑨">binary data</a> in the previous steps
  failed:</p>
       <ol>
        <li data-md>
-        <p>If there were partial modifications and the number of modified bytes is known,
- return the number of modified bytes.</p>
+        <p>If there were partial writes and the number of bytes that were written from <var>data</var> is known,
+ return the number of bytes that were written from <var>data</var>.</p>
        <li data-md>
         <p>Else return 0.</p>
       </ol>
      <li data-md>
-      <p>Return <var>data</var>.<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑨">length</a>.</p>
+      <p>Return <var>data</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①①">length</a>.</p>
     </ol>
    </div>
    <h4 class="heading settled" data-level="2.7.3" id="api-filesystemsyncaccesshandle-truncate"><span class="secno">2.7.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-truncate" id="ref-for-dom-filesystemsyncaccesshandle-truncate①">truncate()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-truncate"></a></h4>
@@ -2336,7 +2334,7 @@ these steps:
     <dl>
      <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-truncate" id="ref-for-dom-filesystemsyncaccesshandle-truncate②">truncate</a></code>(<var>newSize</var>)
      <dd data-md>
-      <p>Resizes the file associated with stream to be <var>newSize</var> bytes long. If size is larger than the current file size this pads the file with null bytes, otherwise it truncates the file.</p>
+      <p>Resizes the file associated with stream to be <var>newSize</var> bytes long. If size is larger than the current file size this pads the file with null bytes; otherwise it truncates the file.</p>
     </dl>
    </div>
    <div class="algorithm" data-algorithm="truncate(newSize)" data-algorithm-for="FileSystemSyncAccessHandle">
@@ -2344,38 +2342,36 @@ these steps:
 these steps: 
     <ol>
      <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③①">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state③">[[state]]</a> is "<code>closed</code>", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror③">InvalidStateError</a></code>.</p>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③①">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state③">[[state]]</a> is "<code>closed</code>", return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with①">a promise rejected with</a> an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror③">InvalidStateError</a></code>.</p>
      <li data-md>
-      <p>If <var>newSize</var> is less than 0, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror④">InvalidStateError</a></code>.</p>
+      <p>Let <var>fileContents</var> be a copy of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③②">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑤">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①⓪">binary data</a>.</p>
      <li data-md>
-      <p>Let <var>fileContents</var> be a copy of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③②">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑧">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①⓪">binary data</a>.</p>
-     <li data-md>
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①③">a new promise</a>.</p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①③">a new promise</a> created in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm③">relevant Realm</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③③">this</a>.</p>
      <li data-md>
       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①②">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>oldSize</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①⓪">length</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③③">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file④">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①①">binary data</a>.</p>
+        <p>Let <var>oldSize</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①②">length</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③④">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑥">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①①">binary data</a>.</p>
        <li data-md>
         <p>If <var>newSize</var> is larger than <var>oldSize</var>:</p>
         <ol>
          <li data-md>
-          <p>If <var>newSize</var> - <var>oldSize</var> exceeds the available <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota⑤">storage quota</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑦">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror③">QuotaExceededError</a></code> and abort.</p>
+          <p>If <var>newSize</var> − <var>oldSize</var> exceeds the available <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota⑤">storage quota</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑦">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror③">QuotaExceededError</a></code> and abort.</p>
          <li data-md>
-          <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③④">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑨">[[file]]</a>'s to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①③">byte sequence</a> formed by concating <var>fileContents</var> with a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①④">byte sequence</a> containing <var>newSize</var>-<var>oldSize</var> <code>0x00</code> bytes.</p>
+          <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑤">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑦">[[file]]</a>'s to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①③">byte sequence</a> formed by concatenating <var>fileContents</var> with a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①④">byte sequence</a> containing <var>newSize</var> − <var>oldSize</var> <code>0x00</code> bytes.</p>
         </ol>
        <li data-md>
         <p>Else if <var>newSize</var> is smaller than <var>oldSize</var>:</p>
         <ol>
          <li data-md>
-          <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑤">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑤">[[file]]</a>'s to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①⑤">byte sequence</a> containing the first <var>newSize</var> bytes
+          <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑥">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑧">[[file]]</a>'s to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①⑤">byte sequence</a> containing the first <var>newSize</var> bytes
   in <var>fileContents</var>.</p>
         </ol>
        <li data-md>
         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②①">Resolve</a> <var>p</var>.</p>
       </ol>
      <li data-md>
-      <p>Return <var>p</var></p>
+      <p>Return <var>p</var>.</p>
     </ol>
    </div>
    <h4 class="heading settled" data-level="2.7.4" id="api-filesystemsyncaccesshandle-getsize"><span class="secno">2.7.4. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-getsize" id="ref-for-dom-filesystemsyncaccesshandle-getsize①">getSize()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-getsize"></a></h4>
@@ -2391,19 +2387,19 @@ these steps:
 these steps: 
     <ol>
      <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑥">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state④">[[state]]</a> is "<code>closed</code>", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror⑤">InvalidStateError</a></code>.</p>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑦">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state④">[[state]]</a> is "<code>closed</code>", return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with②">a promise rejected with</a> an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror④">InvalidStateError</a></code>.</p>
      <li data-md>
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①④">a new promise</a>.</p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①④">a new promise</a> created in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm④">relevant Realm</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑧">this</a>.</p>
      <li data-md>
       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①③">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>size</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①①">length</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑦">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file①⓪">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①②">binary data</a>.</p>
+        <p>Let <var>size</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①③">length</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑨">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑦">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①②">binary data</a>.</p>
        <li data-md>
         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②②">Resolve</a> <var>p</var> with <var>size</var>.</p>
       </ol>
      <li data-md>
-      <p>Return <var>p</var></p>
+      <p>Return <var>p</var>.</p>
     </ol>
    </div>
    <h4 class="heading settled" data-level="2.7.5" id="api-filesystemsyncaccesshandle-flush"><span class="secno">2.7.5. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-flush" id="ref-for-dom-filesystemsyncaccesshandle-flush①">flush()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-flush"></a></h4>
@@ -2411,7 +2407,7 @@ these steps:
     <dl>
      <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-flush" id="ref-for-dom-filesystemsyncaccesshandle-flush②">flush()</a></code>
      <dd data-md>
-      <p>Ensures that the contents of the file associated with <var>handle</var> contain all the modifications done through <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write③">write()</a></code>.</p>
+      <p>Ensures that the contents of the file associated with <var>handle</var> contain all the modifications done through <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write⑤">write()</a></code>.</p>
     </dl>
    </div>
    <div class="algorithm" data-algorithm="flush()" data-algorithm-for="FileSystemSyncAccessHandle">
@@ -2433,17 +2429,17 @@ these steps:
 these steps: 
     <ol>
      <li data-md>
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑤">a new promise</a>.</p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑤">a new promise</a> created in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm⑤">relevant Realm</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④⓪">this</a>.</p>
      <li data-md>
       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①④">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑧">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state⑤">[[state]]</a> to "<code>closed</code>".</p>
+        <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④①">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state⑤">[[state]]</a> to "<code>closed</code>".</p>
        <li data-md>
         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②③">Resolve</a> <var>p</var>.</p>
       </ol>
      <li data-md>
-      <p>Return <var>p</var></p>
+      <p>Return <var>p</var>.</p>
     </ol>
    </div>
    <h2 class="heading settled" data-level="3" id="local-filesystem"><span class="secno">3. </span><span class="content">Accessing Local File System</span><a class="self-link" href="#local-filesystem"></a></h2>
@@ -2509,10 +2505,10 @@ and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondes
     <ol>
      <li data-md>
       <p>If <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin③">origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque" id="ref-for-concept-origin-opaque">opaque origin</a>,
- return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with①">a promise rejected with</a> a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#securityerror" id="ref-for-securityerror③">SecurityError</a></code>.</p>
+ return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with③">a promise rejected with</a> a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#securityerror" id="ref-for-securityerror③">SecurityError</a></code>.</p>
      <li data-md>
       <p>If <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin④">origin</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin②">same origin</a> with <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin" id="ref-for-concept-environment-top-level-origin①">top-level origin</a>,
- return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with②">a promise rejected with</a> a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#securityerror" id="ref-for-securityerror④">SecurityError</a></code>.</p>
+ return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with④">a promise rejected with</a> a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#securityerror" id="ref-for-securityerror④">SecurityError</a></code>.</p>
      <li data-md>
       <p>Let <var>global</var> be <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global①">global object</a>.</p>
      <li data-md>
@@ -2880,7 +2876,7 @@ file picker will open. See <a href="#api-filepickeroptions">§ 3.2 File picker
 these steps: 
      <ol>
       <li data-md>
-       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑨">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object③">relevant settings object</a>.</p>
+       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④②">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object③">relevant settings object</a>.</p>
       <li data-md>
        <p>Let <var>accepts options</var> be the result of <a data-link-type="dfn" href="#process-accept-types" id="ref-for-process-accept-types">processing accept types</a> given <var>options</var>.</p>
       <li data-md>
@@ -2977,7 +2973,7 @@ file picker will open. See <a href="#api-filepickeroptions">§ 3.2 File picker
 these steps: 
      <ol>
       <li data-md>
-       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④⓪">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object④">relevant settings object</a>.</p>
+       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④③">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object④">relevant settings object</a>.</p>
       <li data-md>
        <p>Let <var>accepts options</var> be the result of <a data-link-type="dfn" href="#process-accept-types" id="ref-for-process-accept-types①">processing accept types</a> given <var>options</var>.</p>
       <li data-md>
@@ -3071,7 +3067,7 @@ the selected directory.</p>
 these steps: 
      <ol>
       <li data-md>
-       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④①">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object⑤">relevant settings object</a>.</p>
+       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④④">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object⑤">relevant settings object</a>.</p>
       <li data-md>
        <p>Let <var>starting directory</var> be the result of <a data-link-type="dfn" href="#wellknowndirectory-determine-the-directory-the-picker-will-start-in" id="ref-for-wellknowndirectory-determine-the-directory-the-picker-will-start-in②">determining the directory the picker will start in</a> given <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-directorypickeroptions-id" id="ref-for-dom-directorypickeroptions-id①">id</a></code>, <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-directorypickeroptions-startin" id="ref-for-dom-directorypickeroptions-startin①">startIn</a></code> and <var>environment</var>.</p>
       <li data-md>
@@ -3239,7 +3235,7 @@ invoked, must run these steps:
        <p>Let <var>environment</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object">current settings object</a>.</p>
       <li data-md>
        <p>Let <var>map</var> be the result of running <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#obtain-a-local-storage-bottle-map" id="ref-for-obtain-a-local-storage-bottle-map">obtain a local storage bottle map</a> with <var>environment</var> and <code>"fileSystem"</code>. If this returns failure,
- return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with③">a promise rejected with</a> a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#securityerror" id="ref-for-securityerror⑥">SecurityError</a></code>.</p>
+ return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with⑤">a promise rejected with</a> a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#securityerror" id="ref-for-securityerror⑥">SecurityError</a></code>.</p>
       <li data-md>
        <p>If <var>map</var>["root"] does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑤">exist</a>:</p>
        <ol>
@@ -3468,7 +3464,7 @@ use this API to write to disk.</p>
    <li><a href="#dictdef-filesystemhandlepermissiondescriptor">FileSystemHandlePermissionDescriptor</a><span>, in § 2.3</span>
    <li><a href="#dictdef-filesystempermissiondescriptor">FileSystemPermissionDescriptor</a><span>, in § 2.2</span>
    <li><a href="#enumdef-filesystempermissionmode">FileSystemPermissionMode</a><span>, in § 2.2</span>
-   <li><a href="#dictdef-filesystemreadwriteoptions">FilesystemReadWriteOptions</a><span>, in § 2.7</span>
+   <li><a href="#dictdef-filesystemreadwriteoptions">FileSystemReadWriteOptions</a><span>, in § 2.7</span>
    <li><a href="#dictdef-filesystemremoveoptions">FileSystemRemoveOptions</a><span>, in § 2.5</span>
    <li><a href="#filesystemsyncaccesshandle">FileSystemSyncAccessHandle</a><span>, in § 2.7</span>
    <li><a href="#filesystemwritablefilestream">FileSystemWritableFileStream</a><span>, in § 2.6</span>
@@ -3524,7 +3520,7 @@ use this API to write to disk.</p>
    <li><a href="#dom-filesystemhandle-querypermission">queryPermission()</a><span>, in § 2.3.2</span>
    <li><a href="#dom-filesystemhandle-querypermission">queryPermission(descriptor)</a><span>, in § 2.3.2</span>
    <li><a href="#dom-filesystempermissionmode-read">"read"</a><span>, in § 2.2</span>
-   <li><a href="#dom-filesystemsyncaccesshandle-read-buffer-filesystemreadwriteoptions-options">read(buffer, FilesystemReadWriteOptions: options)</a><span>, in § 2.7.1</span>
+   <li><a href="#dom-filesystemsyncaccesshandle-read-buffer-filesystemreadwriteoptions-options">read(buffer, FileSystemReadWriteOptions: options)</a><span>, in § 2.7.1</span>
    <li><a href="#dom-filesystemsyncaccesshandle-read">read(buffer, options)</a><span>, in § 2.7</span>
    <li><a href="#dom-filesystempermissionmode-readwrite">"readwrite"</a><span>, in § 2.2</span>
    <li><a href="#recently-picked-directory-map">recently picked directory map</a><span>, in § 3.2.2</span>
@@ -3575,7 +3571,7 @@ use this API to write to disk.</p>
    <li><a href="#enumdef-wellknowndirectory">WellKnownDirectory</a><span>, in § 3.2.2</span>
    <li><a href="#dom-writecommandtype-write">"write"</a><span>, in § 2.6</span>
    <li><a href="#write-a-chunk">write a chunk</a><span>, in § 2.6</span>
-   <li><a href="#dom-filesystemsyncaccesshandle-write-buffer-filesystemreadwriteoptions-options">write(buffer, FilesystemReadWriteOptions: options)</a><span>, in § 2.7.2</span>
+   <li><a href="#dom-filesystemsyncaccesshandle-write-buffer-filesystemreadwriteoptions-options">write(buffer, FileSystemReadWriteOptions: options)</a><span>, in § 2.7.2</span>
    <li><a href="#dom-filesystemsyncaccesshandle-write">write(buffer, options)</a><span>, in § 2.7</span>
    <li><a href="#enumdef-writecommandtype">WriteCommandType</a><span>, in § 2.6</span>
    <li><a href="#dom-filesystemwritablefilestream-write">write(data)</a><span>, in § 2.6.1</span>
@@ -3778,6 +3774,9 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-concept-relevant-realm">2.3.1. The isSameEntry() method</a>
     <li><a href="#ref-for-concept-relevant-realm①">2.4.2. The createWritable() method</a>
     <li><a href="#ref-for-concept-relevant-realm②">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-concept-relevant-realm③">2.7.3. The truncate() method</a>
+    <li><a href="#ref-for-concept-relevant-realm④">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-concept-relevant-realm⑤">2.7.6. The close() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
@@ -4322,8 +4321,8 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-invalidstateerror">2.4.3. The createSyncAccessHandle() method</a>
     <li><a href="#ref-for-invalidstateerror①">2.7.1. The read() method</a>
     <li><a href="#ref-for-invalidstateerror②">2.7.2. The write() method</a>
-    <li><a href="#ref-for-invalidstateerror③">2.7.3. The truncate() method</a> <a href="#ref-for-invalidstateerror④">(2)</a>
-    <li><a href="#ref-for-invalidstateerror⑤">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-invalidstateerror③">2.7.3. The truncate() method</a>
+    <li><a href="#ref-for-invalidstateerror④">2.7.4. The getSize() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-nomodificationallowederror">
@@ -4450,8 +4449,10 @@ use this API to write to disk.</p>
    <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">2.6. The FileSystemWritableFileStream interface</a>
-    <li><a href="#ref-for-a-promise-rejected-with①">3.1. Local File System Permissions</a> <a href="#ref-for-a-promise-rejected-with②">(2)</a>
-    <li><a href="#ref-for-a-promise-rejected-with③">4. Accessing the Origin Private File System</a>
+    <li><a href="#ref-for-a-promise-rejected-with①">2.7.3. The truncate() method</a>
+    <li><a href="#ref-for-a-promise-rejected-with②">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-a-promise-rejected-with③">3.1. Local File System Permissions</a> <a href="#ref-for-a-promise-rejected-with④">(2)</a>
+    <li><a href="#ref-for-a-promise-rejected-with⑤">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-a-promise-resolved-with">
@@ -4573,12 +4574,12 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-this②③">2.6.3. The truncate() method</a>
     <li><a href="#ref-for-this②④">2.7.1. The read() method</a> <a href="#ref-for-this②⑤">(2)</a> <a href="#ref-for-this②⑥">(3)</a>
     <li><a href="#ref-for-this②⑦">2.7.2. The write() method</a> <a href="#ref-for-this②⑧">(2)</a> <a href="#ref-for-this②⑨">(3)</a> <a href="#ref-for-this③⓪">(4)</a>
-    <li><a href="#ref-for-this③①">2.7.3. The truncate() method</a> <a href="#ref-for-this③②">(2)</a> <a href="#ref-for-this③③">(3)</a> <a href="#ref-for-this③④">(4)</a> <a href="#ref-for-this③⑤">(5)</a>
-    <li><a href="#ref-for-this③⑥">2.7.4. The getSize() method</a> <a href="#ref-for-this③⑦">(2)</a>
-    <li><a href="#ref-for-this③⑧">2.7.6. The close() method</a>
-    <li><a href="#ref-for-this③⑨">3.3. The showOpenFilePicker() method</a>
-    <li><a href="#ref-for-this④⓪">3.4. The showSaveFilePicker() method</a>
-    <li><a href="#ref-for-this④①">3.5. The showDirectoryPicker() method</a>
+    <li><a href="#ref-for-this③①">2.7.3. The truncate() method</a> <a href="#ref-for-this③②">(2)</a> <a href="#ref-for-this③③">(3)</a> <a href="#ref-for-this③④">(4)</a> <a href="#ref-for-this③⑤">(5)</a> <a href="#ref-for-this③⑥">(6)</a>
+    <li><a href="#ref-for-this③⑦">2.7.4. The getSize() method</a> <a href="#ref-for-this③⑧">(2)</a> <a href="#ref-for-this③⑨">(3)</a>
+    <li><a href="#ref-for-this④⓪">2.7.6. The close() method</a> <a href="#ref-for-this④①">(2)</a>
+    <li><a href="#ref-for-this④②">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-this④③">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-this④④">3.5. The showDirectoryPicker() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-undefined">
@@ -4928,16 +4929,16 @@ use this API to write to disk.</p>
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemwritablefilestream-truncate"><c- g>truncate</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a href="#dom-filesystemwritablefilestream-truncate-size-size"><code><c- g>size</c-></code></a>);
 };
 
-<c- b>dictionary</c-> <a href="#dictdef-filesystemreadwriteoptions"><code><c- g>FilesystemReadWriteOptions</c-></code></a> {
+<c- b>dictionary</c-> <a href="#dictdef-filesystemreadwriteoptions"><code><c- g>FileSystemReadWriteOptions</c-></code></a> {
   [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange"><c- g>EnforceRange</c-></a>] <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a data-type="unsigned long long " href="#dom-filesystemreadwriteoptions-at"><code><c- g>at</c-></code></a>;
 }
 
 [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=<c- n>DedicatedWorker</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext"><c- g>SecureContext</c-></a>]
 <c- b>interface</c-> <a href="#filesystemsyncaccesshandle"><code><c- g>FileSystemSyncAccessHandle</c-></code></a> {
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a href="#dom-filesystemsyncaccesshandle-read"><code><c- g>read</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#AllowShared"><c- g>AllowShared</c-></a>] <a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#BufferSource"><c- n>BufferSource</c-></a> <a href="#dom-filesystemsyncaccesshandle-read-buffer-options-buffer"><code><c- g>buffer</c-></code></a>,
-                             <a data-link-type="idl-name" href="#dictdef-filesystemreadwriteoptions"><c- n>FilesystemReadWriteOptions</c-></a> <a href="#dom-filesystemsyncaccesshandle-read-buffer-options-options"><code><c- g>options</c-></code></a>);
+                          <a data-link-type="idl-name" href="#dictdef-filesystemreadwriteoptions"><c- n>FileSystemReadWriteOptions</c-></a> <a href="#dom-filesystemsyncaccesshandle-read-buffer-options-options"><code><c- g>options</c-></code></a>);
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a href="#dom-filesystemsyncaccesshandle-write"><code><c- g>write</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#AllowShared"><c- g>AllowShared</c-></a>] <a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#BufferSource"><c- n>BufferSource</c-></a> <a href="#dom-filesystemsyncaccesshandle-write-buffer-options-buffer"><code><c- g>buffer</c-></code></a>,
-                              <a data-link-type="idl-name" href="#dictdef-filesystemreadwriteoptions"><c- n>FilesystemReadWriteOptions</c-></a> <a href="#dom-filesystemsyncaccesshandle-write-buffer-options-options"><code><c- g>options</c-></code></a>);
+                           <a data-link-type="idl-name" href="#dictdef-filesystemreadwriteoptions"><c- n>FileSystemReadWriteOptions</c-></a> <a href="#dom-filesystemsyncaccesshandle-write-buffer-options-options"><code><c- g>options</c-></code></a>);
 
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-truncate"><c- g>truncate</c-></a>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a href="#dom-filesystemsyncaccesshandle-truncate-newsize-newsize"><code><c- g>newSize</c-></code></a>);
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-getsize"><c- g>getSize</c-></a>();
@@ -5583,8 +5584,10 @@ than being defined here. So merge this into the table there. <a class="issue-ret
    <b><a href="#filesystemwritablefilestream-file">#filesystemwritablefilestream-file</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystemwritablefilestream-file">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemwritablefilestream-file①">(2)</a> <a href="#ref-for-filesystemwritablefilestream-file②">(3)</a>
-    <li><a href="#ref-for-filesystemwritablefilestream-file③">2.7.2. The write() method</a>
-    <li><a href="#ref-for-filesystemwritablefilestream-file④">2.7.3. The truncate() method</a> <a href="#ref-for-filesystemwritablefilestream-file⑤">(2)</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file③">2.7.1. The read() method</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file④">2.7.2. The write() method</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file⑤">2.7.3. The truncate() method</a> <a href="#ref-for-filesystemwritablefilestream-file⑥">(2)</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file⑦">2.7.4. The getSize() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="filesystemwritablefilestream-buffer">
@@ -5638,8 +5641,8 @@ than being defined here. So merge this into the table there. <a class="issue-ret
    <b><a href="#dictdef-filesystemreadwriteoptions">#dictdef-filesystemreadwriteoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-filesystemreadwriteoptions">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-dictdef-filesystemreadwriteoptions①">(2)</a>
-    <li><a href="#ref-for-dictdef-filesystemreadwriteoptions②">2.7.1. The read() method</a> <a href="#ref-for-dictdef-filesystemreadwriteoptions③">(2)</a>
-    <li><a href="#ref-for-dictdef-filesystemreadwriteoptions④">2.7.2. The write() method</a> <a href="#ref-for-dictdef-filesystemreadwriteoptions⑤">(2)</a>
+    <li><a href="#ref-for-dictdef-filesystemreadwriteoptions②">2.7.1. The read() method</a>
+    <li><a href="#ref-for-dictdef-filesystemreadwriteoptions③">2.7.2. The write() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-filesystemreadwriteoptions-at">
@@ -5663,15 +5666,17 @@ than being defined here. So merge this into the table there. <a class="issue-ret
    <b><a href="#dom-filesystemsyncaccesshandle-read">#dom-filesystemsyncaccesshandle-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemsyncaccesshandle-read">2.4.3. The createSyncAccessHandle() method</a>
-    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-read①">2.7.1. The read() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-read②">(2)</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-read①">2.7. The FileSystemSyncAccessHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-read②">2.7.1. The read() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-read③">(2)</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-read④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-filesystemsyncaccesshandle-write">
    <b><a href="#dom-filesystemsyncaccesshandle-write">#dom-filesystemsyncaccesshandle-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemsyncaccesshandle-write">2.4.3. The createSyncAccessHandle() method</a>
-    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-write①">2.7.2. The write() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-write②">(2)</a>
-    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-write③">2.7.5. The flush() method</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-write①">2.7. The FileSystemSyncAccessHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-write②">2.7.2. The write() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-write③">(2)</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-write④">(3)</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-write⑤">2.7.5. The flush() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="filesystemsyncaccesshandle-file">
@@ -5679,10 +5684,9 @@ than being defined here. So merge this into the table there. <a class="issue-ret
    <ul>
     <li><a href="#ref-for-filesystemsyncaccesshandle-file">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemsyncaccesshandle-file①">(2)</a> <a href="#ref-for-filesystemsyncaccesshandle-file②">(3)</a>
     <li><a href="#ref-for-filesystemsyncaccesshandle-file③">2.7. The FileSystemSyncAccessHandle interface</a>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file④">2.7.1. The read() method</a> <a href="#ref-for-filesystemsyncaccesshandle-file⑤">(2)</a>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file⑥">2.7.2. The write() method</a> <a href="#ref-for-filesystemsyncaccesshandle-file⑦">(2)</a>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file⑧">2.7.3. The truncate() method</a> <a href="#ref-for-filesystemsyncaccesshandle-file⑨">(2)</a>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file①⓪">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file④">2.7.1. The read() method</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file⑤">2.7.2. The write() method</a> <a href="#ref-for-filesystemsyncaccesshandle-file⑥">(2)</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file⑦">2.7.3. The truncate() method</a> <a href="#ref-for-filesystemsyncaccesshandle-file⑧">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="filesystemsyncaccesshandle-state">

--- a/index.html
+++ b/index.html
@@ -662,7 +662,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">File System Access</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2022-03-17">17 March 2022</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2022-04-06">6 April 2022</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -845,51 +845,43 @@ U+002B (+), or U+002E (.).</p>
 majority of file extensions are purely alphanumeric, but compound extensions (such as <code>.tar.gz</code>) and extensions such as <code>.c++</code> for C++ source code are also fairly common,
 hence the inclusion of + and . as allowed code points.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="file|file entry" data-noexport id="file">file entry</dfn> additionally consists of <dfn class="dfn-paneled" data-dfn-for="file entry" data-dfn-type="dfn" data-noexport id="file-entry-binary-data">binary data</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence">byte sequence</a>), a <dfn class="dfn-paneled" data-dfn-for="file entry" data-dfn-type="dfn" data-noexport id="file-entry-modification-timestamp">modification timestamp</dfn> (a number representing the number of milliseconds since the <a data-link-type="dfn" href="https://w3c.github.io/FileAPI/#UnixEpoch" id="ref-for-UnixEpoch">Unix Epoch</a>)
-and a <dfn class="dfn-paneled" data-dfn-for="file entry" data-dfn-type="dfn" data-noexport id="file-entry-lock">lock</dfn>. A lock is a string that may exclusively be "open", "taken-exclusive", and "taken-shared".</p>
+and a <dfn class="dfn-paneled" data-dfn-for="file entry" data-dfn-type="dfn" data-noexport id="file-entry-lock">lock</dfn>. A lock is a string that may exclusively be "<code>open</code>", "<code>taken-exclusive</code>", and "<code>taken-shared</code>".</p>
    <div class="algorithm" data-algorithm="take" data-algorithm-for="file entry/lock">
-     To <dfn class="dfn-paneled" data-dfn-for="file entry/lock" data-dfn-type="dfn" data-noexport id="file-entry-lock-take">take</dfn> a <a data-link-type="dfn" href="#file-entry-lock" id="ref-for-file-entry-lock">lock</a> with a <var>value</var> of "exclusive" or "shared", for a given <var>file</var>,
+     To <dfn class="dfn-paneled" data-dfn-for="file entry/lock" data-dfn-type="dfn" data-noexport id="file-entry-lock-take">take</dfn> a <a data-link-type="dfn" href="#file-entry-lock" id="ref-for-file-entry-lock">lock</a> with a <var>value</var> of "<code>exclusive</code>" or "<code>shared</code>" on a given <a data-link-type="dfn" href="#file" id="ref-for-file①">file entry</a> <var>file</var>,
 run the following steps: 
     <ol>
      <li data-md>
-      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise">a new promise</a>.</p>
+      <p>Let <var>lock</var> be the <var>file</var>’s <a data-link-type="dfn" href="#file-entry-lock" id="ref-for-file-entry-lock①">lock</a>.</p>
      <li data-md>
-      <p>Let <var>lock</var> be the <var>file</var>’s associated <a data-link-type="dfn" href="#file-entry-lock" id="ref-for-file-entry-lock①">lock</a></p>
+      <p>Let <var>result</var> be <code>false</code>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>:</p>
+      <p>If <var>value</var> is "<code>exclusive</code>":</p>
       <ol>
        <li data-md>
-        <p>If <var>value</var> is "exclusive":</p>
+        <p>If <var>lock</var> is "<code>open</code>":</p>
         <ol>
          <li data-md>
-          <p>If <var>lock</var> is "open":</p>
-          <ol>
-           <li data-md>
-            <p>Set lock to "taken-exclusive".</p>
-           <li data-md>
-            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve">resolve</a> <var>result</var>.</p>
-          </ol>
+          <p>Set lock to "<code>taken-exclusive</code>".</p>
          <li data-md>
-          <p>Else <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject">reject</a> <var>result</var>.</p>
+          <p>Set <var>result</var> to <code>true</code></p>
+        </ol>
+      </ol>
+     <li data-md>
+      <p>If <var>value</var> is "<code>shared</code>":</p>
+      <ol>
+       <li data-md>
+        <p>If <var>lock</var> is "<code>open</code>":</p>
+        <ol>
+         <li data-md>
+          <p>Set lock to "<code>taken-shared</code>".</p>
+         <li data-md>
+          <p>Set <var>result</var> to <code>true</code></p>
         </ol>
        <li data-md>
-        <p>If <var>value</var> is "shared":</p>
+        <p>Else if <var>lock</var> is "<code>taken-shared</code>":</p>
         <ol>
          <li data-md>
-          <p>If <var>lock</var> is "open":</p>
-          <ol>
-           <li data-md>
-            <p>Set lock to "taken-exclusive".</p>
-           <li data-md>
-            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①">resolve</a> <var>result</var>.</p>
-          </ol>
-         <li data-md>
-          <p>Else if <var>lock</var> is "taken-shared":</p>
-          <ol>
-           <li data-md>
-            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②">resolve</a> <var>result</var>.</p>
-          </ol>
-         <li data-md>
-          <p>Else <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①">reject</a> <var>result</var>.</p>
+          <p>Set <var>result</var> to <code>true</code></p>
         </ol>
       </ol>
      <li data-md>
@@ -897,17 +889,17 @@ run the following steps:
     </ol>
    </div>
    <div class="algorithm" data-algorithm="release" data-algorithm-for="file entry/lock">
-     To <dfn class="dfn-paneled" data-dfn-for="file entry/lock" data-dfn-type="dfn" data-noexport id="file-entry-lock-release">release</dfn> a <a data-link-type="dfn" href="#file-entry-lock" id="ref-for-file-entry-lock②">lock</a> for a given <var>file</var>,
+     To <dfn class="dfn-paneled" data-dfn-for="file entry/lock" data-dfn-type="dfn" data-noexport id="file-entry-lock-release">release</dfn> a <a data-link-type="dfn" href="#file-entry-lock" id="ref-for-file-entry-lock②">lock</a> on a given <a data-link-type="dfn" href="#file" id="ref-for-file②">file entry</a> <var>file</var>,
 run the following steps: 
     <ol>
      <li data-md>
-      <p>Let <var>lock</var> be the <var>file</var>’s associated <a data-link-type="dfn" href="#file-entry-lock" id="ref-for-file-entry-lock③">lock</a></p>
+      <p>Let <var>lock</var> be the <var>file</var>’s associated <a data-link-type="dfn" href="#file-entry-lock" id="ref-for-file-entry-lock③">lock</a>.</p>
      <li data-md>
-      <p>Set lock to "open".</p>
+      <p>Set lock to "<code>open</code>".</p>
     </ol>
    </div>
    <p class="note" role="note"><span>Note:</span> Locks help prevent concurrent modifications to a file. A <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream">FileSystemWritableFileStream</a></code> requires a shared lock, while a <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle">FileSystemSyncAccessHandle</a></code> requires an exclusive one.</p>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="directory|directory entry" data-noexport id="directory">directory entry</dfn> additionally consists of a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">set</a> of <dfn class="dfn-paneled" data-dfn-for="directory entry" data-dfn-type="dfn" data-noexport id="directory-entry-children">children</dfn>, which are themselves <a data-link-type="dfn" href="#entry" id="ref-for-entry①">entries</a>. Each member is either a <a data-link-type="dfn" href="#file" id="ref-for-file①">file</a> or a <a data-link-type="dfn" href="#directory" id="ref-for-directory①">directory</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="directory|directory entry" data-noexport id="directory">directory entry</dfn> additionally consists of a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">set</a> of <dfn class="dfn-paneled" data-dfn-for="directory entry" data-dfn-type="dfn" data-noexport id="directory-entry-children">children</dfn>, which are themselves <a data-link-type="dfn" href="#entry" id="ref-for-entry①">entries</a>. Each member is either a <a data-link-type="dfn" href="#file" id="ref-for-file③">file</a> or a <a data-link-type="dfn" href="#directory" id="ref-for-directory①">directory</a>.</p>
    <p>An <a data-link-type="dfn" href="#entry" id="ref-for-entry②">entry</a> <var>entry</var> should be <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contained</a> in the <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children">children</a> of at most one <a data-link-type="dfn" href="#directory" id="ref-for-directory②">directory entry</a>, and that directory entry is also known as <var>entry</var>’s <dfn class="dfn-paneled" data-dfn-for="entry" data-dfn-type="dfn" data-noexport id="entry-parent">parent</dfn>.
 An <a data-link-type="dfn" href="#entry" id="ref-for-entry③">entry</a>'s <a data-link-type="dfn" href="#entry-parent" id="ref-for-entry-parent">parent</a> is null if no such directory entry exists.</p>
    <p class="note" role="note"><span>Note:</span> Two different <a data-link-type="dfn" href="#entry" id="ref-for-entry④">entries</a> can represent the same file or directory on disk, in which
@@ -930,12 +922,12 @@ directory on disk but an entry doesn’t have to map to any file on disk).</p>
 run the following steps: 
     <ol>
      <li data-md>
-      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①">a new promise</a>.</p>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise">a new promise</a>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>If <var>child</var> is <a data-link-type="dfn" href="#entry-the-same-as" id="ref-for-entry-the-same-as">the same as</a> <var>root</var>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve③">resolve</a> <var>result</var> with an empty list, and abort.</p>
+        <p>If <var>child</var> is <a data-link-type="dfn" href="#entry-the-same-as" id="ref-for-entry-the-same-as">the same as</a> <var>root</var>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve">resolve</a> <var>result</var> with an empty list, and abort.</p>
        <li data-md>
         <p>Let <var>childPromises</var> be « ».</p>
        <li data-md>
@@ -954,7 +946,7 @@ run the following steps:
              <li data-md>
               <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-prepend" id="ref-for-list-prepend">Prepend</a> <var>entry</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name">name</a> to <var>path</var>.</p>
              <li data-md>
-              <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve④">Resolve</a> <var>result</var> with <var>path</var>.</p>
+              <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①">Resolve</a> <var>result</var> with <var>path</var>.</p>
             </ol>
           </ol>
         </ol>
@@ -962,7 +954,7 @@ run the following steps:
         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#wait-for-all" id="ref-for-wait-for-all">Wait for all</a> <var>childPromises</var>, with the following success steps:</p>
         <ol>
          <li data-md>
-          <p>If <var>result</var> hasn’t been resolved yet, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑤">resolve</a> <var>result</var> with <code>null</code>.</p>
+          <p>If <var>result</var> hasn’t been resolved yet, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②">resolve</a> <var>result</var> with <code>null</code>.</p>
         </ol>
       </ol>
      <li data-md>
@@ -1079,21 +1071,6 @@ run these steps:
    <p class="issue" id="issue-7fc2f5c7"><a class="self-link" href="#issue-7fc2f5c7"></a> Currently <code class="idl"><a data-link-type="idl" href="#enumdef-filesystempermissionmode" id="ref-for-enumdef-filesystempermissionmode③">FileSystemPermissionMode</a></code> can only be <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read①">"read"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite①">"readwrite"</a></code>. In
 the future we might want to add a "write" mode as well to support write-only handles. <a href="https://github.com/wicg/file-system-access/issues/119">[Issue #119]</a></p>
    <h3 class="heading settled" data-level="2.3" id="api-filesystemhandle"><span class="secno">2.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#filesystemhandle" id="ref-for-filesystemhandle③">FileSystemHandle</a></code> interface</span><a class="self-link" href="#api-filesystemhandle"></a></h3>
-   <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><span>MDN</span></button>
-    <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle" title="The FileSystemHandle interface of the File System Access API is an object which represents a file or directory entry. Multiple handles can represent the same entry. For the most part you do not work with FileSystemHandle directly but rather its child interfaces FileSystemFileHandle and FileSystemDirectoryHandle.">FileSystemHandle</a></p>
-     <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-      <hr>
-      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-      <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-      <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-     </div>
-    </div>
-   </div>
 <pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystemhandlepermissiondescriptor"><code><c- g>FileSystemHandlePermissionDescriptor</c-></code></dfn> {
   <a data-link-type="idl-name" href="#enumdef-filesystempermissionmode" id="ref-for-enumdef-filesystempermissionmode④"><c- n>FileSystemPermissionMode</c-></a> <dfn class="dfn-paneled idl-code" data-default="&quot;read&quot;" data-dfn-for="FileSystemHandlePermissionDescriptor" data-dfn-type="dict-member" data-export data-type="FileSystemPermissionMode " id="dom-filesystemhandlepermissiondescriptor-mode"><code><c- g>mode</c-></code></dfn> = "read";
 };
@@ -1141,70 +1118,23 @@ In Chrome 82 they are.</strong></p>
    </div>
    <div class="note domintro" role="note">
     <dl>
-     <dt data-md>
-      <div class="mdn-anno wrapped">
-       <button class="mdn-anno-btn"><span>MDN</span></button>
-       <div class="feature">
-        <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/kind" title="The kind read-only property of the FileSystemHandle interface returns the type of entry. This is &apos;file&apos; if the associated entry is a file or &apos;directory&apos;. It is used to distinguish files from directories when iterating over the contents of a directory.">FileSystemHandle/kind</a></p>
-        <div class="support">
-         <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-         <hr>
-         <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-         <hr>
-         <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-         <hr>
-         <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-        </div>
-       </div>
-      </div>
-      <p><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-kind" id="ref-for-dom-filesystemhandle-kind①">kind</a></code></p>
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-kind" id="ref-for-dom-filesystemhandle-kind①">kind</a></code>
      <dd data-md>
       <p>Returns <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlekind-file" id="ref-for-dom-filesystemhandlekind-file">"file"</a></code> if <var>handle</var> is a <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle">FileSystemFileHandle</a></code>,
  or <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlekind-directory" id="ref-for-dom-filesystemhandlekind-directory">"directory"</a></code> if <var>handle</var> is a <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle">FileSystemDirectoryHandle</a></code>.</p>
       <p>This can be used to distinguish files from directories when iterating over the contents
  of a directory.</p>
-     <dt data-md>
-      <div class="mdn-anno wrapped">
-       <button class="mdn-anno-btn"><span>MDN</span></button>
-       <div class="feature">
-        <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/name" title="The name read-only property of the FileSystemHandle interface returns the name of the entry represented by handle.">FileSystemHandle/name</a></p>
-        <div class="support">
-         <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-         <hr>
-         <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-         <hr>
-         <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-         <hr>
-         <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-        </div>
-       </div>
-      </div>
-      <p><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-name" id="ref-for-dom-filesystemhandle-name①">name</a></code></p>
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-name" id="ref-for-dom-filesystemhandle-name①">name</a></code>
      <dd data-md>
       <p>Returns the <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name①">name</a> of the entry represented by <var>handle</var>.</p>
     </dl>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemHandle" data-dfn-type="attribute" data-export id="dom-filesystemhandle-kind"><code>kind</code></dfn> attribute must
-return <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlekind-file" id="ref-for-dom-filesystemhandlekind-file①">"file"</a></code> if the associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry④">entry</a> is a <a data-link-type="dfn" href="#file" id="ref-for-file②">file entry</a>,
+return <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlekind-file" id="ref-for-dom-filesystemhandlekind-file①">"file"</a></code> if the associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry④">entry</a> is a <a data-link-type="dfn" href="#file" id="ref-for-file④">file entry</a>,
 and return <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlekind-directory" id="ref-for-dom-filesystemhandlekind-directory①">"directory"</a></code> otherwise.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemHandle" data-dfn-type="attribute" data-export id="dom-filesystemhandle-name"><code>name</code></dfn> attribute must return the <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name②">name</a> of the
 associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry⑤">entry</a>.</p>
    <h4 class="heading settled" data-level="2.3.1" id="api-filesystemhandle-issameentry"><span class="secno">2.3.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-issameentry" id="ref-for-dom-filesystemhandle-issameentry①">isSameEntry()</a></code> method</span><a class="self-link" href="#api-filesystemhandle-issameentry"></a></h4>
-   <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><span>MDN</span></button>
-    <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/isSameEntry" title="The isSameEntry() method of the FileSystemHandle interface compares two handles to see if the associated entries (either a file or directory) match.">FileSystemHandle/isSameEntry</a></p>
-     <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-      <hr>
-      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-      <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-      <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-     </div>
-    </div>
-   </div>
    <div class="note domintro" role="note">
     <dl>
      <dt data-md><var>same</var> = await <var>handle1</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-issameentry" id="ref-for-dom-filesystemhandle-issameentry②">isSameEntry</a></code>( <var>handle2</var> )
@@ -1219,14 +1149,14 @@ associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-fi
      <li data-md>
       <p>Let <var>realm</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this">this</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm">relevant Realm</a>.</p>
      <li data-md>
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise②">a new promise</a> in <var>realm</var>.</p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①">a new promise</a> in <var>realm</var>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①">this</a>'s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry⑥">entry</a> is <a data-link-type="dfn" href="#entry-the-same-as" id="ref-for-entry-the-same-as①">the same as</a> <var>other</var>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry⑦">entry</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑥">resolve</a> <var>p</var> with <code>true</code>.</p>
+        <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①">this</a>'s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry⑥">entry</a> is <a data-link-type="dfn" href="#entry-the-same-as" id="ref-for-entry-the-same-as①">the same as</a> <var>other</var>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry⑦">entry</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve③">resolve</a> <var>p</var> with <code>true</code>.</p>
        <li data-md>
-        <p>Else <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑦">resolve</a> <var>p</var> with <code>false</code>.</p>
+        <p>Else <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve④">resolve</a> <var>p</var> with <code>false</code>.</p>
       </ol>
      <li data-md>
       <p>Return <var>p</var>.</p>
@@ -1275,14 +1205,14 @@ associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-fi
      The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemHandle" data-dfn-type="method" data-export data-lt="queryPermission(descriptor)|queryPermission()" id="dom-filesystemhandle-querypermission"><code>queryPermission(<var>descriptor</var>)</code></dfn> method, when invoked, must run these steps: 
     <ol>
      <li data-md>
-      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise③">a new promise</a>.</p>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise②">a new promise</a>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②">in parallel</a>:</p>
       <ol>
        <li data-md>
         <p>Let <var>state</var> be the result of <a data-link-type="dfn" href="#querying-file-system-permission" id="ref-for-querying-file-system-permission">querying file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②">this</a></b> and <var>descriptor</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlepermissiondescriptor-mode" id="ref-for-dom-filesystemhandlepermissiondescriptor-mode②">mode</a></code>.</p>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑧">Resolve</a> <var>result</var> with <var>state</var>.</p>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑤">Resolve</a> <var>result</var> with <var>state</var>.</p>
       </ol>
      <li data-md>
       <p>Return <var>result</var>.</p>
@@ -1327,44 +1257,23 @@ associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-fi
      The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemHandle" data-dfn-type="method" data-export data-lt="requestPermission(descriptor)|requestPermission()" id="dom-filesystemhandle-requestpermission"><code>requestPermission(<var>descriptor</var>)</code></dfn> method, when invoked, must run these steps: 
     <ol>
      <li data-md>
-      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise④">a new promise</a>.</p>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise③">a new promise</a>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel④">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③">in parallel</a>:</p>
       <ol>
        <li data-md>
         <p>Let <var>state</var> be the result of <a data-link-type="dfn" href="#requesting-file-system-permission" id="ref-for-requesting-file-system-permission">requesting file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③">this</a></b> and <var>descriptor</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlepermissiondescriptor-mode" id="ref-for-dom-filesystemhandlepermissiondescriptor-mode⑤">mode</a></code>.
- If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②">reject</a> <var>result</var> with that exception and abort.</p>
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject">reject</a> <var>result</var> with that exception and abort.</p>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑨">Resolve</a> <var>result</var> with <var>state</var>.</p>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑥">Resolve</a> <var>result</var> with <var>state</var>.</p>
       </ol>
      <li data-md>
       <p>Return <var>result</var>.</p>
     </ol>
    </div>
    <h3 class="heading settled" data-level="2.4" id="api-filesystemfilehandle"><span class="secno">2.4. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①">FileSystemFileHandle</a></code> interface</span><a class="self-link" href="#api-filesystemfilehandle"></a></h3>
-   <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><span>MDN</span></button>
-    <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle" title="The FileSystemFileHandle interface of the File System Access API represents a handle to a file system entry. The interface is accessed through the window.showOpenFilePicker() method.">FileSystemFileHandle</a></p>
-     <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-      <hr>
-      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-      <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-      <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-     </div>
-    </div>
-   </div>
 <pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystemcreatewritableoptions"><code><c- g>FileSystemCreateWritableOptions</c-></code></dfn> {
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean①"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-default="false" data-dfn-for="FileSystemCreateWritableOptions" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-filesystemcreatewritableoptions-keepexistingdata"><code><c- g>keepExistingData</c-></code></dfn> = <c- b>false</c->;
-};
-
-<c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-accesshandlemode"><code><c- g>AccessHandleMode</c-></code></dfn> { <dfn class="idl-code" data-dfn-for="AccessHandleMode" data-dfn-type="enum-value" data-export id="dom-accesshandlemode-in-place"><code><c- s>"in-place"</c-></code><a class="self-link" href="#dom-accesshandlemode-in-place"></a></dfn> };
-
-<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystemfilehandlecreateaccesshandleoptions"><code><c- g>FileSystemFileHandleCreateAccessHandleOptions</c-></code></dfn> {
-  <c- b>required</c-> <a data-link-type="idl-name" href="#enumdef-accesshandlemode" id="ref-for-enumdef-accesshandlemode"><c- n>AccessHandleMode</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemFileHandleCreateAccessHandleOptions" data-dfn-type="dict-member" data-export data-type="AccessHandleMode " id="dom-filesystemfilehandlecreateaccesshandleoptions-mode"><code><c- g>mode</c-></code></dfn>;
 };
 
 [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->), <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext" id="ref-for-SecureContext①"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable" id="ref-for-serializable①"><c- g>Serializable</c-></a>]
@@ -1372,29 +1281,14 @@ associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-fi
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise③"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-file" id="ref-for-dfn-file"><c- n>File</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-getfile" id="ref-for-dom-filesystemfilehandle-getfile"><c- g>getFile</c-></a>();
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise④"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream①"><c- n>FileSystemWritableFileStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createwritable" id="ref-for-dom-filesystemfilehandle-createwritable"><c- g>createWritable</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemcreatewritableoptions" id="ref-for-dictdef-filesystemcreatewritableoptions"><c- n>FileSystemCreateWritableOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemFileHandle/createWritable(options), FileSystemFileHandle/createWritable()" data-dfn-type="argument" data-export id="dom-filesystemfilehandle-createwritable-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemfilehandle-createwritable-options-options"></a></dfn> = {});
   [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed②"><c- g>Exposed</c-></a>=<c- n>DedicatedWorker</c->]
-  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑤"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle①"><c- n>FileSystemSyncAccessHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createsyncaccesshandle" id="ref-for-dom-filesystemfilehandle-createsyncaccesshandle"><c- g>createSyncAccessHandle</c-></a>(<a data-link-type="idl-name" href="#dictdef-filesystemfilehandlecreateaccesshandleoptions" id="ref-for-dictdef-filesystemfilehandlecreateaccesshandleoptions"><c- n>FileSystemFileHandleCreateAccessHandleOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemFileHandle/createSyncAccessHandle(options)" data-dfn-type="argument" data-export id="dom-filesystemfilehandle-createsyncaccesshandle-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemfilehandle-createsyncaccesshandle-options-options"></a></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑤"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle①"><c- n>FileSystemSyncAccessHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createsyncaccesshandle" id="ref-for-dom-filesystemfilehandle-createsyncaccesshandle"><c- g>createSyncAccessHandle</c-></a>();
 };
 </pre>
-   <p>A <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle②">FileSystemFileHandle</a></code>'s associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry⑧">entry</a> must be a <a data-link-type="dfn" href="#file" id="ref-for-file③">file entry</a>.</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle②">FileSystemFileHandle</a></code>'s associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry⑧">entry</a> must be a <a data-link-type="dfn" href="#file" id="ref-for-file⑤">file entry</a>.</p>
    <p><code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle③">FileSystemFileHandle</a></code> objects are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects" id="ref-for-serializable-objects①">serializable objects</a>. Their <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps" id="ref-for-serialization-steps①">serialization steps</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps" id="ref-for-deserialization-steps①">deserialization steps</a> are the same as those for <code class="idl"><a data-link-type="idl" href="#filesystemhandle" id="ref-for-filesystemhandle①⓪">FileSystemHandle</a></code>.</p>
    <p><strong class="advisement"> In the Origin Trial as available in Chrome 78, these objects are not yet serializable.
 In Chrome 82 they are.</strong></p>
    <h4 class="heading settled" data-level="2.4.1" id="api-filesystemfilehandle-getfile"><span class="secno">2.4.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-getfile" id="ref-for-dom-filesystemfilehandle-getfile①">getFile()</a></code> method</span><a class="self-link" href="#api-filesystemfilehandle-getfile"></a></h4>
-   <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><span>MDN</span></button>
-    <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle/getFile" title="The getFile() method of the FileSystemFileHandle interface returns a Promise which resolves to a File object representing the state on disk of the entry represented by the handle.">FileSystemFileHandle/getFile</a></p>
-     <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-      <hr>
-      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-      <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-      <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-     </div>
-    </div>
-   </div>
    <div class="note domintro" role="note">
     <dl>
      <dt data-md><var>file</var> = await <var>fileHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-getfile" id="ref-for-dom-filesystemfilehandle-getfile②">getFile()</a></code>
@@ -1407,9 +1301,9 @@ In Chrome 82 they are.</strong></p>
      The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemFileHandle" data-dfn-type="method" data-export id="dom-filesystemfilehandle-getfile"><code>getFile()</code></dfn> method, when invoked, must run these steps: 
     <ol>
      <li data-md>
-      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑤">a new promise</a>.</p>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise④">a new promise</a>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑤">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel④">in parallel</a>:</p>
       <ol>
        <li data-md>
         <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#querying-file-system-permission" id="ref-for-querying-file-system-permission①">querying file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④">this</a></b> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read④">"read"</a></code>.</p>
@@ -1433,28 +1327,13 @@ In Chrome 82 they are.</strong></p>
         <p class="issue" id="issue-1fb8bcae"><a class="self-link" href="#issue-1fb8bcae"></a> The reading and snapshotting behavior needs to be better specified in the <a data-link-type="biblio" href="#biblio-file-api">[FILE-API]</a> spec,
  for now this is kind of hand-wavy.</p>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⓪">Resolve</a> <var>result</var> with <var>f</var>.</p>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑦">Resolve</a> <var>result</var> with <var>f</var>.</p>
       </ol>
      <li data-md>
       <p>Return <var>result</var>.</p>
     </ol>
    </div>
    <h4 class="heading settled" data-level="2.4.2" id="api-filesystemfilehandle-createwritable"><span class="secno">2.4.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-createwritable" id="ref-for-dom-filesystemfilehandle-createwritable①">createWritable()</a></code> method</span><a class="self-link" href="#api-filesystemfilehandle-createwritable"></a></h4>
-   <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><span>MDN</span></button>
-    <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle/createWritable" title="The createWritable() method of the FileSystemFileHandle interface creates a FileSystemWritableFileStream that can be used to write to a file. The method returns a Promise which resolves to this created stream.">FileSystemFileHandle/createWritable</a></p>
-     <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>preview+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-      <hr>
-      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-      <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-      <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-     </div>
-    </div>
-   </div>
    <p><strong class="advisement"> In the Origin Trial as available in Chrome 82, createWritable replaces the createWriter method.</strong></p>
    <div class="note domintro" role="note">
     <dl>
@@ -1482,23 +1361,22 @@ modifications to existing large files. <a href="https://github.com/wicg/file-sys
      The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemFileHandle" data-dfn-type="method" data-export data-lt="createWritable(options)|createWritable()" id="dom-filesystemfilehandle-createwritable"><code>createWritable(<var>options</var>)</code></dfn> method, when invoked, must run these steps: 
     <ol>
      <li data-md>
-      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑥">a new promise</a>.</p>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑤">a new promise</a>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑥">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑤">in parallel</a>:</p>
       <ol>
        <li data-md>
         <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#requesting-file-system-permission" id="ref-for-requesting-file-system-permission①">requesting file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑥">this</a></b> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite⑤">"readwrite"</a></code>.
- If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③">reject</a> <var>result</var> with that exception and abort.</p>
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①">reject</a> <var>result</var> with that exception and abort.</p>
        <li data-md>
         <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted③">"granted"</a></code>,
  reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror①">NotAllowedError</a></code> and abort.</p>
        <li data-md>
         <p>Let <var>entry</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑦">this</a></b>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①①">entry</a>.</p>
        <li data-md>
-        <p>Let <var>lockValue</var> be "shared".</p>
+        <p>Let <var>lockResult</var> be the result of <a data-link-type="dfn" href="#file-entry-lock-take" id="ref-for-file-entry-lock-take①">taking a lock</a> with "<code>shared</code>" on <var>entry</var>.</p>
        <li data-md>
-        <p>Let <var>lockResult</var> be the result of <a data-link-type="dfn" href="#file-entry-lock-take" id="ref-for-file-entry-lock-take①">taking a lock</a> with <var>lockValue</var> on <var>entry</var>.
- If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject④">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#nomodificationallowederror" id="ref-for-nomodificationallowederror">NoModificationAllowedError</a></code> and abort.</p>
+        <p>If <var>lockResult</var> is <code>false</code>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#nomodificationallowederror" id="ref-for-nomodificationallowederror">NoModificationAllowedError</a></code> and abort.</p>
        <li data-md>
         <p>Let <var>stream</var> be the result of <a data-link-type="dfn" href="#create-a-new-filesystemwritablefilestream" id="ref-for-create-a-new-filesystemwritablefilestream">creating a new FileSystemWritableFileStream</a> for <var>entry</var> in <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑧">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm①">relevant realm</a>.</p>
        <li data-md>
@@ -1508,7 +1386,7 @@ modifications to existing large files. <a href="https://github.com/wicg/file-sys
           <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer">[[buffer]]</a> to a copy of <var>entry</var>’s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data②">binary data</a>.</p>
         </ol>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①①">Resolve</a> <var>result</var> with <var>stream</var>.</p>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑧">Resolve</a> <var>result</var> with <var>stream</var>.</p>
       </ol>
      <li data-md>
       <p>Return <var>result</var>.</p>
@@ -1517,31 +1395,30 @@ modifications to existing large files. <a href="https://github.com/wicg/file-sys
    <h4 class="heading settled" data-level="2.4.3" id="api-filesystemfilehandle-createsyncaccesshandle"><span class="secno">2.4.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-createsyncaccesshandle" id="ref-for-dom-filesystemfilehandle-createsyncaccesshandle①">createSyncAccessHandle()</a></code> method</span><a class="self-link" href="#api-filesystemfilehandle-createsyncaccesshandle"></a></h4>
    <div class="note domintro" role="note">
     <dl>
-     <dt data-md><var>handle</var> = await <var>fileHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-createsyncaccesshandle" id="ref-for-dom-filesystemfilehandle-createsyncaccesshandle②">createSyncAccessHandle</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandlecreateaccesshandleoptions-mode" id="ref-for-dom-filesystemfilehandlecreateaccesshandleoptions-mode">mode</a></code>: "in-place" })
+     <dt data-md><var>handle</var> = await <var>fileHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-createsyncaccesshandle" id="ref-for-dom-filesystemfilehandle-createsyncaccesshandle②">createSyncAccessHandle</a></code>()
      <dd data-md>
       <p>Returns a <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle③">FileSystemSyncAccessHandle</a></code> that can be used to read/write from/to the file.
  Changes made through <var>handle</var> might be immediately reflected in the file represented by <var>fileHandle</var>.
  To ensure the changes are reflected in this file, the handle must be flushed or closed.</p>
       <p>Creating a <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle④">FileSystemSyncAccessHandle</a></code> <a data-link-type="dfn" href="#file-entry-lock-take" id="ref-for-file-entry-lock-take②">takes an exclusive lock</a> on the <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①②">entry</a> associated with <var>fileHandle</var>. This prevents the creation of
-further <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑤">FileSystemSyncAccessHandles</a></code> or <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream④">FileSystemWritableFileStreams</a></code> for the entry, until the access handle is closed.</p>
-      <p>The returned <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑥">FileSystemSyncAccessHandle</a></code> offers synchronous <code class="idl"><a data-link-type="idl">read()</a></code> and <code class="idl"><a data-link-type="idl">write()</a></code> methods. This allows for higher performance for critical methods on
+further <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑤">FileSystemSyncAccessHandle</a></code>s or <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream④">FileSystemWritableFileStream</a></code>s
+for the entry, until the access handle is closed.</p>
+      <p>The returned <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑥">FileSystemSyncAccessHandle</a></code> offers synchronous <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read">read()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write">write()</a></code> methods. This allows for higher performance for critical methods on
 contexts where asynchronous operations come with high overhead, i.e., WebAssembly.</p>
-      <p>For the time being, this method will only succeed when the <var>fileHandle</var> belongs to the <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system①">origin private file system</a>. Also temporarily, the <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandlecreateaccesshandleoptions-mode" id="ref-for-dom-filesystemfilehandlecreateaccesshandleoptions-mode①">mode</a></code> parameter
-must be set to "in-place". This prevents us from setting a default behavior and allows us to bring access handles to
-other filesytems in the future.</p>
+      <p>For the time being, this method will only succeed when the <var>fileHandle</var> belongs to the <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system①">origin private file system</a>.</p>
     </dl>
    </div>
-   <div class="algorithm" data-algorithm="createSyncAccessHandle(options)" data-algorithm-for="FileSystemFileHandle">
-     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemFileHandle" data-dfn-type="method" data-export id="dom-filesystemfilehandle-createsyncaccesshandle"><code>createSyncAccessHandle(<var>options</var>)</code></dfn> method, when invoked, must run these steps: 
+   <div class="algorithm" data-algorithm="createSyncAccessHandle()" data-algorithm-for="FileSystemFileHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemFileHandle" data-dfn-type="method" data-export id="dom-filesystemfilehandle-createsyncaccesshandle"><code>createSyncAccessHandle()</code></dfn> method, when invoked, must run these steps: 
     <ol>
      <li data-md>
-      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑦">a new promise</a>.</p>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑥">a new promise</a>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑦">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑥">in parallel</a>:</p>
       <ol>
        <li data-md>
         <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#requesting-file-system-permission" id="ref-for-requesting-file-system-permission②">requesting file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑨">this</a></b> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite⑥">"readwrite"</a></code>.
- If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑤">reject</a> <var>result</var> with that exception and abort.</p>
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③">reject</a> <var>result</var> with that exception and abort.</p>
        <li data-md>
         <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted④">"granted"</a></code>,
  reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror②">NotAllowedError</a></code> and abort.</p>
@@ -1551,35 +1428,19 @@ other filesytems in the future.</p>
         <p>If <var>entry</var> does not represent an <a data-link-type="dfn" href="#entry" id="ref-for-entry①③">entry</a> in an <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system②">origin private file system</a>,
  reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code> and abort.</p>
        <li data-md>
-        <p>Let <var>lockValue</var> be "exclusive".</p>
+        <p>Let <var>lockResult</var> be the result of <a data-link-type="dfn" href="#file-entry-lock-take" id="ref-for-file-entry-lock-take③">taking a lock</a> with  "<code>exclusive</code>" on <var>entry</var>.</p>
        <li data-md>
-        <p>Let <var>lockResult</var> be the result of <a data-link-type="dfn" href="#file-entry-lock-take" id="ref-for-file-entry-lock-take③">taking a lock</a> with <var>lockValue</var> on <var>entry</var>.
- If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑥">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#nomodificationallowederror" id="ref-for-nomodificationallowederror①">NoModificationAllowedError</a></code> and abort.</p>
+        <p>If <var>lockResult</var> is <code>false</code>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject④">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#nomodificationallowederror" id="ref-for-nomodificationallowederror①">NoModificationAllowedError</a></code> and abort.</p>
        <li data-md>
         <p>Let <var>handle</var> be the result of <a data-link-type="dfn" href="#create-a-new-filesystemsyncaccesshandle" id="ref-for-create-a-new-filesystemsyncaccesshandle">creating a new FileSystemSyncAccessHandle</a> for <var>entry</var> in <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①①">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm②">relevant realm</a>.</p>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①②">Resolve</a> <var>result</var> with <var>handle</var>.</p>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑨">Resolve</a> <var>result</var> with <var>handle</var>.</p>
       </ol>
      <li data-md>
       <p>Return <var>result</var>.</p>
     </ol>
    </div>
    <h3 class="heading settled" data-level="2.5" id="api-filesystemdirectoryhandle"><span class="secno">2.5. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①">FileSystemDirectoryHandle</a></code> interface</span><a class="self-link" href="#api-filesystemdirectoryhandle"></a></h3>
-   <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><span>MDN</span></button>
-    <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle" title="The FileSystemDirectoryHandle interface of the File System Access API provides a handle to a file system directory. The interface is accessed via the window.showDirectoryPicker() method.">FileSystemDirectoryHandle</a></p>
-     <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-      <hr>
-      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-      <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-      <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-     </div>
-    </div>
-   </div>
 <pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystemgetfileoptions"><code><c- g>FileSystemGetFileOptions</c-></code></dfn> {
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean②"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-default="false" data-dfn-for="FileSystemGetFileOptions" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-filesystemgetfileoptions-create"><code><c- g>create</c-></code></dfn> = <c- b>false</c->;
 };
@@ -1644,7 +1505,7 @@ support for example recursive iteration. <a href="https://github.com/wicg/file-s
      To <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result" id="ref-for-dfn-get-the-next-iteration-result">get the next iteration result</a> for a <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle⑥">FileSystemDirectoryHandle</a></code> <var>handle</var> and its async iterator <var>iterator</var>: 
     <ol>
      <li data-md>
-      <p>Let <var>promise</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑧">a new promise</a>.</p>
+      <p>Let <var>promise</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑦">a new promise</a>.</p>
      <li data-md>
       <p>Let <var>directory</var> be <var>handle</var>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①⑤">entry</a>.</p>
      <li data-md>
@@ -1664,7 +1525,7 @@ support for example recursive iteration. <a href="https://github.com/wicg/file-s
       <p>If <var>child</var> is <code>null</code>, then:</p>
       <ol>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①③">Resolve</a> <var>promise</var> with <code>undefined</code>.</p>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⓪">Resolve</a> <var>promise</var> with <code>undefined</code>.</p>
       </ol>
      <li data-md>
       <p>Otherwise:</p>
@@ -1672,7 +1533,7 @@ support for example recursive iteration. <a href="https://github.com/wicg/file-s
        <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>child</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name⑥">name</a> to <var>iterator</var>’s <a data-link-type="dfn" href="#filesystemdirectoryhandle-iterator-past-results" id="ref-for-filesystemdirectoryhandle-iterator-past-results①">past results</a>.</p>
        <li data-md>
-        <p>If <var>child</var> is a <a data-link-type="dfn" href="#file" id="ref-for-file④">file entry</a>:</p>
+        <p>If <var>child</var> is a <a data-link-type="dfn" href="#file" id="ref-for-file⑥">file entry</a>:</p>
         <ol>
          <li data-md>
           <p>Let <var>result</var> be a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle⑤">FileSystemFileHandle</a></code> associated with <var>child</var>.</p>
@@ -1684,28 +1545,13 @@ support for example recursive iteration. <a href="https://github.com/wicg/file-s
           <p>Let <var>result</var> be a new <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle⑦">FileSystemDirectoryHandle</a></code> associated with <var>child</var>.</p>
         </ol>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①④">Resolve</a> <var>promise</var> with (<var>child</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name⑦">name</a>, <var>result</var>).</p>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①①">Resolve</a> <var>promise</var> with (<var>child</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name⑦">name</a>, <var>result</var>).</p>
       </ol>
      <li data-md>
       <p>Return <var>promise</var>.</p>
     </ol>
    </div>
    <h4 class="heading settled" data-level="2.5.2" id="api-filesystemdirectoryhandle-getfilehandle"><span class="secno">2.5.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-getfilehandle" id="ref-for-dom-filesystemdirectoryhandle-getfilehandle①">getFileHandle()</a></code> method</span><a class="self-link" href="#api-filesystemdirectoryhandle-getfilehandle"></a></h4>
-   <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><span>MDN</span></button>
-    <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/getFileHandle" title="The getFileHandle() method of the FileSystemDirectoryHandle interface returns a FileSystemFileHandle for a file with the specified name, within the directory the method is called.">FileSystemDirectoryHandle/getFileHandle</a></p>
-     <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-      <hr>
-      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-      <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-      <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-     </div>
-    </div>
-   </div>
    <div class="note domintro" role="note">
     <dl>
      <dt data-md><var>fileHandle</var> = await <var>directoryHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-getfilehandle" id="ref-for-dom-filesystemdirectoryhandle-getfilehandle②">getFileHandle</a></code>(<var>name</var>)
@@ -1731,12 +1577,12 @@ support for example recursive iteration. <a href="https://github.com/wicg/file-s
 must run these steps: 
     <ol>
      <li data-md>
-      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑨">a new promise</a>.</p>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑧">a new promise</a>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑧">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑦">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>If <var>name</var> is not a <a data-link-type="dfn" href="#valid-file-name" id="ref-for-valid-file-name①">valid file name</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑦">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror">TypeError</a></code> and abort.</p>
+        <p>If <var>name</var> is not a <a data-link-type="dfn" href="#valid-file-name" id="ref-for-valid-file-name①">valid file name</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑤">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror">TypeError</a></code> and abort.</p>
        <li data-md>
         <p>Let <var>entry</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①②">this</a></b>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①⑥">entry</a>.</p>
        <li data-md>
@@ -1744,7 +1590,7 @@ must run these steps:
         <ol>
          <li data-md>
           <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#requesting-file-system-permission" id="ref-for-requesting-file-system-permission③">requesting file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①③">this</a></b> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite⑦">"readwrite"</a></code>.
- If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑧">reject</a> <var>result</var> with that exception and abort.</p>
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑥">reject</a> <var>result</var> with that exception and abort.</p>
         </ol>
        <li data-md>
         <p>Otherwise:</p>
@@ -1765,20 +1611,20 @@ must run these steps:
             <p>If <var>child</var> is a <a data-link-type="dfn" href="#directory" id="ref-for-directory⑤">directory entry</a>:</p>
             <ol>
              <li data-md>
-              <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑨">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#typemismatcherror" id="ref-for-typemismatcherror">TypeMismatchError</a></code> and abort.</p>
+              <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑦">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#typemismatcherror" id="ref-for-typemismatcherror">TypeMismatchError</a></code> and abort.</p>
             </ol>
            <li data-md>
-            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑤">Resolve</a> <var>result</var> with a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle⑥">FileSystemFileHandle</a></code> whose <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①⑦">entry</a> is <var>child</var> and abort.</p>
+            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①②">Resolve</a> <var>result</var> with a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle⑥">FileSystemFileHandle</a></code> whose <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①⑦">entry</a> is <var>child</var> and abort.</p>
           </ol>
         </ol>
        <li data-md>
         <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemgetfileoptions-create" id="ref-for-dom-filesystemgetfileoptions-create④">create</a></code> is <code>false</code>:</p>
         <ol>
          <li data-md>
-          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⓪">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notfounderror" id="ref-for-notfounderror">NotFoundError</a></code> and abort.</p>
+          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑧">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notfounderror" id="ref-for-notfounderror">NotFoundError</a></code> and abort.</p>
         </ol>
        <li data-md>
-        <p>Let <var>child</var> be a new <a data-link-type="dfn" href="#file" id="ref-for-file⑤">file entry</a>.</p>
+        <p>Let <var>child</var> be a new <a data-link-type="dfn" href="#file" id="ref-for-file⑦">file entry</a>.</p>
        <li data-md>
         <p>Set <var>child</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name⑨">name</a> to <var>name</var>.</p>
        <li data-md>
@@ -1788,31 +1634,16 @@ must run these steps:
        <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append①">Append</a> <var>child</var> to <var>entry</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children⑤">children</a>.</p>
        <li data-md>
-        <p>If creating <var>child</var> in the underlying file system throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①①">reject</a> <var>result</var> with that exception and abort.</p>
+        <p>If creating <var>child</var> in the underlying file system throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑨">reject</a> <var>result</var> with that exception and abort.</p>
         <p class="issue" id="issue-721a33e4"><a class="self-link" href="#issue-721a33e4"></a> Better specify what possible exceptions this could throw. <a href="https://github.com/wicg/file-system-access/issues/68">[Issue #68]</a></p>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑥">Resolve</a> <var>result</var> with a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle⑦">FileSystemFileHandle</a></code> whose <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①⑧">entry</a> is <var>child</var>.</p>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①③">Resolve</a> <var>result</var> with a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle⑦">FileSystemFileHandle</a></code> whose <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①⑧">entry</a> is <var>child</var>.</p>
       </ol>
      <li data-md>
       <p>Return <var>result</var>.</p>
     </ol>
    </div>
    <h4 class="heading settled" data-level="2.5.3" id="api-filesystemdirectoryhandle-getdirectoryhandle"><span class="secno">2.5.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-getdirectoryhandle" id="ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle①">getDirectoryHandle()</a></code> method</span><a class="self-link" href="#api-filesystemdirectoryhandle-getdirectoryhandle"></a></h4>
-   <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><span>MDN</span></button>
-    <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/getDirectoryHandle" title="The getDirectoryHandle() method of the FileSystemDirectoryHandle interface returns a FileSystemDirectoryHandle for a subdirectory with the specified name within the directory handle on which the method is called.">FileSystemDirectoryHandle/getDirectoryHandle</a></p>
-     <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-      <hr>
-      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-      <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-      <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-     </div>
-    </div>
-   </div>
    <div class="note domintro" role="note">
     <dl>
      <dt data-md><var>subdirHandle</var> = await <var>directoryHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-getdirectoryhandle" id="ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle②">getDirectoryHandle</a></code>(<var>name</var>)
@@ -1836,12 +1667,12 @@ must run these steps:
 invoked, must run these steps: 
     <ol>
      <li data-md>
-      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⓪">a new promise</a>.</p>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑨">a new promise</a>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑨">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑧">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>If <var>name</var> is not a <a data-link-type="dfn" href="#valid-file-name" id="ref-for-valid-file-name②">valid file name</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①②">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①">TypeError</a></code> and abort.</p>
+        <p>If <var>name</var> is not a <a data-link-type="dfn" href="#valid-file-name" id="ref-for-valid-file-name②">valid file name</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⓪">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①">TypeError</a></code> and abort.</p>
        <li data-md>
         <p>Let <var>entry</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑤">this</a></b>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①⑨">entry</a>.</p>
        <li data-md>
@@ -1849,7 +1680,7 @@ invoked, must run these steps:
         <ol>
          <li data-md>
           <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#requesting-file-system-permission" id="ref-for-requesting-file-system-permission④">requesting file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑥">this</a></b> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite⑧">"readwrite"</a></code>.
- If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①③">reject</a> <var>result</var> with that exception and abort.</p>
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①①">reject</a> <var>result</var> with that exception and abort.</p>
         </ol>
        <li data-md>
         <p>Otherwise:</p>
@@ -1867,20 +1698,20 @@ invoked, must run these steps:
           <p>If <var>child</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name①⓪">name</a> equals <var>name</var>:</p>
           <ol>
            <li data-md>
-            <p>If <var>child</var> is a <a data-link-type="dfn" href="#file" id="ref-for-file⑥">file entry</a>:</p>
+            <p>If <var>child</var> is a <a data-link-type="dfn" href="#file" id="ref-for-file⑧">file entry</a>:</p>
             <ol>
              <li data-md>
-              <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①④">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#typemismatcherror" id="ref-for-typemismatcherror①">TypeMismatchError</a></code> and abort.</p>
+              <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①②">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#typemismatcherror" id="ref-for-typemismatcherror①">TypeMismatchError</a></code> and abort.</p>
             </ol>
            <li data-md>
-            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑦">Resolve</a> <var>result</var> with a new <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle⑧">FileSystemDirectoryHandle</a></code> whose <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②⓪">entry</a> is <var>child</var> and abort.</p>
+            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①④">Resolve</a> <var>result</var> with a new <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle⑧">FileSystemDirectoryHandle</a></code> whose <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②⓪">entry</a> is <var>child</var> and abort.</p>
           </ol>
         </ol>
        <li data-md>
         <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemgetfileoptions-create" id="ref-for-dom-filesystemgetfileoptions-create⑤">create</a></code> is <code>false</code>:</p>
         <ol>
          <li data-md>
-          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑤">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notfounderror" id="ref-for-notfounderror①">NotFoundError</a></code> and abort.</p>
+          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①③">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notfounderror" id="ref-for-notfounderror①">NotFoundError</a></code> and abort.</p>
         </ol>
        <li data-md>
         <p>Let <var>child</var> be a new <a data-link-type="dfn" href="#directory" id="ref-for-directory⑥">directory entry</a>.</p>
@@ -1891,31 +1722,16 @@ invoked, must run these steps:
        <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append②">Append</a> <var>child</var> to <var>entry</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children⑧">children</a>.</p>
        <li data-md>
-        <p>If creating <var>child</var> in the underlying file system throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑥">reject</a> <var>result</var> with that exception and abort.</p>
+        <p>If creating <var>child</var> in the underlying file system throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①④">reject</a> <var>result</var> with that exception and abort.</p>
         <p class="issue" id="issue-721a33e4①"><a class="self-link" href="#issue-721a33e4①"></a> Better specify what possible exceptions this could throw. <a href="https://github.com/wicg/file-system-access/issues/68">[Issue #68]</a></p>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑧">Resolve</a> <var>result</var> with a new <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle⑨">FileSystemDirectoryHandle</a></code> whose <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②①">entry</a> is <var>child</var>.</p>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑤">Resolve</a> <var>result</var> with a new <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle⑨">FileSystemDirectoryHandle</a></code> whose <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②①">entry</a> is <var>child</var>.</p>
       </ol>
      <li data-md>
       <p>Return <var>result</var>.</p>
     </ol>
    </div>
    <h4 class="heading settled" data-level="2.5.4" id="api-filesystemdirectoryhandle-removeentry"><span class="secno">2.5.4. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-removeentry" id="ref-for-dom-filesystemdirectoryhandle-removeentry①">removeEntry()</a></code> method</span><a class="self-link" href="#api-filesystemdirectoryhandle-removeentry"></a></h4>
-   <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><span>MDN</span></button>
-    <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/removeEntry" title="The removeEntry() method of the FileSystemDirectoryHandle interface attempts to remove an entry if the directory handle contains a file or directory called the name specified.">FileSystemDirectoryHandle/removeEntry</a></p>
-     <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-      <hr>
-      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-      <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-      <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-     </div>
-    </div>
-   </div>
    <div class="note domintro" role="note">
     <dl>
      <dt data-md>await <var>directoryHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-removeentry" id="ref-for-dom-filesystemdirectoryhandle-removeentry②">removeEntry</a></code>(<var>name</var>)
@@ -1938,17 +1754,17 @@ invoked, must run these steps:
 these steps: 
     <ol>
      <li data-md>
-      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①①">a new promise</a>.</p>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⓪">a new promise</a>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⓪">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑨">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>If <var>name</var> is not a <a data-link-type="dfn" href="#valid-file-name" id="ref-for-valid-file-name③">valid file name</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑦">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror②">TypeError</a></code> and abort.</p>
+        <p>If <var>name</var> is not a <a data-link-type="dfn" href="#valid-file-name" id="ref-for-valid-file-name③">valid file name</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑤">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror②">TypeError</a></code> and abort.</p>
        <li data-md>
         <p>Let <var>entry</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑧">this</a></b>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②②">entry</a>.</p>
        <li data-md>
         <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#requesting-file-system-permission" id="ref-for-requesting-file-system-permission⑤">requesting file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑨">this</a></b> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite⑨">"readwrite"</a></code>.
- If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑧">reject</a> <var>result</var> with that exception and abort.</p>
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑥">reject</a> <var>result</var> with that exception and abort.</p>
        <li data-md>
         <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted⑨">"granted"</a></code>,
  reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑦">NotAllowedError</a></code> and abort.</p>
@@ -1965,44 +1781,29 @@ these steps:
               <p>If <var>child</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children①⓪">children</a> is not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">empty</a> and <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemremoveoptions-recursive" id="ref-for-dom-filesystemremoveoptions-recursive②">recursive</a></code> is <code>false</code>:</p>
               <ol>
                <li data-md>
-                <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑨">Reject</a> <var>result</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidmodificationerror" id="ref-for-invalidmodificationerror">InvalidModificationError</a></code> and abort.</p>
+                <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑦">Reject</a> <var>result</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidmodificationerror" id="ref-for-invalidmodificationerror">InvalidModificationError</a></code> and abort.</p>
               </ol>
             </ol>
            <li data-md>
             <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove">Remove</a> <var>child</var> from <var>entry</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children①①">children</a>.</p>
            <li data-md>
-            <p>If removing <var>child</var> in the underlying file system throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⓪">reject</a> <var>result</var> with that exception and abort.</p>
+            <p>If removing <var>child</var> in the underlying file system throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑧">reject</a> <var>result</var> with that exception and abort.</p>
             <p class="note" role="note"><span>Note:</span> If <code class="idl"><a data-link-type="idl" href="#dom-filesystemremoveoptions-recursive" id="ref-for-dom-filesystemremoveoptions-recursive③">recursive</a></code> is <code>true</code>, the removal can fail
  non-atomically. Some files or directories might have been removed while other files
  or directories still exist.</p>
             <p class="issue" id="issue-721a33e4②"><a class="self-link" href="#issue-721a33e4②"></a> Better specify what possible exceptions this could throw. <a href="https://github.com/wicg/file-system-access/issues/68">[Issue #68]</a></p>
            <li data-md>
-            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑨">Resolve</a> <var>result</var> with <code>undefined</code>.</p>
+            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑥">Resolve</a> <var>result</var> with <code>undefined</code>.</p>
           </ol>
         </ol>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②①">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notfounderror" id="ref-for-notfounderror②">NotFoundError</a></code>.</p>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑨">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notfounderror" id="ref-for-notfounderror②">NotFoundError</a></code>.</p>
       </ol>
      <li data-md>
       <p>Return <var>result</var>.</p>
     </ol>
    </div>
    <h4 class="heading settled" data-level="2.5.5" id="api-filesystemdirectoryhandle-resolve"><span class="secno">2.5.5. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-resolve" id="ref-for-dom-filesystemdirectoryhandle-resolve①">resolve()</a></code> method</span><a class="self-link" href="#api-filesystemdirectoryhandle-resolve"></a></h4>
-   <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><span>MDN</span></button>
-    <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/resolve" title="The resolve() method of the FileSystemDirectoryHandle interface returns an Array of directory names from the parent handle to the specified child entry, with the name of the child entry as the last array item.">FileSystemDirectoryHandle/resolve</a></p>
-     <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari yes"><span>Safari</span><span>15.2+</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-      <hr>
-      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-      <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-      <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>15.2+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-     </div>
-    </div>
-   </div>
    <div class="note domintro" role="note">
     <dl>
      <dt data-md><var>path</var> = await <var>directory</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-resolve" id="ref-for-dom-filesystemdirectoryhandle-resolve②">resolve</a></code>( <var>child</var> )
@@ -2057,22 +1858,6 @@ these steps:
    <div class="algorithm" data-algorithm="resolve(possibleDescendant)" data-algorithm-for="FileSystemDirectoryHandle"> The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemDirectoryHandle" data-dfn-type="method" data-export id="dom-filesystemdirectoryhandle-resolve"><code>resolve(<var>possibleDescendant</var>)</code></dfn> method,
 when invoked, must return the result of <a data-link-type="dfn" href="#entry-resolve" id="ref-for-entry-resolve①">resolving</a> <var>possibleDescendant</var>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②③">entry</a> relative to <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⓪">this</a>'s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②④">entry</a>. </div>
    <h3 class="heading settled" data-level="2.6" id="api-filesystemwritablefilestream"><span class="secno">2.6. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream⑤">FileSystemWritableFileStream</a></code> interface</span><a class="self-link" href="#api-filesystemwritablefilestream"></a></h3>
-   <div class="mdn-anno wrapped after">
-    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
-    <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream" title="The FileSystemWritableFileStream interface of the File System Access API is a WritableStream object with additional convenience methods, which operates on a single file on disk. The interface is accessed through the FileSystemFileHandle.createWritable() method.">FileSystemWritableFileStream</a></p>
-     <p class="less-than-two-engines-text">In only one current engine.</p>
-     <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-      <hr>
-      <span class="opera no"><span>Opera</span><span>None</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-      <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-      <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>None</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>None</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-     </div>
-    </div>
-   </div>
 <pre class="idl highlight def"><c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-writecommandtype"><code><c- g>WriteCommandType</c-></code></dfn> {
   <dfn class="dfn-paneled idl-code" data-dfn-for="WriteCommandType" data-dfn-type="enum-value" data-export id="dom-writecommandtype-write"><code><c- s>"write"</c-></code></dfn>,
   <dfn class="dfn-paneled idl-code" data-dfn-for="WriteCommandType" data-dfn-type="enum-value" data-export id="dom-writecommandtype-seek"><code><c- s>"seek"</c-></code></dfn>,
@@ -2095,7 +1880,7 @@ when invoked, must return the result of <a data-link-type="dfn" href="#entry-res
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①②"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined③"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemwritablefilestream-truncate" id="ref-for-dom-filesystemwritablefilestream-truncate"><c- g>truncate</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long③"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemWritableFileStream/truncate(size)" data-dfn-type="argument" data-export id="dom-filesystemwritablefilestream-truncate-size-size"><code><c- g>size</c-></code><a class="self-link" href="#dom-filesystemwritablefilestream-truncate-size-size"></a></dfn>);
 };
 </pre>
-   <p>A <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream⑥">FileSystemWritableFileStream</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="FileSystemWritableFileStream" data-dfn-type="dfn" data-noexport id="filesystemwritablefilestream-file">[[file]]</dfn> (a <a data-link-type="dfn" href="#file" id="ref-for-file⑦">file entry</a>).</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream⑥">FileSystemWritableFileStream</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="FileSystemWritableFileStream" data-dfn-type="dfn" data-noexport id="filesystemwritablefilestream-file">[[file]]</dfn> (a <a data-link-type="dfn" href="#file" id="ref-for-file⑨">file entry</a>).</p>
    <p>A <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream⑦">FileSystemWritableFileStream</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="FileSystemWritableFileStream" data-dfn-type="dfn" data-noexport id="filesystemwritablefilestream-buffer">[[buffer]]</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence②">byte sequence</a>).
 It is initially empty.</p>
    <p class="note" role="note"><span>Note:</span> This buffer can get arbitrarily large, so it is expected that implementations will not keep this in memory,
@@ -2115,7 +1900,7 @@ When using <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritab
     <p><code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-get-writer" id="ref-for-ws-get-writer">getWriter()</a></code> returns an instance of <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter" id="ref-for-writablestreamdefaultwriter">WritableStreamDefaultWriter</a></code>.</p>
    </div>
    <div class="algorithm" data-algorithm="create a new FileSystemWritableFileStream">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="create-a-new-filesystemwritablefilestream">create a new FileSystemWritableFileStream</dfn> given a <a data-link-type="dfn" href="#file" id="ref-for-file⑧">file entry</a> <var>file</var> in a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#realm" id="ref-for-realm">Realm</a> <var>realm</var>, perform the following steps: 
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="create-a-new-filesystemwritablefilestream">create a new FileSystemWritableFileStream</dfn> given a <a data-link-type="dfn" href="#file" id="ref-for-file①⓪">file entry</a> <var>file</var> in a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#realm" id="ref-for-realm">Realm</a> <var>realm</var>, perform the following steps: 
     <ol>
      <li data-md>
       <p>Let <var>stream</var> be a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new">new</a> <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream①②">FileSystemWritableFileStream</a></code> in <var>realm</var>.</p>
@@ -2128,28 +1913,28 @@ When using <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritab
       <p>Let <var>closeAlgorithm</var> be the following steps:</p>
       <ol>
        <li data-md>
-        <p>Let <var>closeResult</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①②">a new promise</a>.</p>
+        <p>Let <var>closeResult</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①①">a new promise</a>.</p>
        <li data-md>
-        <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①①">in parallel</a>:</p>
+        <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⓪">in parallel</a>:</p>
         <ol>
          <li data-md>
-          <p>Let <var>permissionStatus</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state⑦">permission state</a> for a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor⑤">FileSystemPermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑧">handle</a></code> representing <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file①">[[file]]</a>,
+          <p>Let <var>permissionStatus</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state⑦">permission state</a> for a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor⑤">FileSystemPermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑧">handle</a></code> representing <var>stream</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file">[[file]]</a>,
  and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode⑥">mode</a></code> = <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite①⓪">"readwrite"</a></code>.</p>
          <li data-md>
           <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①⓪">"granted"</a></code>,
  reject <var>closeResult</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑧">NotAllowedError</a></code> and abort.</p>
          <li data-md>
           <p>Perform user agent-specific <a data-link-type="dfn" href="#wellknowndirectory-malware-scans-and-safe-browsing-checks" id="ref-for-wellknowndirectory-malware-scans-and-safe-browsing-checks">malware scans and safe browsing checks</a>.
- If these checks fail, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②②">reject</a> <var>closeResult</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror">AbortError</a></code> and abort.</p>
+ If these checks fail, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⓪">reject</a> <var>closeResult</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror">AbortError</a></code> and abort.</p>
          <li data-md>
-          <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data④">binary data</a> to <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①">[[buffer]]</a>.
- If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②③">reject</a> <var>closeResult</var> with that exception and abort.</p>
+          <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file①">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data④">binary data</a> to <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①">[[buffer]]</a>.
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②①">reject</a> <var>closeResult</var> with that exception and abort.</p>
           <p class="note" role="note"><span>Note:</span> It is expected that this atomically updates the contents of the file on disk
  being written to.</p>
          <li data-md>
-          <p><a data-link-type="dfn" href="#file-entry-lock-release" id="ref-for-file-entry-lock-release">Release the lock</a> on <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file②">[[file]]</a>.</p>
+          <p><a data-link-type="dfn" href="#file-entry-lock-release" id="ref-for-file-entry-lock-release">Release the lock</a> on <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file①">[[file]]</a>.</p>
          <li data-md>
-          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⓪">Resolve</a> <var>closeResult</var> with <code>undefined</code>.</p>
+          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑦">Resolve</a> <var>closeResult</var> with <code>undefined</code>.</p>
         </ol>
        <li data-md>
         <p>Return <var>closeResult</var>.</p>
@@ -2158,7 +1943,7 @@ When using <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritab
       <p>Let <var>abortAlgorithm</var> be the following step:</p>
       <ol>
        <li data-md>
-        <p><a data-link-type="dfn" href="#file-entry-lock-release" id="ref-for-file-entry-lock-release①">Release the lock</a> on <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file③">[[file]]</a>.</p>
+        <p><a data-link-type="dfn" href="#file-entry-lock-release" id="ref-for-file-entry-lock-release①">Release the lock</a> on <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file②">[[file]]</a>.</p>
       </ol>
      <li data-md>
       <p>Let <var>highWaterMark</var> be 1.</p>
@@ -2179,12 +1964,12 @@ runs these steps:
       <p>Let <var>input</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#javascript-string-convert" id="ref-for-javascript-string-convert">converting</a> <var>chunk</var> to a <code class="idl"><a data-link-type="idl" href="#typedefdef-filesystemwritechunktype" id="ref-for-typedefdef-filesystemwritechunktype①">FileSystemWriteChunkType</a></code>.
  If this throws an exception, then return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with">a promise rejected with</a> that exception.</p>
      <li data-md>
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①③">a new promise</a>.</p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①②">a new promise</a>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①②">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①①">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>permissionStatus</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state⑧">permission state</a> for a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor⑥">FileSystemPermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑨">handle</a></code> representing <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file④">[[file]]</a>,
+        <p>Let <var>permissionStatus</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state⑧">permission state</a> for a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor⑥">FileSystemPermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑨">handle</a></code> representing <var>stream</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file②">[[file]]</a>,
   and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode⑦">mode</a></code> = <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite①①">"readwrite"</a></code>.</p>
        <li data-md>
         <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①①">"granted"</a></code>,
@@ -2216,7 +2001,7 @@ runs these steps:
           <ol>
            <li data-md>
             <p>Let <var>dataBytes</var> be the result of performing the <a data-link-type="dfn" href="https://w3c.github.io/FileAPI/#readOperation" id="ref-for-readOperation">read operation</a> on <var>data</var>.
-  If this throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②④">reject</a> <var>p</var> with that exception and abort.</p>
+  If this throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②②">reject</a> <var>p</var> with that exception and abort.</p>
           </ol>
          <li data-md>
           <p>Else:</p>
@@ -2247,7 +2032,7 @@ runs these steps:
           <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer⑥">[[buffer]]</a> to the concatenation of <var>head</var>, <var>data</var> and <var>tail</var>.</p>
          <li data-md>
           <p>If the operations modifying <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer⑦">[[buffer]]</a> in the previous steps failed
- due to exceeding the <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota">storage quota</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑤">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror">QuotaExceededError</a></code> and abort,
+ due to exceeding the <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota">storage quota</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②③">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror">QuotaExceededError</a></code> and abort,
  leaving <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer⑧">[[buffer]]</a> unmodified.</p>
           <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota①">Storage quota</a> only applies to files stored in the <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system③">origin private file system</a>.
  However this operation could still fail for other files, for example if the disk being written
@@ -2255,23 +2040,23 @@ runs these steps:
          <li data-md>
           <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-seekoffset" id="ref-for-filesystemwritablefilestream-seekoffset①">[[seekOffset]]</a> to <var>writePosition</var> + <var>data</var>.<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length③">length</a>.</p>
          <li data-md>
-          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②①">Resolve</a> <var>p</var>.</p>
+          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑧">Resolve</a> <var>p</var>.</p>
         </ol>
        <li data-md>
         <p>Else if <var>command</var> is <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-seek" id="ref-for-dom-writecommandtype-seek">"seek"</a></code>:</p>
         <ol>
          <li data-md>
-          <p>If <var>chunk</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-position" id="ref-for-dom-writeparams-position②">position</a></code> is <code>undefined</code>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑥">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror④">TypeError</a></code> and abort.</p>
+          <p>If <var>chunk</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-position" id="ref-for-dom-writeparams-position②">position</a></code> is <code>undefined</code>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②④">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror④">TypeError</a></code> and abort.</p>
          <li data-md>
           <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-seekoffset" id="ref-for-filesystemwritablefilestream-seekoffset②">[[seekOffset]]</a> to <var>chunk</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-position" id="ref-for-dom-writeparams-position③">position</a></code>.</p>
          <li data-md>
-          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②②">Resolve</a> <var>p</var>.</p>
+          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑨">Resolve</a> <var>p</var>.</p>
         </ol>
        <li data-md>
         <p>Else if <var>command</var> is <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-truncate" id="ref-for-dom-writecommandtype-truncate">"truncate"</a></code>:</p>
         <ol>
          <li data-md>
-          <p>If <var>chunk</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-size" id="ref-for-dom-writeparams-size">size</a></code> is <code>undefined</code>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑦">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror⑤">TypeError</a></code> and abort.</p>
+          <p>If <var>chunk</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-size" id="ref-for-dom-writeparams-size">size</a></code> is <code>undefined</code>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑤">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror⑤">TypeError</a></code> and abort.</p>
          <li data-md>
           <p>Let <var>newSize</var> be <var>chunk</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-size" id="ref-for-dom-writeparams-size①">size</a></code>.</p>
          <li data-md>
@@ -2282,7 +2067,7 @@ runs these steps:
            <li data-md>
             <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①⓪">[[buffer]]</a> to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑥">byte sequence</a> formed by concating <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①①">[[buffer]]</a> with a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑦">byte sequence</a> containing <var>newSize</var>-<var>oldSize</var> <code>0x00</code> bytes.</p>
            <li data-md>
-            <p>If the operation in the previous step failed due to exceeding the <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota②">storage quota</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑧">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror①">QuotaExceededError</a></code> and abort,
+            <p>If the operation in the previous step failed due to exceeding the <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota②">storage quota</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑥">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror①">QuotaExceededError</a></code> and abort,
   leaving <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①②">[[buffer]]</a> unmodified.</p>
             <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota③">Storage quota</a> only applies to files stored in the <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system④">origin private file system</a>.
   However this operation could still fail for other files, for example if the disk being written
@@ -2299,7 +2084,7 @@ runs these steps:
           <p>If <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-seekoffset" id="ref-for-filesystemwritablefilestream-seekoffset③">[[seekOffset]]</a> is bigger than <var>newSize</var>,
  set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-seekoffset" id="ref-for-filesystemwritablefilestream-seekoffset④">[[seekOffset]]</a> to <var>newSize</var>.</p>
          <li data-md>
-          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②③">Resolve</a> <var>p</var>.</p>
+          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⓪">Resolve</a> <var>p</var>.</p>
         </ol>
       </ol>
      <li data-md>
@@ -2336,22 +2121,6 @@ runs these steps:
  Changes are typically written to a temporary file instead.</p>
     </dl>
    </div>
-   <div class="mdn-anno wrapped">
-    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
-    <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/write" title="The write() method of the FileSystemWritableFileStream interface writes content into the file the method is called on, at the current file cursor offset.">FileSystemWritableFileStream/write</a></p>
-     <p class="less-than-two-engines-text">In only one current engine.</p>
-     <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-      <hr>
-      <span class="opera no"><span>Opera</span><span>None</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-      <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-      <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>None</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>None</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-     </div>
-    </div>
-   </div>
    <div class="algorithm" data-algorithm="write(data)" data-algorithm-for="FileSystemWritableFileStream">
      The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemWritableFileStream" data-dfn-type="method" data-export id="dom-filesystemwritablefilestream-write"><code>write(<var>data</var>)</code></dfn> method, when invoked, must run
 these steps: 
@@ -2373,22 +2142,6 @@ these steps:
      <dd data-md>
       <p>Updates the current file cursor offset the <var>position</var> bytes from the top of the file.</p>
     </dl>
-   </div>
-   <div class="mdn-anno wrapped">
-    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
-    <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/seek" title="The seek() method of the FileSystemWritableFileStream interface updates the current file cursor offset to the position (in bytes) specified when calling the method.">FileSystemWritableFileStream/seek</a></p>
-     <p class="less-than-two-engines-text">In only one current engine.</p>
-     <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-      <hr>
-      <span class="opera no"><span>Opera</span><span>None</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-      <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-      <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>None</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>None</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-     </div>
-    </div>
    </div>
    <div class="algorithm" data-algorithm="seek(position)" data-algorithm-for="FileSystemWritableFileStream">
      The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemWritableFileStream" data-dfn-type="method" data-export id="dom-filesystemwritablefilestream-seek"><code>seek(<var>position</var>)</code></dfn> method, when invoked, must run these
@@ -2418,22 +2171,6 @@ steps:
       <p>No changes are written to the actual file until on disk until the stream has been closed.
  Changes are typically written to a temporary file instead.</p>
     </dl>
-   </div>
-   <div class="mdn-anno wrapped">
-    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
-    <div class="feature">
-     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/truncate" title="The truncate() method of the FileSystemWritableFileStream interface resizes the file associated with the stream to be the specified size in bytes.">FileSystemWritableFileStream/truncate</a></p>
-     <p class="less-than-two-engines-text">In only one current engine.</p>
-     <div class="support">
-      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
-      <hr>
-      <span class="opera no"><span>Opera</span><span>None</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
-      <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-      <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>None</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>None</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
-     </div>
-    </div>
    </div>
    <div class="algorithm" data-algorithm="truncate(size)" data-algorithm-for="FileSystemWritableFileStream">
      The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemWritableFileStream" data-dfn-type="method" data-export id="dom-filesystemwritablefilestream-truncate"><code>truncate(<var>size</var>)</code></dfn> method, when invoked, must run these
@@ -2469,9 +2206,9 @@ steps:
 };
 
 </pre>
-   <p>A <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑧">FileSystemSyncAccessHandle</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="dfn" data-noexport id="filesystemsyncaccesshandle-file">[[file]]</dfn> (a <a data-link-type="dfn" href="#file" id="ref-for-file⑨">file entry</a>).</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑧">FileSystemSyncAccessHandle</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="dfn" data-noexport id="filesystemsyncaccesshandle-file">[[file]]</dfn> (a <a data-link-type="dfn" href="#file" id="ref-for-file①①">file entry</a>).</p>
    <p>A <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑨">FileSystemSyncAccessHandle</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="dfn" data-noexport id="filesystemsyncaccesshandle-state">[[state]]</dfn>,
-a string that may exclusively be "open" or "closed".</p>
+a string that may exclusively be "<code>open</code>" or "<code>closed</code>".</p>
    <div class="note domintro" role="note">
     <p>A <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle①⓪">FileSystemSyncAccessHandle</a></code> is an object that is capable of reading/writing from/to,
 as well as obtaining and changing the size of, a single file.</p>
@@ -2480,22 +2217,22 @@ This allows for higher performance for critical methods on contexts where asynch
 operations come with high overhead, i.e., WebAssembly.</p>
    </div>
    <div class="algorithm" data-algorithm="create a new FileSystemSyncAccessHandle">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="create-a-new-filesystemsyncaccesshandle">create a new FileSystemSyncAccessHandle</dfn> given a <a data-link-type="dfn" href="#file" id="ref-for-file①⓪">file entry</a> <var>file</var> in a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#realm" id="ref-for-realm①">Realm</a> <var>realm</var>, perform the following steps: 
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="create-a-new-filesystemsyncaccesshandle">create a new FileSystemSyncAccessHandle</dfn> given a <a data-link-type="dfn" href="#file" id="ref-for-file①②">file entry</a> <var>file</var> in a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#realm" id="ref-for-realm①">Realm</a> <var>realm</var>, perform the following steps: 
     <ol>
      <li data-md>
       <p>Let <var>handle</var> be a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new①">new</a> <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle①①">FileSystemSyncAccessHandle</a></code> in <var>realm</var>.</p>
      <li data-md>
-      <p>Set <var>handle</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file①">[[file]]</a> to <var>file</var>.</p>
+      <p>Set <var>handle</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file③">[[file]]</a> to <var>file</var>.</p>
      <li data-md>
-      <p>Set <var>handle</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state">[[state]]</a> to "open".</p>
+      <p>Set <var>handle</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state">[[state]]</a> to "<code>open</code>".</p>
      <li data-md>
       <p>Return <var>handle</var>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="2.7.1" id="api-filesystemsyncaccesshandle-read"><span class="secno">2.7.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read">read()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-read"></a></h4>
+   <h4 class="heading settled" data-level="2.7.1" id="api-filesystemsyncaccesshandle-read"><span class="secno">2.7.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read①">read()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-read"></a></h4>
    <div class="note domintro" role="note">
     <dl>
-     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read①">read</a></code>(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions②">FilesystemReadWriteOptions</a></code>: <var>options</var>
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read②">read</a></code>(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions②">FilesystemReadWriteOptions</a></code>: <var>options</var>
      <dd data-md>
       <p>Reads the contents of the file associated with <var>handle</var> into <var>buffer</var>, with <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at">at</a></code> as the offset.</p>
     </dl>
@@ -2506,7 +2243,7 @@ operations come with high overhead, i.e., WebAssembly.</p>
 these steps: 
     <ol>
      <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②④">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state①">[[state]]</a> is "closed", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>.</p>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②④">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state①">[[state]]</a> is "<code>closed</code>", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>.</p>
      <li data-md>
       <p>Let <var>readPosition</var> be <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at①">at</a></code>.</p>
      <li data-md>
@@ -2514,9 +2251,9 @@ these steps:
      <li data-md>
       <p>Let <var>result</var> be <var>size</var>.</p>
      <li data-md>
-      <p>Let <var>bytes</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑨">byte sequence</a> containing the bytes from <var>readPosition</var> to <var>readPosition</var> + (<var>size</var> - 1) of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑤">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file②">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑤">binary data</a>.</p>
+      <p>Let <var>bytes</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑨">byte sequence</a> containing the bytes from <var>readPosition</var> to <var>readPosition</var> + (<var>size</var> - 1) of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑤">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file④">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑤">binary data</a>.</p>
      <li data-md>
-      <p>If the operations reading from <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑥">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑤">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑥">binary data</a> in the previous steps
+      <p>If the operations reading from <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑥">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑤">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑥">binary data</a> in the previous steps
  failed:</p>
       <ol>
        <li data-md>
@@ -2533,10 +2270,10 @@ these steps:
       <p>Return <var>result</var>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="2.7.2" id="api-filesystemsyncaccesshandle-write"><span class="secno">2.7.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write">write()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-write"></a></h4>
+   <h4 class="heading settled" data-level="2.7.2" id="api-filesystemsyncaccesshandle-write"><span class="secno">2.7.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write①">write()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-write"></a></h4>
    <div class="note domintro" role="note">
     <dl>
-     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write①">write</a></code>(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions④">FilesystemReadWriteOptions</a></code>: <var>options</var>)
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write②">write</a></code>(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions④">FilesystemReadWriteOptions</a></code>: <var>options</var>)
      <dd data-md>
       <p>Writes the content of <var>buffer</var> into the file associated with <var>handle</var> with <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at②">at</a></code> as the offset.</p>
     </dl>
@@ -2548,11 +2285,11 @@ these steps:
 these steps: 
     <ol>
      <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑦">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state②">[[state]]</a> is "closed", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror②">InvalidStateError</a></code>.</p>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑦">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state②">[[state]]</a> is "<code>closed</code>", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror②">InvalidStateError</a></code>.</p>
      <li data-md>
       <p>Let <var>writePosition</var> be <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at③">at</a></code>.</p>
      <li data-md>
-      <p>Let <var>fileContents</var> be a copy of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑧">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file③">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑦">binary data</a>.</p>
+      <p>Let <var>fileContents</var> be a copy of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑧">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file③">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑦">binary data</a>.</p>
      <li data-md>
       <p>Let <var>oldSize</var> be <var>fileContents</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑤">length</a>.</p>
      <li data-md>
@@ -2579,9 +2316,9 @@ these steps:
      <li data-md>
       <p>If <var>newSize</var> - <var>oldSize</var> exceeds the available <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota④">storage quota</a>, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror②">QuotaExceededError</a></code>.</p>
      <li data-md>
-      <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑨">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑥">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑧">binary data</a> to the concatenation of <var>head</var>, <var>data</var> and <var>tail</var>.</p>
+      <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑨">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑥">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑧">binary data</a> to the concatenation of <var>head</var>, <var>data</var> and <var>tail</var>.</p>
      <li data-md>
-      <p>If the operations modifying the <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⓪">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file④">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑨">binary data</a> in the previous steps
+      <p>If the operations modifying the <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⓪">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑦">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑨">binary data</a> in the previous steps
  failed:</p>
       <ol>
        <li data-md>
@@ -2607,35 +2344,35 @@ these steps:
 these steps: 
     <ol>
      <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③①">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state③">[[state]]</a> is "closed", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror③">InvalidStateError</a></code>.</p>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③①">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state③">[[state]]</a> is "<code>closed</code>", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror③">InvalidStateError</a></code>.</p>
      <li data-md>
       <p>If <var>newSize</var> is less than 0, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror④">InvalidStateError</a></code>.</p>
      <li data-md>
-      <p>Let <var>fileContents</var> be a copy of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③②">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑤">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①⓪">binary data</a>.</p>
+      <p>Let <var>fileContents</var> be a copy of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③②">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑧">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①⓪">binary data</a>.</p>
      <li data-md>
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①④">a new promise</a>.</p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①③">a new promise</a>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①③">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①②">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>oldSize</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①⓪">length</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③③">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑦">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①①">binary data</a>.</p>
+        <p>Let <var>oldSize</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①⓪">length</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③③">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file④">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①①">binary data</a>.</p>
        <li data-md>
         <p>If <var>newSize</var> is larger than <var>oldSize</var>:</p>
         <ol>
          <li data-md>
-          <p>If <var>newSize</var> - <var>oldSize</var> exceeds the available <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota⑤">storage quota</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑨">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror③">QuotaExceededError</a></code> and abort.</p>
+          <p>If <var>newSize</var> - <var>oldSize</var> exceeds the available <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota⑤">storage quota</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑦">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror③">QuotaExceededError</a></code> and abort.</p>
          <li data-md>
-          <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③④">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑧">[[file]]</a>'s to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①③">byte sequence</a> formed by concating <var>fileContents</var> with a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①④">byte sequence</a> containing <var>newSize</var>-<var>oldSize</var> <code>0x00</code> bytes.</p>
+          <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③④">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑨">[[file]]</a>'s to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①③">byte sequence</a> formed by concating <var>fileContents</var> with a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①④">byte sequence</a> containing <var>newSize</var>-<var>oldSize</var> <code>0x00</code> bytes.</p>
         </ol>
        <li data-md>
         <p>Else if <var>newSize</var> is smaller than <var>oldSize</var>:</p>
         <ol>
          <li data-md>
-          <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑤">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑨">[[file]]</a>'s to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①⑤">byte sequence</a> containing the first <var>newSize</var> bytes
+          <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑤">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑤">[[file]]</a>'s to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①⑤">byte sequence</a> containing the first <var>newSize</var> bytes
   in <var>fileContents</var>.</p>
         </ol>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②④">Resolve</a> <var>p</var>.</p>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②①">Resolve</a> <var>p</var>.</p>
       </ol>
      <li data-md>
       <p>Return <var>p</var></p>
@@ -2654,16 +2391,16 @@ these steps:
 these steps: 
     <ol>
      <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑥">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state④">[[state]]</a> is "closed", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror⑤">InvalidStateError</a></code>.</p>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑥">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state④">[[state]]</a> is "<code>closed</code>", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror⑤">InvalidStateError</a></code>.</p>
      <li data-md>
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑤">a new promise</a>.</p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①④">a new promise</a>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①④">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①③">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>size</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①①">length</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑦">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file①⓪">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①②">binary data</a>.</p>
+        <p>Let <var>size</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①①">length</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑦">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file①⓪">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①②">binary data</a>.</p>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑤">Resolve</a> <var>p</var> with <var>size</var>.</p>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②②">Resolve</a> <var>p</var> with <var>size</var>.</p>
       </ol>
      <li data-md>
       <p>Return <var>p</var></p>
@@ -2674,7 +2411,7 @@ these steps:
     <dl>
      <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-flush" id="ref-for-dom-filesystemsyncaccesshandle-flush②">flush()</a></code>
      <dd data-md>
-      <p>Ensures that the contents of the file associated with <var>handle</var> contain all the modifications done through <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write②">write()</a></code>.</p>
+      <p>Ensures that the contents of the file associated with <var>handle</var> contain all the modifications done through <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write③">write()</a></code>.</p>
     </dl>
    </div>
    <div class="algorithm" data-algorithm="flush()" data-algorithm-for="FileSystemSyncAccessHandle">
@@ -2696,14 +2433,14 @@ these steps:
 these steps: 
     <ol>
      <li data-md>
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑥">a new promise</a>.</p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑤">a new promise</a>.</p>
      <li data-md>
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑤">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①④">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑧">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state⑤">[[state]]</a> to "closed".</p>
+        <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑧">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state⑤">[[state]]</a> to "<code>closed</code>".</p>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑥">Resolve</a> <var>p</var>.</p>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②③">Resolve</a> <var>p</var>.</p>
       </ol>
      <li data-md>
       <p>Return <var>p</var></p>
@@ -3047,7 +2784,7 @@ run the following steps:
          <p>If <var>entry</var> does not represent an <a data-link-type="dfn" href="#entry" id="ref-for-entry①⑤">entry</a> in an <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system⑤">origin private file system</a>:</p>
          <ol>
           <li data-md>
-           <p>If <var>entry</var> is a <a data-link-type="dfn" href="#file" id="ref-for-file①①">file entry</a>, and a path on the local file system
+           <p>If <var>entry</var> is a <a data-link-type="dfn" href="#file" id="ref-for-file①③">file entry</a>, and a path on the local file system
  corresponding to the parent directory if <var>entry</var> can be determined,
  then return that path.</p>
           <li data-md>
@@ -3153,9 +2890,9 @@ these steps:
       <li data-md>
        <p>Verify that <var>environment</var> <a data-link-type="dfn" href="#is-allowed-to-show-a-file-picker" id="ref-for-is-allowed-to-show-a-file-picker">is allowed to show a file picker</a>.</p>
       <li data-md>
-       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑦">a new promise</a>.</p>
+       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑥">a new promise</a>.</p>
       <li data-md>
-       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑥">in parallel</a>:</p>
+       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑤">in parallel</a>:</p>
        <ol>
         <li data-md>
          <p>Optionally, wait until any prior execution of this algorithm has terminated.</p>
@@ -3169,9 +2906,9 @@ these steps:
         <li data-md>
          <p>Wait for the user to have made their selection.</p>
         <li data-md>
-         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③⓪">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror①">AbortError</a></code> and abort.</p>
+         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑧">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror①">AbortError</a></code> and abort.</p>
         <li data-md>
-         <p>Let <var>entries</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> of <a data-link-type="dfn" href="#file" id="ref-for-file①②">file entries</a> representing the selected files or directories.</p>
+         <p>Let <var>entries</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> of <a data-link-type="dfn" href="#file" id="ref-for-file①④">file entries</a> representing the selected files or directories.</p>
         <li data-md>
          <p>Let <var>result</var> be a empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a>.</p>
         <li data-md>
@@ -3184,8 +2921,8 @@ these steps:
              <p>Inform the user that the selected files or directories can’t be exposed to this website.</p>
             <li data-md>
              <p>At the discretion of the user agent,
- either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑦">in parallel</a> steps,
- or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③①">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror②">AbortError</a></code> and abort.</p>
+ either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑥">in parallel</a> steps,
+ or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑨">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror②">AbortError</a></code> and abort.</p>
            </ol>
           <li data-md>
            <p>Add a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①①">FileSystemFileHandle</a></code> associated with <var>entry</var> to <var>result</var>.</p>
@@ -3197,7 +2934,7 @@ these steps:
          <p class="note" role="note"><span>Note:</span> This lets a website immediately perform operations on the returned handles that
  might require user activation, such as requesting more permissions.</p>
         <li data-md>
-         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑦">Resolve</a> <var>p</var> with <var>result</var>.</p>
+         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②④">Resolve</a> <var>p</var> with <var>result</var>.</p>
        </ol>
       <li data-md>
        <p>Return <var>p</var>.</p>
@@ -3250,9 +2987,9 @@ these steps:
       <li data-md>
        <p>Verify that <var>environment</var> <a data-link-type="dfn" href="#is-allowed-to-show-a-file-picker" id="ref-for-is-allowed-to-show-a-file-picker①">is allowed to show a file picker</a>.</p>
       <li data-md>
-       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑧">a new promise</a>.</p>
+       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑦">a new promise</a>.</p>
       <li data-md>
-       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑧">in parallel</a>:</p>
+       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑦">in parallel</a>:</p>
        <ol>
         <li data-md>
          <p>Optionally, wait until any prior execution of this algorithm has terminated.</p>
@@ -3272,9 +3009,9 @@ these steps:
         <li data-md>
          <p>Wait for the user to have made their selection.</p>
         <li data-md>
-         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③②">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror③">AbortError</a></code> and abort.</p>
+         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③⓪">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror③">AbortError</a></code> and abort.</p>
         <li data-md>
-         <p>Let <var>entry</var> be a <a data-link-type="dfn" href="#file" id="ref-for-file①③">file entry</a> representing the selected file.</p>
+         <p>Let <var>entry</var> be a <a data-link-type="dfn" href="#file" id="ref-for-file①⑤">file entry</a> representing the selected file.</p>
         <li data-md>
          <p>If <var>entry</var> is deemed <a data-link-type="dfn" href="#wellknowndirectory-too-sensitive-or-dangerous" id="ref-for-wellknowndirectory-too-sensitive-or-dangerous①">too sensitive or dangerous</a> to be exposed to this website by the user agent:</p>
          <ol>
@@ -3282,8 +3019,8 @@ these steps:
            <p>Inform the user that the selected files or directories can’t be exposed to this website.</p>
           <li data-md>
            <p>At the discretion of the user agent,
- either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑨">in parallel</a> steps,
- or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③③">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror④">AbortError</a></code> and abort.</p>
+ either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑧">in parallel</a> steps,
+ or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③①">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror④">AbortError</a></code> and abort.</p>
          </ol>
         <li data-md>
          <p>Set <var>entry</var>’s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①③">binary data</a> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①⑥">byte sequence</a>.</p>
@@ -3296,7 +3033,7 @@ these steps:
          <p class="note" role="note"><span>Note:</span> This lets a website immediately perform operations on the returned handles that
  might require user activation, such as requesting more permissions.</p>
         <li data-md>
-         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑧">Resolve</a> <var>p</var> with <var>result</var>.</p>
+         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑤">Resolve</a> <var>p</var> with <var>result</var>.</p>
        </ol>
       <li data-md>
        <p>Return <var>p</var>.</p>
@@ -3342,9 +3079,9 @@ these steps:
       <li data-md>
        <p>Verify that <var>environment</var> <a data-link-type="dfn" href="#is-allowed-to-show-a-file-picker" id="ref-for-is-allowed-to-show-a-file-picker②">is allowed to show a file picker</a>.</p>
       <li data-md>
-       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑨">a new promise</a>.</p>
+       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑧">a new promise</a>.</p>
       <li data-md>
-       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②⓪">in parallel</a>:</p>
+       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑨">in parallel</a>:</p>
        <ol>
         <li data-md>
          <p>Optionally, wait until any prior execution of this algorithm has terminated.</p>
@@ -3354,7 +3091,7 @@ these steps:
         <li data-md>
          <p>Wait for the user to have made their selection.</p>
         <li data-md>
-         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③④">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror⑤">AbortError</a></code> and abort.</p>
+         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③②">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror⑤">AbortError</a></code> and abort.</p>
         <li data-md>
          <p>Let <var>entry</var> be a <a data-link-type="dfn" href="#directory" id="ref-for-directory⑨">directory entry</a> representing the selected directory.</p>
         <li data-md>
@@ -3364,8 +3101,8 @@ these steps:
            <p>Inform the user that the selected files or directories can’t be exposed to this website.</p>
           <li data-md>
            <p>At the discretion of the user agent,
- either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②①">in parallel</a> steps,
- or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③⑤">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror⑥">AbortError</a></code> and abort.</p>
+ either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②⓪">in parallel</a> steps,
+ or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③③">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror⑥">AbortError</a></code> and abort.</p>
          </ol>
         <li data-md>
          <p>Set <var>result</var> to a new <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①③">FileSystemDirectoryHandle</a></code> associated with <var>entry</var>.</p>
@@ -3378,7 +3115,7 @@ these steps:
          <p class="issue" id="issue-923f3009"><a class="self-link" href="#issue-923f3009"></a> Rather than requiring the website to prompt separately for a writable directory,
  we should provide some kind of API to request a writable directory in one step. <a href="https://github.com/wicg/file-system-access/issues/89">[Issue #89]</a></p>
         <li data-md>
-         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑨">Resolve</a> <var>p</var> with <var>result</var>.</p>
+         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑥">Resolve</a> <var>p</var> with <var>result</var>.</p>
        </ol>
       <li data-md>
        <p>Return <var>p</var>.</p>
@@ -3390,7 +3127,7 @@ these steps:
 };
 </pre>
     <p>During a <em>drag-and-drop operation</em>, dragged file and
-directory items are associated with <a data-link-type="dfn" href="#file" id="ref-for-file①④">file entries</a> and <a data-link-type="dfn" href="#directory" id="ref-for-directory①⓪">directory entries</a> respectively.</p>
+directory items are associated with <a data-link-type="dfn" href="#file" id="ref-for-file①⑥">file entries</a> and <a data-link-type="dfn" href="#directory" id="ref-for-directory①⓪">directory entries</a> respectively.</p>
     <div class="note domintro" role="note">
      <dt data-md><var>handle</var> = await item . <code class="idl"><a data-link-type="idl" href="#dom-datatransferitem-getasfilesystemhandle" id="ref-for-dom-datatransferitem-getasfilesystemhandle①">getAsFileSystemHandle()</a></code>
      <dd data-md>
@@ -3422,14 +3159,14 @@ directory items are associated with <a data-link-type="dfn" href="#file" id="ref
        <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-item-kind" id="ref-for-the-drag-data-item-kind">the drag data item kind</a> is not <em>File</em>,
   then return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-resolved-with" id="ref-for-a-promise-resolved-with①">a promise resolved with</a> <code>null</code>.</p>
       <li data-md>
-       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise②⓪">a new promise</a>.</p>
+       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑨">a new promise</a>.</p>
       <li data-md>
-       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②②">in parallel</a>:</p>
+       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②①">in parallel</a>:</p>
        <ol>
         <li data-md>
          <p>Let <var>entry</var> be the <a data-link-type="dfn" href="#entry" id="ref-for-entry①⑦">entry</a> representing the dragged file or directory.</p>
         <li data-md>
-         <p>If <var>entry</var> is a <a data-link-type="dfn" href="#file" id="ref-for-file①⑤">file entry</a>:</p>
+         <p>If <var>entry</var> is a <a data-link-type="dfn" href="#file" id="ref-for-file①⑦">file entry</a>:</p>
          <ol>
           <li data-md>
            <p>Let <var>handle</var> be a <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①④">FileSystemFileHandle</a></code> associated with <var>entry</var>.</p>
@@ -3441,7 +3178,7 @@ directory items are associated with <a data-link-type="dfn" href="#file" id="ref
            <p>Let <var>handle</var> be a <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①⑤">FileSystemDirectoryHandle</a></code> associated with <var>entry</var>.</p>
          </ol>
         <li data-md>
-         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve③⓪">Resolve</a> <var>p</var> with <var>entry</var>.</p>
+         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑦">Resolve</a> <var>p</var> with <var>entry</var>.</p>
        </ol>
       <li data-md>
        <p>Return <var>p</var>.</p>
@@ -3676,7 +3413,6 @@ use this API to write to disk.</p>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
    <li><a href="#dom-filepickeraccepttype-accept">accept</a><span>, in § 3</span>
-   <li><a href="#enumdef-accesshandlemode">AccessHandleMode</a><span>, in § 2.4</span>
    <li><a href="#dom-filesystemreadwriteoptions-at">at</a><span>, in § 2.7</span>
    <li><a href="#file-entry-binary-data">binary data</a><span>, in § 2.1</span>
    <li><a href="#filesystemwritablefilestream-buffer">[[buffer]]</a><span>, in § 2.6</span>
@@ -3690,7 +3426,7 @@ use this API to write to disk.</p>
     </ul>
    <li><a href="#create-a-new-filesystemsyncaccesshandle">create a new FileSystemSyncAccessHandle</a><span>, in § 2.7</span>
    <li><a href="#create-a-new-filesystemwritablefilestream">create a new FileSystemWritableFileStream</a><span>, in § 2.6</span>
-   <li><a href="#dom-filesystemfilehandle-createsyncaccesshandle">createSyncAccessHandle(options)</a><span>, in § 2.4.3</span>
+   <li><a href="#dom-filesystemfilehandle-createsyncaccesshandle">createSyncAccessHandle()</a><span>, in § 2.4.3</span>
    <li><a href="#dom-filesystemfilehandle-createwritable">createWritable()</a><span>, in § 2.4.2</span>
    <li><a href="#dom-filesystemfilehandle-createwritable">createWritable(options)</a><span>, in § 2.4.2</span>
    <li><a href="#dom-writeparams-data">data</a><span>, in § 2.6</span>
@@ -3725,7 +3461,6 @@ use this API to write to disk.</p>
    <li><a href="#dictdef-filesystemcreatewritableoptions">FileSystemCreateWritableOptions</a><span>, in § 2.4</span>
    <li><a href="#filesystemdirectoryhandle">FileSystemDirectoryHandle</a><span>, in § 2.5</span>
    <li><a href="#filesystemfilehandle">FileSystemFileHandle</a><span>, in § 2.4</span>
-   <li><a href="#dictdef-filesystemfilehandlecreateaccesshandleoptions">FileSystemFileHandleCreateAccessHandleOptions</a><span>, in § 2.4</span>
    <li><a href="#dictdef-filesystemgetdirectoryoptions">FileSystemGetDirectoryOptions</a><span>, in § 2.5</span>
    <li><a href="#dictdef-filesystemgetfileoptions">FileSystemGetFileOptions</a><span>, in § 2.5</span>
    <li><a href="#filesystemhandle">FileSystemHandle</a><span>, in § 2.3</span>
@@ -3754,7 +3489,6 @@ use this API to write to disk.</p>
      <li><a href="#dom-directorypickeroptions-id">dict-member for DirectoryPickerOptions</a><span>, in § 3</span>
      <li><a href="#dom-filepickeroptions-id">dict-member for FilePickerOptions</a><span>, in § 3</span>
     </ul>
-   <li><a href="#dom-accesshandlemode-in-place">"in-place"</a><span>, in § 2.4</span>
    <li><a href="#is-allowed-to-show-a-file-picker">is allowed to show a file picker</a><span>, in § 3.1</span>
    <li><a href="#dom-filesystemhandle-issameentry">isSameEntry(other)</a><span>, in § 2.3.1</span>
    <li><a href="#dom-filesystemcreatewritableoptions-keepexistingdata">keepExistingData</a><span>, in § 2.4</span>
@@ -3765,7 +3499,6 @@ use this API to write to disk.</p>
    <li>
     mode
     <ul>
-     <li><a href="#dom-filesystemfilehandlecreateaccesshandleoptions-mode">dict-member for FileSystemFileHandleCreateAccessHandleOptions</a><span>, in § 2.4</span>
      <li><a href="#dom-filesystemhandlepermissiondescriptor-mode">dict-member for FileSystemHandlePermissionDescriptor</a><span>, in § 2.3</span>
      <li><a href="#dom-filesystempermissiondescriptor-mode">dict-member for FileSystemPermissionDescriptor</a><span>, in § 2.2</span>
     </ul>
@@ -3986,24 +3719,24 @@ use this API to write to disk.</p>
   <aside class="dfn-panel" data-for="term-for-in-parallel">
    <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-in-parallel">2.1. Concepts</a> <a href="#ref-for-in-parallel①">(2)</a>
-    <li><a href="#ref-for-in-parallel②">2.3.1. The isSameEntry() method</a>
-    <li><a href="#ref-for-in-parallel③">2.3.2. The queryPermission() method</a>
-    <li><a href="#ref-for-in-parallel④">2.3.3. The requestPermission() method</a>
-    <li><a href="#ref-for-in-parallel⑤">2.4.1. The getFile() method</a>
-    <li><a href="#ref-for-in-parallel⑥">2.4.2. The createWritable() method</a>
-    <li><a href="#ref-for-in-parallel⑦">2.4.3. The createSyncAccessHandle() method</a>
-    <li><a href="#ref-for-in-parallel⑧">2.5.2. The getFileHandle() method</a>
-    <li><a href="#ref-for-in-parallel⑨">2.5.3. The getDirectoryHandle() method</a>
-    <li><a href="#ref-for-in-parallel①⓪">2.5.4. The removeEntry() method</a>
-    <li><a href="#ref-for-in-parallel①①">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-in-parallel①②">(2)</a>
-    <li><a href="#ref-for-in-parallel①③">2.7.3. The truncate() method</a>
-    <li><a href="#ref-for-in-parallel①④">2.7.4. The getSize() method</a>
-    <li><a href="#ref-for-in-parallel①⑤">2.7.6. The close() method</a>
-    <li><a href="#ref-for-in-parallel①⑥">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-in-parallel①⑦">(2)</a>
-    <li><a href="#ref-for-in-parallel①⑧">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-in-parallel①⑨">(2)</a>
-    <li><a href="#ref-for-in-parallel②⓪">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-in-parallel②①">(2)</a>
-    <li><a href="#ref-for-in-parallel②②">3.6. Drag and Drop</a>
+    <li><a href="#ref-for-in-parallel">2.1. Concepts</a>
+    <li><a href="#ref-for-in-parallel①">2.3.1. The isSameEntry() method</a>
+    <li><a href="#ref-for-in-parallel②">2.3.2. The queryPermission() method</a>
+    <li><a href="#ref-for-in-parallel③">2.3.3. The requestPermission() method</a>
+    <li><a href="#ref-for-in-parallel④">2.4.1. The getFile() method</a>
+    <li><a href="#ref-for-in-parallel⑤">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-in-parallel⑥">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-in-parallel⑦">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-in-parallel⑧">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-in-parallel⑨">2.5.4. The removeEntry() method</a>
+    <li><a href="#ref-for-in-parallel①⓪">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-in-parallel①①">(2)</a>
+    <li><a href="#ref-for-in-parallel①②">2.7.3. The truncate() method</a>
+    <li><a href="#ref-for-in-parallel①③">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-in-parallel①④">2.7.6. The close() method</a>
+    <li><a href="#ref-for-in-parallel①⑤">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-in-parallel①⑥">(2)</a>
+    <li><a href="#ref-for-in-parallel①⑦">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-in-parallel①⑧">(2)</a>
+    <li><a href="#ref-for-in-parallel①⑨">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-in-parallel②⓪">(2)</a>
+    <li><a href="#ref-for-in-parallel②①">3.6. Drag and Drop</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-event-messageerror">
@@ -4692,25 +4425,25 @@ use this API to write to disk.</p>
   <aside class="dfn-panel" data-for="term-for-a-new-promise">
    <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-a-new-promise">2.1. Concepts</a> <a href="#ref-for-a-new-promise①">(2)</a>
-    <li><a href="#ref-for-a-new-promise②">2.3.1. The isSameEntry() method</a>
-    <li><a href="#ref-for-a-new-promise③">2.3.2. The queryPermission() method</a>
-    <li><a href="#ref-for-a-new-promise④">2.3.3. The requestPermission() method</a>
-    <li><a href="#ref-for-a-new-promise⑤">2.4.1. The getFile() method</a>
-    <li><a href="#ref-for-a-new-promise⑥">2.4.2. The createWritable() method</a>
-    <li><a href="#ref-for-a-new-promise⑦">2.4.3. The createSyncAccessHandle() method</a>
-    <li><a href="#ref-for-a-new-promise⑧">2.5.1. Directory iteration</a>
-    <li><a href="#ref-for-a-new-promise⑨">2.5.2. The getFileHandle() method</a>
-    <li><a href="#ref-for-a-new-promise①⓪">2.5.3. The getDirectoryHandle() method</a>
-    <li><a href="#ref-for-a-new-promise①①">2.5.4. The removeEntry() method</a>
-    <li><a href="#ref-for-a-new-promise①②">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-a-new-promise①③">(2)</a>
-    <li><a href="#ref-for-a-new-promise①④">2.7.3. The truncate() method</a>
-    <li><a href="#ref-for-a-new-promise①⑤">2.7.4. The getSize() method</a>
-    <li><a href="#ref-for-a-new-promise①⑥">2.7.6. The close() method</a>
-    <li><a href="#ref-for-a-new-promise①⑦">3.3. The showOpenFilePicker() method</a>
-    <li><a href="#ref-for-a-new-promise①⑧">3.4. The showSaveFilePicker() method</a>
-    <li><a href="#ref-for-a-new-promise①⑨">3.5. The showDirectoryPicker() method</a>
-    <li><a href="#ref-for-a-new-promise②⓪">3.6. Drag and Drop</a>
+    <li><a href="#ref-for-a-new-promise">2.1. Concepts</a>
+    <li><a href="#ref-for-a-new-promise①">2.3.1. The isSameEntry() method</a>
+    <li><a href="#ref-for-a-new-promise②">2.3.2. The queryPermission() method</a>
+    <li><a href="#ref-for-a-new-promise③">2.3.3. The requestPermission() method</a>
+    <li><a href="#ref-for-a-new-promise④">2.4.1. The getFile() method</a>
+    <li><a href="#ref-for-a-new-promise⑤">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-a-new-promise⑥">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-a-new-promise⑦">2.5.1. Directory iteration</a>
+    <li><a href="#ref-for-a-new-promise⑧">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-a-new-promise⑨">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-a-new-promise①⓪">2.5.4. The removeEntry() method</a>
+    <li><a href="#ref-for-a-new-promise①①">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-a-new-promise①②">(2)</a>
+    <li><a href="#ref-for-a-new-promise①③">2.7.3. The truncate() method</a>
+    <li><a href="#ref-for-a-new-promise①④">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-a-new-promise①⑤">2.7.6. The close() method</a>
+    <li><a href="#ref-for-a-new-promise①⑥">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-a-new-promise①⑦">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-a-new-promise①⑧">3.5. The showDirectoryPicker() method</a>
+    <li><a href="#ref-for-a-new-promise①⑨">3.6. Drag and Drop</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
@@ -4778,42 +4511,41 @@ use this API to write to disk.</p>
   <aside class="dfn-panel" data-for="term-for-reject">
    <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-reject">2.1. Concepts</a> <a href="#ref-for-reject①">(2)</a>
-    <li><a href="#ref-for-reject②">2.3.3. The requestPermission() method</a>
-    <li><a href="#ref-for-reject③">2.4.2. The createWritable() method</a> <a href="#ref-for-reject④">(2)</a>
-    <li><a href="#ref-for-reject⑤">2.4.3. The createSyncAccessHandle() method</a> <a href="#ref-for-reject⑥">(2)</a>
-    <li><a href="#ref-for-reject⑦">2.5.2. The getFileHandle() method</a> <a href="#ref-for-reject⑧">(2)</a> <a href="#ref-for-reject⑨">(3)</a> <a href="#ref-for-reject①⓪">(4)</a> <a href="#ref-for-reject①①">(5)</a>
-    <li><a href="#ref-for-reject①②">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-reject①③">(2)</a> <a href="#ref-for-reject①④">(3)</a> <a href="#ref-for-reject①⑤">(4)</a> <a href="#ref-for-reject①⑥">(5)</a>
-    <li><a href="#ref-for-reject①⑦">2.5.4. The removeEntry() method</a> <a href="#ref-for-reject①⑧">(2)</a> <a href="#ref-for-reject①⑨">(3)</a> <a href="#ref-for-reject②⓪">(4)</a> <a href="#ref-for-reject②①">(5)</a>
-    <li><a href="#ref-for-reject②②">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-reject②③">(2)</a> <a href="#ref-for-reject②④">(3)</a> <a href="#ref-for-reject②⑤">(4)</a> <a href="#ref-for-reject②⑥">(5)</a> <a href="#ref-for-reject②⑦">(6)</a> <a href="#ref-for-reject②⑧">(7)</a>
-    <li><a href="#ref-for-reject②⑨">2.7.3. The truncate() method</a>
-    <li><a href="#ref-for-reject③⓪">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-reject③①">(2)</a>
-    <li><a href="#ref-for-reject③②">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-reject③③">(2)</a>
-    <li><a href="#ref-for-reject③④">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-reject③⑤">(2)</a>
+    <li><a href="#ref-for-reject">2.3.3. The requestPermission() method</a>
+    <li><a href="#ref-for-reject①">2.4.2. The createWritable() method</a> <a href="#ref-for-reject②">(2)</a>
+    <li><a href="#ref-for-reject③">2.4.3. The createSyncAccessHandle() method</a> <a href="#ref-for-reject④">(2)</a>
+    <li><a href="#ref-for-reject⑤">2.5.2. The getFileHandle() method</a> <a href="#ref-for-reject⑥">(2)</a> <a href="#ref-for-reject⑦">(3)</a> <a href="#ref-for-reject⑧">(4)</a> <a href="#ref-for-reject⑨">(5)</a>
+    <li><a href="#ref-for-reject①⓪">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-reject①①">(2)</a> <a href="#ref-for-reject①②">(3)</a> <a href="#ref-for-reject①③">(4)</a> <a href="#ref-for-reject①④">(5)</a>
+    <li><a href="#ref-for-reject①⑤">2.5.4. The removeEntry() method</a> <a href="#ref-for-reject①⑥">(2)</a> <a href="#ref-for-reject①⑦">(3)</a> <a href="#ref-for-reject①⑧">(4)</a> <a href="#ref-for-reject①⑨">(5)</a>
+    <li><a href="#ref-for-reject②⓪">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-reject②①">(2)</a> <a href="#ref-for-reject②②">(3)</a> <a href="#ref-for-reject②③">(4)</a> <a href="#ref-for-reject②④">(5)</a> <a href="#ref-for-reject②⑤">(6)</a> <a href="#ref-for-reject②⑥">(7)</a>
+    <li><a href="#ref-for-reject②⑦">2.7.3. The truncate() method</a>
+    <li><a href="#ref-for-reject②⑧">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-reject②⑨">(2)</a>
+    <li><a href="#ref-for-reject③⓪">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-reject③①">(2)</a>
+    <li><a href="#ref-for-reject③②">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-reject③③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-resolve">
    <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-resolve">2.1. Concepts</a> <a href="#ref-for-resolve①">(2)</a> <a href="#ref-for-resolve②">(3)</a> <a href="#ref-for-resolve③">(4)</a> <a href="#ref-for-resolve④">(5)</a> <a href="#ref-for-resolve⑤">(6)</a>
-    <li><a href="#ref-for-resolve⑥">2.3.1. The isSameEntry() method</a> <a href="#ref-for-resolve⑦">(2)</a>
-    <li><a href="#ref-for-resolve⑧">2.3.2. The queryPermission() method</a>
-    <li><a href="#ref-for-resolve⑨">2.3.3. The requestPermission() method</a>
-    <li><a href="#ref-for-resolve①⓪">2.4.1. The getFile() method</a>
-    <li><a href="#ref-for-resolve①①">2.4.2. The createWritable() method</a>
-    <li><a href="#ref-for-resolve①②">2.4.3. The createSyncAccessHandle() method</a>
-    <li><a href="#ref-for-resolve①③">2.5.1. Directory iteration</a> <a href="#ref-for-resolve①④">(2)</a>
-    <li><a href="#ref-for-resolve①⑤">2.5.2. The getFileHandle() method</a> <a href="#ref-for-resolve①⑥">(2)</a>
-    <li><a href="#ref-for-resolve①⑦">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-resolve①⑧">(2)</a>
-    <li><a href="#ref-for-resolve①⑨">2.5.4. The removeEntry() method</a>
-    <li><a href="#ref-for-resolve②⓪">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-resolve②①">(2)</a> <a href="#ref-for-resolve②②">(3)</a> <a href="#ref-for-resolve②③">(4)</a>
-    <li><a href="#ref-for-resolve②④">2.7.3. The truncate() method</a>
-    <li><a href="#ref-for-resolve②⑤">2.7.4. The getSize() method</a>
-    <li><a href="#ref-for-resolve②⑥">2.7.6. The close() method</a>
-    <li><a href="#ref-for-resolve②⑦">3.3. The showOpenFilePicker() method</a>
-    <li><a href="#ref-for-resolve②⑧">3.4. The showSaveFilePicker() method</a>
-    <li><a href="#ref-for-resolve②⑨">3.5. The showDirectoryPicker() method</a>
-    <li><a href="#ref-for-resolve③⓪">3.6. Drag and Drop</a>
+    <li><a href="#ref-for-resolve">2.1. Concepts</a> <a href="#ref-for-resolve①">(2)</a> <a href="#ref-for-resolve②">(3)</a>
+    <li><a href="#ref-for-resolve③">2.3.1. The isSameEntry() method</a> <a href="#ref-for-resolve④">(2)</a>
+    <li><a href="#ref-for-resolve⑤">2.3.2. The queryPermission() method</a>
+    <li><a href="#ref-for-resolve⑥">2.3.3. The requestPermission() method</a>
+    <li><a href="#ref-for-resolve⑦">2.4.1. The getFile() method</a>
+    <li><a href="#ref-for-resolve⑧">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-resolve⑨">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-resolve①⓪">2.5.1. Directory iteration</a> <a href="#ref-for-resolve①①">(2)</a>
+    <li><a href="#ref-for-resolve①②">2.5.2. The getFileHandle() method</a> <a href="#ref-for-resolve①③">(2)</a>
+    <li><a href="#ref-for-resolve①④">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-resolve①⑤">(2)</a>
+    <li><a href="#ref-for-resolve①⑥">2.5.4. The removeEntry() method</a>
+    <li><a href="#ref-for-resolve①⑦">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-resolve①⑧">(2)</a> <a href="#ref-for-resolve①⑨">(3)</a> <a href="#ref-for-resolve②⓪">(4)</a>
+    <li><a href="#ref-for-resolve②①">2.7.3. The truncate() method</a>
+    <li><a href="#ref-for-resolve②②">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-resolve②③">2.7.6. The close() method</a>
+    <li><a href="#ref-for-resolve②④">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-resolve②⑤">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-resolve②⑥">3.5. The showDirectoryPicker() method</a>
+    <li><a href="#ref-for-resolve②⑦">3.6. Drag and Drop</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-sequence">
@@ -5142,18 +4874,12 @@ use this API to write to disk.</p>
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a data-default="false" data-type="boolean " href="#dom-filesystemcreatewritableoptions-keepexistingdata"><code><c- g>keepExistingData</c-></code></a> = <c- b>false</c->;
 };
 
-<c- b>enum</c-> <a href="#enumdef-accesshandlemode"><code><c- g>AccessHandleMode</c-></code></a> { <a href="#dom-accesshandlemode-in-place"><code><c- s>"in-place"</c-></code></a> };
-
-<c- b>dictionary</c-> <a href="#dictdef-filesystemfilehandlecreateaccesshandleoptions"><code><c- g>FileSystemFileHandleCreateAccessHandleOptions</c-></code></a> {
-  <c- b>required</c-> <a data-link-type="idl-name" href="#enumdef-accesshandlemode"><c- n>AccessHandleMode</c-></a> <a data-type="AccessHandleMode " href="#dom-filesystemfilehandlecreateaccesshandleoptions-mode"><code><c- g>mode</c-></code></a>;
-};
-
 [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->), <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable"><c- g>Serializable</c-></a>]
 <c- b>interface</c-> <a href="#filesystemfilehandle"><code><c- g>FileSystemFileHandle</c-></code></a> : <a data-link-type="idl-name" href="#filesystemhandle"><c- n>FileSystemHandle</c-></a> {
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-file"><c- n>File</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-getfile"><c- g>getFile</c-></a>();
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemwritablefilestream"><c- n>FileSystemWritableFileStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createwritable"><c- g>createWritable</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemcreatewritableoptions"><c- n>FileSystemCreateWritableOptions</c-></a> <a href="#dom-filesystemfilehandle-createwritable-options-options"><code><c- g>options</c-></code></a> = {});
   [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=<c- n>DedicatedWorker</c->]
-  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemsyncaccesshandle"><c- n>FileSystemSyncAccessHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createsyncaccesshandle"><c- g>createSyncAccessHandle</c-></a>(<a data-link-type="idl-name" href="#dictdef-filesystemfilehandlecreateaccesshandleoptions"><c- n>FileSystemFileHandleCreateAccessHandleOptions</c-></a> <a href="#dom-filesystemfilehandle-createsyncaccesshandle-options-options"><code><c- g>options</c-></code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemsyncaccesshandle"><c- n>FileSystemSyncAccessHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createsyncaccesshandle"><c- g>createSyncAccessHandle</c-></a>();
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-filesystemgetfileoptions"><code><c- g>FileSystemGetFileOptions</c-></code></a> {
@@ -5347,18 +5073,18 @@ than being defined here. So merge this into the table there. <a class="issue-ret
   <aside class="dfn-panel" data-for="file">
    <b><a href="#file">#file</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-file">2.1. Concepts</a> <a href="#ref-for-file①">(2)</a>
-    <li><a href="#ref-for-file②">2.3. The FileSystemHandle interface</a>
-    <li><a href="#ref-for-file③">2.4. The FileSystemFileHandle interface</a>
-    <li><a href="#ref-for-file④">2.5.1. Directory iteration</a>
-    <li><a href="#ref-for-file⑤">2.5.2. The getFileHandle() method</a>
-    <li><a href="#ref-for-file⑥">2.5.3. The getDirectoryHandle() method</a>
-    <li><a href="#ref-for-file⑦">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-file⑧">(2)</a>
-    <li><a href="#ref-for-file⑨">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-file①⓪">(2)</a>
-    <li><a href="#ref-for-file①①">3.2.2. Starting Directory</a>
-    <li><a href="#ref-for-file①②">3.3. The showOpenFilePicker() method</a>
-    <li><a href="#ref-for-file①③">3.4. The showSaveFilePicker() method</a>
-    <li><a href="#ref-for-file①④">3.6. Drag and Drop</a> <a href="#ref-for-file①⑤">(2)</a>
+    <li><a href="#ref-for-file">2.1. Concepts</a> <a href="#ref-for-file①">(2)</a> <a href="#ref-for-file②">(3)</a> <a href="#ref-for-file③">(4)</a>
+    <li><a href="#ref-for-file④">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-file⑤">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-file⑥">2.5.1. Directory iteration</a>
+    <li><a href="#ref-for-file⑦">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-file⑧">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-file⑨">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-file①⓪">(2)</a>
+    <li><a href="#ref-for-file①①">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-file①②">(2)</a>
+    <li><a href="#ref-for-file①③">3.2.2. Starting Directory</a>
+    <li><a href="#ref-for-file①④">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-file①⑤">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-file①⑥">3.6. Drag and Drop</a> <a href="#ref-for-file①⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="file-entry-binary-data">
@@ -5649,24 +5375,6 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-dom-filesystemcreatewritableoptions-keepexistingdata">2.4.2. The createWritable() method</a> <a href="#ref-for-dom-filesystemcreatewritableoptions-keepexistingdata①">(2)</a> <a href="#ref-for-dom-filesystemcreatewritableoptions-keepexistingdata②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-accesshandlemode">
-   <b><a href="#enumdef-accesshandlemode">#enumdef-accesshandlemode</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-enumdef-accesshandlemode">2.4. The FileSystemFileHandle interface</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dictdef-filesystemfilehandlecreateaccesshandleoptions">
-   <b><a href="#dictdef-filesystemfilehandlecreateaccesshandleoptions">#dictdef-filesystemfilehandlecreateaccesshandleoptions</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dictdef-filesystemfilehandlecreateaccesshandleoptions">2.4. The FileSystemFileHandle interface</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemfilehandlecreateaccesshandleoptions-mode">
-   <b><a href="#dom-filesystemfilehandlecreateaccesshandleoptions-mode">#dom-filesystemfilehandlecreateaccesshandleoptions-mode</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-filesystemfilehandlecreateaccesshandleoptions-mode">2.4.3. The createSyncAccessHandle() method</a> <a href="#ref-for-dom-filesystemfilehandlecreateaccesshandleoptions-mode①">(2)</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="filesystemfilehandle">
    <b><a href="#filesystemfilehandle">#filesystemfilehandle</a></b><b>Referenced in:</b>
    <ul>
@@ -5874,11 +5582,9 @@ than being defined here. So merge this into the table there. <a class="issue-ret
   <aside class="dfn-panel" data-for="filesystemwritablefilestream-file">
    <b><a href="#filesystemwritablefilestream-file">#filesystemwritablefilestream-file</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-filesystemwritablefilestream-file">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemwritablefilestream-file①">(2)</a> <a href="#ref-for-filesystemwritablefilestream-file②">(3)</a> <a href="#ref-for-filesystemwritablefilestream-file③">(4)</a> <a href="#ref-for-filesystemwritablefilestream-file④">(5)</a>
-    <li><a href="#ref-for-filesystemwritablefilestream-file⑤">2.7.1. The read() method</a>
-    <li><a href="#ref-for-filesystemwritablefilestream-file⑥">2.7.2. The write() method</a>
-    <li><a href="#ref-for-filesystemwritablefilestream-file⑦">2.7.3. The truncate() method</a> <a href="#ref-for-filesystemwritablefilestream-file⑧">(2)</a> <a href="#ref-for-filesystemwritablefilestream-file⑨">(3)</a>
-    <li><a href="#ref-for-filesystemwritablefilestream-file①⓪">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemwritablefilestream-file①">(2)</a> <a href="#ref-for-filesystemwritablefilestream-file②">(3)</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file③">2.7.2. The write() method</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file④">2.7.3. The truncate() method</a> <a href="#ref-for-filesystemwritablefilestream-file⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="filesystemwritablefilestream-buffer">
@@ -5956,24 +5662,27 @@ than being defined here. So merge this into the table there. <a class="issue-ret
   <aside class="dfn-panel" data-for="dom-filesystemsyncaccesshandle-read">
    <b><a href="#dom-filesystemsyncaccesshandle-read">#dom-filesystemsyncaccesshandle-read</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-read">2.7.1. The read() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-read①">(2)</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-read">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-read①">2.7.1. The read() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-read②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-filesystemsyncaccesshandle-write">
    <b><a href="#dom-filesystemsyncaccesshandle-write">#dom-filesystemsyncaccesshandle-write</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-write">2.7.2. The write() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-write①">(2)</a>
-    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-write②">2.7.5. The flush() method</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-write">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-write①">2.7.2. The write() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-write②">(2)</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-write③">2.7.5. The flush() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="filesystemsyncaccesshandle-file">
    <b><a href="#filesystemsyncaccesshandle-file">#filesystemsyncaccesshandle-file</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file">2.6. The FileSystemWritableFileStream interface</a>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file①">2.7. The FileSystemSyncAccessHandle interface</a>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file②">2.7.1. The read() method</a>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file③">2.7.2. The write() method</a> <a href="#ref-for-filesystemsyncaccesshandle-file④">(2)</a>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file⑤">2.7.3. The truncate() method</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemsyncaccesshandle-file①">(2)</a> <a href="#ref-for-filesystemsyncaccesshandle-file②">(3)</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file③">2.7. The FileSystemSyncAccessHandle interface</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file④">2.7.1. The read() method</a> <a href="#ref-for-filesystemsyncaccesshandle-file⑤">(2)</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file⑥">2.7.2. The write() method</a> <a href="#ref-for-filesystemsyncaccesshandle-file⑦">(2)</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file⑧">2.7.3. The truncate() method</a> <a href="#ref-for-filesystemsyncaccesshandle-file⑨">(2)</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file①⓪">2.7.4. The getSize() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="filesystemsyncaccesshandle-state">

--- a/index.html
+++ b/index.html
@@ -662,7 +662,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">File System Access</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2022-04-07">7 April 2022</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2022-04-11">11 April 2022</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1424,7 +1424,7 @@ contexts where asynchronous operations come with high overhead, e.g., WebAssembl
         <p>Let <var>entry</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⓪">this</a></b>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①③">entry</a>.</p>
        <li data-md>
         <p>If <var>entry</var> does not represent an <a data-link-type="dfn" href="#entry" id="ref-for-entry①③">entry</a> in an <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system②">origin private file system</a>,
- reject <var>result</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code> and abort.</p>
+ reject <var>result</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror③">NotAllowedError</a></code> and abort.</p>
        <li data-md>
         <p>Let <var>lockResult</var> be the result of <a data-link-type="dfn" href="#file-entry-lock-take" id="ref-for-file-entry-lock-take③">taking a lock</a> with  "<code>exclusive</code>" on <var>entry</var>.</p>
        <li data-md>
@@ -1494,7 +1494,7 @@ support for example recursive iteration. <a href="https://github.com/wicg/file-s
       <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#querying-file-system-permission" id="ref-for-querying-file-system-permission②">querying file system permission</a> given <var>handle</var> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read⑤">"read"</a></code>.</p>
      <li data-md>
       <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted⑤">"granted"</a></code>,
- throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror③">NotAllowedError</a></code>.</p>
+ throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror④">NotAllowedError</a></code>.</p>
      <li data-md>
       <p>Set <var>iterator</var>’s <dfn class="dfn-paneled" data-dfn-for="FileSystemDirectoryHandle-iterator" data-dfn-type="dfn" data-noexport id="filesystemdirectoryhandle-iterator-past-results">past results</dfn> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">set</a>.</p>
     </ol>
@@ -1510,7 +1510,7 @@ support for example recursive iteration. <a href="https://github.com/wicg/file-s
       <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#querying-file-system-permission" id="ref-for-querying-file-system-permission③">querying file system permission</a> given <var>handle</var> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read⑥">"read"</a></code>.</p>
      <li data-md>
       <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted⑥">"granted"</a></code>,
- reject <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror④">NotAllowedError</a></code> and return <var>promise</var>.</p>
+ reject <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑤">NotAllowedError</a></code> and return <var>promise</var>.</p>
      <li data-md>
       <p>Let <var>child</var> be an <a data-link-type="dfn" href="#entry" id="ref-for-entry①④">entry</a> in <var>directory</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children③">children</a>,
  such that <var>child</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name⑤">name</a> is not contained in <var>iterator</var>’s <a data-link-type="dfn" href="#filesystemdirectoryhandle-iterator-past-results" id="ref-for-filesystemdirectoryhandle-iterator-past-results">past results</a>,
@@ -1598,7 +1598,7 @@ must run these steps:
         </ol>
        <li data-md>
         <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted⑦">"granted"</a></code>,
- reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑤">NotAllowedError</a></code> and abort.</p>
+ reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑥">NotAllowedError</a></code> and abort.</p>
        <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①">For each</a> <var>child</var> of <var>entry</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children④">children</a>:</p>
         <ol>
@@ -1688,7 +1688,7 @@ invoked, must run these steps:
         </ol>
        <li data-md>
         <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted⑧">"granted"</a></code>,
- reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑥">NotAllowedError</a></code> and abort.</p>
+ reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑦">NotAllowedError</a></code> and abort.</p>
        <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate②">For each</a> <var>child</var> of <var>entry</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children⑥">children</a>:</p>
         <ol>
@@ -1765,7 +1765,7 @@ these steps:
  If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑥">reject</a> <var>result</var> with that exception and abort.</p>
        <li data-md>
         <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted⑨">"granted"</a></code>,
- reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑦">NotAllowedError</a></code> and abort.</p>
+ reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑧">NotAllowedError</a></code> and abort.</p>
        <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate③">For each</a> <var>child</var> of <var>entry</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children⑨">children</a>:</p>
         <ol>
@@ -1920,17 +1920,17 @@ When using <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritab
  and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode⑥">mode</a></code> = <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite①⓪">"readwrite"</a></code>.</p>
          <li data-md>
           <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①⓪">"granted"</a></code>,
- reject <var>closeResult</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑧">NotAllowedError</a></code> and abort.</p>
+ reject <var>closeResult</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑨">NotAllowedError</a></code> and abort.</p>
          <li data-md>
           <p>Perform user agent-specific <a data-link-type="dfn" href="#wellknowndirectory-malware-scans-and-safe-browsing-checks" id="ref-for-wellknowndirectory-malware-scans-and-safe-browsing-checks">malware scans and safe browsing checks</a>.
  If these checks fail, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⓪">reject</a> <var>closeResult</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror">AbortError</a></code> and abort.</p>
          <li data-md>
-          <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file①">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data④">binary data</a> to <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①">[[buffer]]</a>.
+          <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file①">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data④">binary data</a> to <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①">[[buffer]]</a>.
  If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②①">reject</a> <var>closeResult</var> with that exception and abort.</p>
           <p class="note" role="note"><span>Note:</span> It is expected that this atomically updates the contents of the file on disk
  being written to.</p>
          <li data-md>
-          <p><a data-link-type="dfn" href="#file-entry-lock-release" id="ref-for-file-entry-lock-release">Release the lock</a> on <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file①">[[file]]</a>.</p>
+          <p><a data-link-type="dfn" href="#file-entry-lock-release" id="ref-for-file-entry-lock-release">Release the lock</a> on <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file②">[[file]]</a>.</p>
          <li data-md>
           <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑦">Resolve</a> <var>closeResult</var> with <code>undefined</code>.</p>
         </ol>
@@ -1941,7 +1941,7 @@ When using <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritab
       <p>Let <var>abortAlgorithm</var> be the following step:</p>
       <ol>
        <li data-md>
-        <p><a data-link-type="dfn" href="#file-entry-lock-release" id="ref-for-file-entry-lock-release①">Release the lock</a> on <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file②">[[file]]</a>.</p>
+        <p><a data-link-type="dfn" href="#file-entry-lock-release" id="ref-for-file-entry-lock-release①">Release the lock</a> on <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file③">[[file]]</a>.</p>
       </ol>
      <li data-md>
       <p>Let <var>highWaterMark</var> be 1.</p>
@@ -1967,11 +1967,11 @@ runs these steps:
       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①①">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>permissionStatus</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state⑧">permission state</a> for a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor⑥">FileSystemPermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑨">handle</a></code> representing <var>stream</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file②">[[file]]</a>,
+        <p>Let <var>permissionStatus</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-state" id="ref-for-dfn-state⑧">permission state</a> for a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor⑥">FileSystemPermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑨">handle</a></code> representing <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file④">[[file]]</a>,
   and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode⑦">mode</a></code> = <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite①①">"readwrite"</a></code>.</p>
        <li data-md>
         <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①①">"granted"</a></code>,
-  reject <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑨">NotAllowedError</a></code> and abort.</p>
+  reject <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror①⓪">NotAllowedError</a></code> and abort.</p>
        <li data-md>
         <p>Let <var>command</var> be <var>input</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-type" id="ref-for-dom-writeparams-type">type</a></code> if <var>input</var> is a <code class="idl"><a data-link-type="idl" href="#dictdef-writeparams" id="ref-for-dictdef-writeparams②">WriteParams</a></code>,
   and <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-write" id="ref-for-dom-writecommandtype-write">"write"</a></code> otherwise.</p>
@@ -2220,7 +2220,7 @@ operations come with high overhead, e.g., WebAssembly.</p>
      <li data-md>
       <p>Let <var>handle</var> be a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new①">new</a> <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle①①">FileSystemSyncAccessHandle</a></code> in <var>realm</var>.</p>
      <li data-md>
-      <p>Set <var>handle</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file③">[[file]]</a> to <var>file</var>.</p>
+      <p>Set <var>handle</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file①">[[file]]</a> to <var>file</var>.</p>
      <li data-md>
       <p>Set <var>handle</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state">[[state]]</a> to "<code>open</code>".</p>
      <li data-md>
@@ -2241,18 +2241,27 @@ operations come with high overhead, e.g., WebAssembly.</p>
 these steps: 
     <ol>
      <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②④">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state①">[[state]]</a> is "<code>closed</code>", throw an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>.</p>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②④">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state①">[[state]]</a> is "<code>closed</code>", throw an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code>.</p>
      <li data-md>
-      <p>Let <var>readPosition</var> be <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at①">at</a></code>.</p>
+      <p>Let <var>bufferSize</var> be <var>buffer</var>’s <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#buffersource-byte-length" id="ref-for-buffersource-byte-length">byte length</a>.</p>
      <li data-md>
-      <p>Let <var>size</var> be <var>buffer</var>’s <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#buffersource-byte-length" id="ref-for-buffersource-byte-length">byte length</a>.</p>
+      <p>Let <var>fileContents</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑤">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑤">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑤">binary data</a>.</p>
      <li data-md>
-      <p>Let <var>result</var> be <var>size</var>.</p>
+      <p>Let <var>fileSize</var> be <var>fileContents</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑤">length</a>.</p>
      <li data-md>
-      <p>Let <var>bytes</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑨">byte sequence</a> containing the bytes from <var>readPosition</var> to <var>readPosition</var> + (<var>size</var> − 1) of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑤">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file④">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑤">binary data</a>.</p>
+      <p>Let <var>readStart</var> be <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at①">at</a></code>.</p>
      <li data-md>
-      <p>If the operations reading from <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑥">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file③">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑥">binary data</a> in the previous steps
- failed:</p>
+      <p>If <var>readStart</var> is larger than <var>fileSize</var>, return 0.</p>
+     <li data-md>
+      <p>Let <var>readEnd</var> be <var>readStart</var> + (<var>bufferSize</var> − 1).</p>
+     <li data-md>
+      <p>If <var>readEnd</var> is larger than <var>fileSize</var>, set <var>readEnd</var> to <var>fileSize</var>.</p>
+     <li data-md>
+      <p>Let <var>result</var> be <var>bufferSize</var>.</p>
+     <li data-md>
+      <p>Let <var>bytes</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑨">byte sequence</a> containing the bytes from <var>readStart</var> to <var>readEnd</var> of <var>fileContents</var>.</p>
+     <li data-md>
+      <p>If the operations reading from <var>fileContents</var> in the previous steps failed:</p>
       <ol>
        <li data-md>
         <p>If there were partial reads  and the number of modified bytes in <var>bytes</var> is known,
@@ -2277,21 +2286,27 @@ these steps:
       <p>Writes the content of <var>buffer</var> into the file associated with <var>handle</var>, optionally at a given offset.</p>
     </dl>
    </div>
-   <p>// TODO(fivedots): Figure out mechanism to prevent concurrent IO operations e.g. doing write() while a truncate() is executing in parallel.</p>
+   <p>// TODO(fivedots): Figure out how to properly check the available storage quota (in this method and others) by passing the right storage shelf.
+// TODO(fivedots): Figure out mechanism to prevent concurrent IO operations e.g. doing write() while a truncate() is executing in parallel.</p>
    <div class="algorithm" data-algorithm="write(buffer, FileSystemReadWriteOptions: options)" data-algorithm-for="FileSystemSyncAccessHandle">
      The <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-write-buffer-filesystemreadwriteoptions-options"><code>write(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions③">FileSystemReadWriteOptions</a></code>: <var>options</var>)</code><a class="self-link" href="#dom-filesystemsyncaccesshandle-write-buffer-filesystemreadwriteoptions-options"></a></dfn> method, when invoked, must run
 these steps: 
     <ol>
      <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑦">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state②">[[state]]</a> is "<code>closed</code>", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror②">InvalidStateError</a></code>.</p>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑥">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state②">[[state]]</a> is "<code>closed</code>", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>.</p>
      <li data-md>
       <p>Let <var>writePosition</var> be <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at③">at</a></code>.</p>
      <li data-md>
-      <p>Let <var>fileContents</var> be a copy of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑧">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file④">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑦">binary data</a>.</p>
+      <p>Let <var>fileContents</var> be a copy of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑦">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑥">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑥">binary data</a>.</p>
      <li data-md>
-      <p>Let <var>oldSize</var> be <var>fileContents</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑤">length</a>.</p>
+      <p>Let <var>oldSize</var> be <var>fileContents</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑥">length</a>.</p>
      <li data-md>
       <p>Let <var>data</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy" id="ref-for-dfn-get-buffer-source-copy①">a copy of</a> <var>buffer</var>.</p>
+      <p class="note" role="note"><span>Note:</span> The objective of this copy is to prevent concurrent modifications of the buffer
+ from being reflected in the written data. Depending on the implementation, a copy
+ of non-shared ArrayBuffers may not be needed in a synchronous call like this one.
+ It might also be possible to do a buffer copy at an earlier time or through a
+ different mechanism.</p>
      <li data-md>
       <p>If <var>writePosition</var> is larger than <var>oldSize</var>,
  append <var>writePosition</var> − <var>oldSize</var> <code>0x00</code> (NUL) bytes to the end of <var>fileContents</var>.</p>
@@ -2304,19 +2319,19 @@ these steps:
      <li data-md>
       <p>Let <var>tail</var> be an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①①">byte sequence</a>.</p>
      <li data-md>
-      <p>If <var>writePosition</var> + <var>data</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑥">length</a> is smaller than <var>oldSize</var>:</p>
+      <p>If <var>writePosition</var> + <var>data</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑦">length</a> is smaller than <var>oldSize</var>:</p>
       <ol>
        <li data-md>
-        <p>Set <var>tail</var> to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①②">byte sequence</a> containing the last <var>oldSize</var> − (<var>writePosition</var> + <var>data</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑦">length</a>) bytes of <var>fileContents</var>.</p>
+        <p>Set <var>tail</var> to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①②">byte sequence</a> containing the last <var>oldSize</var> − (<var>writePosition</var> + <var>data</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑧">length</a>) bytes of <var>fileContents</var>.</p>
       </ol>
      <li data-md>
-      <p>Let <var>newSize</var> be <var>head</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑧">length</a> + <var>data</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑨">length</a> + <var>tail</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①⓪">length</a>.</p>
+      <p>Let <var>newSize</var> be <var>head</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length⑨">length</a> + <var>data</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①⓪">length</a> + <var>tail</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①①">length</a>.</p>
      <li data-md>
       <p>If <var>newSize</var> − <var>oldSize</var> exceeds the available <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota④">storage quota</a>, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror②">QuotaExceededError</a></code>.</p>
      <li data-md>
-      <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑨">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑤">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑧">binary data</a> to the concatenation of <var>head</var>, <var>data</var> and <var>tail</var>.</p>
+      <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑧">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑦">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑦">binary data</a> to the concatenation of <var>head</var>, <var>data</var> and <var>tail</var>.</p>
      <li data-md>
-      <p>If the operations modifying the <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⓪">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑥">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑨">binary data</a> in the previous steps
+      <p>If the operations modifying the <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑨">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑧">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑧">binary data</a> in the previous steps
  failed:</p>
       <ol>
        <li data-md>
@@ -2326,7 +2341,7 @@ these steps:
         <p>Else return 0.</p>
       </ol>
      <li data-md>
-      <p>Return <var>data</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①①">length</a>.</p>
+      <p>Return <var>data</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①②">length</a>.</p>
     </ol>
    </div>
    <h4 class="heading settled" data-level="2.7.3" id="api-filesystemsyncaccesshandle-truncate"><span class="secno">2.7.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-truncate" id="ref-for-dom-filesystemsyncaccesshandle-truncate①">truncate()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-truncate"></a></h4>
@@ -2342,30 +2357,36 @@ these steps:
 these steps: 
     <ol>
      <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③①">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state③">[[state]]</a> is "<code>closed</code>", return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with①">a promise rejected with</a> an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror③">InvalidStateError</a></code>.</p>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⓪">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state③">[[state]]</a> is "<code>closed</code>", return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with①">a promise rejected with</a> an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror②">InvalidStateError</a></code>.</p>
      <li data-md>
-      <p>Let <var>fileContents</var> be a copy of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③②">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑤">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①⓪">binary data</a>.</p>
+      <p>Let <var>fileContents</var> be a copy of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③①">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file②">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑨">binary data</a>.</p>
      <li data-md>
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①③">a new promise</a> created in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm③">relevant Realm</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③③">this</a>.</p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①③">a new promise</a> created in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm③">relevant Realm</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③②">this</a>.</p>
      <li data-md>
       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①②">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>oldSize</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①②">length</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③④">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑥">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①①">binary data</a>.</p>
+        <p>Let <var>oldSize</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①③">length</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③③">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑨">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①⓪">binary data</a>.</p>
        <li data-md>
         <p>If <var>newSize</var> is larger than <var>oldSize</var>:</p>
         <ol>
          <li data-md>
           <p>If <var>newSize</var> − <var>oldSize</var> exceeds the available <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota⑤">storage quota</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑦">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror③">QuotaExceededError</a></code> and abort.</p>
          <li data-md>
-          <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑤">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑦">[[file]]</a>'s to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①③">byte sequence</a> formed by concatenating <var>fileContents</var> with a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①④">byte sequence</a> containing <var>newSize</var> − <var>oldSize</var> <code>0x00</code> bytes.</p>
+          <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③④">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file①⓪">[[file]]</a>'s to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①③">byte sequence</a> formed by concatenating <var>fileContents</var> with a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①④">byte sequence</a> containing <var>newSize</var> − <var>oldSize</var> <code>0x00</code> bytes.</p>
+         <li data-md>
+          <p>If the operations modifying the <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑤">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file①①">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①①">binary data</a> in the previous steps
+  failed, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑧">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror③">InvalidStateError</a></code> and abort.</p>
         </ol>
        <li data-md>
         <p>Else if <var>newSize</var> is smaller than <var>oldSize</var>:</p>
         <ol>
          <li data-md>
-          <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑥">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file⑧">[[file]]</a>'s to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①⑤">byte sequence</a> containing the first <var>newSize</var> bytes
+          <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑥">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file③">[[file]]</a>'s to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①⑤">byte sequence</a> containing the first <var>newSize</var> bytes
   in <var>fileContents</var>.</p>
+         <li data-md>
+          <p>If the operations modifying the <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑦">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file④">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①②">binary data</a> in the previous steps
+  failed, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑨">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror④">InvalidStateError</a></code> and abort.</p>
         </ol>
        <li data-md>
         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②①">Resolve</a> <var>p</var>.</p>
@@ -2387,14 +2408,14 @@ these steps:
 these steps: 
     <ol>
      <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑦">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state④">[[state]]</a> is "<code>closed</code>", return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with②">a promise rejected with</a> an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror④">InvalidStateError</a></code>.</p>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑧">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state④">[[state]]</a> is "<code>closed</code>", return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with②">a promise rejected with</a> an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror⑤">InvalidStateError</a></code>.</p>
      <li data-md>
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①④">a new promise</a> created in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm④">relevant Realm</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑧">this</a>.</p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①④">a new promise</a> created in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm④">relevant Realm</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑨">this</a>.</p>
      <li data-md>
       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①③">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>size</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①③">length</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③⑨">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file⑦">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①②">binary data</a>.</p>
+        <p>Let <var>size</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①④">length</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④⓪">this</a>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file①②">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①③">binary data</a>.</p>
        <li data-md>
         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②②">Resolve</a> <var>p</var> with <var>size</var>.</p>
       </ol>
@@ -2429,12 +2450,12 @@ these steps:
 these steps: 
     <ol>
      <li data-md>
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑤">a new promise</a> created in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm⑤">relevant Realm</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④⓪">this</a>.</p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑤">a new promise</a> created in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm⑤">relevant Realm</a> of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④①">this</a>.</p>
      <li data-md>
       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①④">in parallel</a>:</p>
       <ol>
        <li data-md>
-        <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④①">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state⑤">[[state]]</a> to "<code>closed</code>".</p>
+        <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④②">this</a>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-state" id="ref-for-filesystemsyncaccesshandle-state⑤">[[state]]</a> to "<code>closed</code>".</p>
        <li data-md>
         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②③">Resolve</a> <var>p</var>.</p>
       </ol>
@@ -2876,7 +2897,7 @@ file picker will open. See <a href="#api-filepickeroptions">§ 3.2 File picker
 these steps: 
      <ol>
       <li data-md>
-       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④②">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object③">relevant settings object</a>.</p>
+       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④③">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object③">relevant settings object</a>.</p>
       <li data-md>
        <p>Let <var>accepts options</var> be the result of <a data-link-type="dfn" href="#process-accept-types" id="ref-for-process-accept-types">processing accept types</a> given <var>options</var>.</p>
       <li data-md>
@@ -2902,7 +2923,7 @@ these steps:
         <li data-md>
          <p>Wait for the user to have made their selection.</p>
         <li data-md>
-         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑧">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror①">AbortError</a></code> and abort.</p>
+         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③⓪">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror①">AbortError</a></code> and abort.</p>
         <li data-md>
          <p>Let <var>entries</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> of <a data-link-type="dfn" href="#file" id="ref-for-file①④">file entries</a> representing the selected files or directories.</p>
         <li data-md>
@@ -2918,7 +2939,7 @@ these steps:
             <li data-md>
              <p>At the discretion of the user agent,
  either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑥">in parallel</a> steps,
- or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑨">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror②">AbortError</a></code> and abort.</p>
+ or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③①">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror②">AbortError</a></code> and abort.</p>
            </ol>
           <li data-md>
            <p>Add a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①①">FileSystemFileHandle</a></code> associated with <var>entry</var> to <var>result</var>.</p>
@@ -2973,7 +2994,7 @@ file picker will open. See <a href="#api-filepickeroptions">§ 3.2 File picker
 these steps: 
      <ol>
       <li data-md>
-       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④③">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object④">relevant settings object</a>.</p>
+       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④④">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object④">relevant settings object</a>.</p>
       <li data-md>
        <p>Let <var>accepts options</var> be the result of <a data-link-type="dfn" href="#process-accept-types" id="ref-for-process-accept-types①">processing accept types</a> given <var>options</var>.</p>
       <li data-md>
@@ -3005,7 +3026,7 @@ these steps:
         <li data-md>
          <p>Wait for the user to have made their selection.</p>
         <li data-md>
-         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③⓪">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror③">AbortError</a></code> and abort.</p>
+         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③②">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror③">AbortError</a></code> and abort.</p>
         <li data-md>
          <p>Let <var>entry</var> be a <a data-link-type="dfn" href="#file" id="ref-for-file①⑤">file entry</a> representing the selected file.</p>
         <li data-md>
@@ -3016,10 +3037,10 @@ these steps:
           <li data-md>
            <p>At the discretion of the user agent,
  either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑧">in parallel</a> steps,
- or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③①">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror④">AbortError</a></code> and abort.</p>
+ or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③③">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror④">AbortError</a></code> and abort.</p>
          </ol>
         <li data-md>
-         <p>Set <var>entry</var>’s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①③">binary data</a> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①⑥">byte sequence</a>.</p>
+         <p>Set <var>entry</var>’s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①④">binary data</a> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①⑥">byte sequence</a>.</p>
         <li data-md>
          <p>Set <var>result</var> to a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①②">FileSystemFileHandle</a></code> associated with <var>entry</var>.</p>
         <li data-md>
@@ -3067,7 +3088,7 @@ the selected directory.</p>
 these steps: 
      <ol>
       <li data-md>
-       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④④">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object⑤">relevant settings object</a>.</p>
+       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④⑤">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object⑤">relevant settings object</a>.</p>
       <li data-md>
        <p>Let <var>starting directory</var> be the result of <a data-link-type="dfn" href="#wellknowndirectory-determine-the-directory-the-picker-will-start-in" id="ref-for-wellknowndirectory-determine-the-directory-the-picker-will-start-in②">determining the directory the picker will start in</a> given <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-directorypickeroptions-id" id="ref-for-dom-directorypickeroptions-id①">id</a></code>, <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-directorypickeroptions-startin" id="ref-for-dom-directorypickeroptions-startin①">startIn</a></code> and <var>environment</var>.</p>
       <li data-md>
@@ -3087,7 +3108,7 @@ these steps:
         <li data-md>
          <p>Wait for the user to have made their selection.</p>
         <li data-md>
-         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③②">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror⑤">AbortError</a></code> and abort.</p>
+         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③④">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror⑤">AbortError</a></code> and abort.</p>
         <li data-md>
          <p>Let <var>entry</var> be a <a data-link-type="dfn" href="#directory" id="ref-for-directory⑨">directory entry</a> representing the selected directory.</p>
         <li data-md>
@@ -3098,7 +3119,7 @@ these steps:
           <li data-md>
            <p>At the discretion of the user agent,
  either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②⓪">in parallel</a> steps,
- or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③③">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror⑥">AbortError</a></code> and abort.</p>
+ or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③⑤">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror⑥">AbortError</a></code> and abort.</p>
          </ol>
         <li data-md>
          <p>Set <var>result</var> to a new <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①③">FileSystemDirectoryHandle</a></code> associated with <var>entry</var>.</p>
@@ -4318,11 +4339,10 @@ use this API to write to disk.</p>
   <aside class="dfn-panel" data-for="term-for-invalidstateerror">
    <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-invalidstateerror">2.4.3. The createSyncAccessHandle() method</a>
-    <li><a href="#ref-for-invalidstateerror①">2.7.1. The read() method</a>
-    <li><a href="#ref-for-invalidstateerror②">2.7.2. The write() method</a>
-    <li><a href="#ref-for-invalidstateerror③">2.7.3. The truncate() method</a>
-    <li><a href="#ref-for-invalidstateerror④">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-invalidstateerror">2.7.1. The read() method</a>
+    <li><a href="#ref-for-invalidstateerror①">2.7.2. The write() method</a>
+    <li><a href="#ref-for-invalidstateerror②">2.7.3. The truncate() method</a> <a href="#ref-for-invalidstateerror③">(2)</a> <a href="#ref-for-invalidstateerror④">(3)</a>
+    <li><a href="#ref-for-invalidstateerror⑤">2.7.4. The getSize() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-nomodificationallowederror">
@@ -4337,12 +4357,12 @@ use this API to write to disk.</p>
    <ul>
     <li><a href="#ref-for-notallowederror">2.4.1. The getFile() method</a>
     <li><a href="#ref-for-notallowederror①">2.4.2. The createWritable() method</a>
-    <li><a href="#ref-for-notallowederror②">2.4.3. The createSyncAccessHandle() method</a>
-    <li><a href="#ref-for-notallowederror③">2.5.1. Directory iteration</a> <a href="#ref-for-notallowederror④">(2)</a>
-    <li><a href="#ref-for-notallowederror⑤">2.5.2. The getFileHandle() method</a>
-    <li><a href="#ref-for-notallowederror⑥">2.5.3. The getDirectoryHandle() method</a>
-    <li><a href="#ref-for-notallowederror⑦">2.5.4. The removeEntry() method</a>
-    <li><a href="#ref-for-notallowederror⑧">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-notallowederror⑨">(2)</a>
+    <li><a href="#ref-for-notallowederror②">2.4.3. The createSyncAccessHandle() method</a> <a href="#ref-for-notallowederror③">(2)</a>
+    <li><a href="#ref-for-notallowederror④">2.5.1. Directory iteration</a> <a href="#ref-for-notallowederror⑤">(2)</a>
+    <li><a href="#ref-for-notallowederror⑥">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-notallowederror⑦">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-notallowederror⑧">2.5.4. The removeEntry() method</a>
+    <li><a href="#ref-for-notallowederror⑨">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-notallowederror①⓪">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-notfounderror">
@@ -4519,10 +4539,10 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-reject①⓪">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-reject①①">(2)</a> <a href="#ref-for-reject①②">(3)</a> <a href="#ref-for-reject①③">(4)</a> <a href="#ref-for-reject①④">(5)</a>
     <li><a href="#ref-for-reject①⑤">2.5.4. The removeEntry() method</a> <a href="#ref-for-reject①⑥">(2)</a> <a href="#ref-for-reject①⑦">(3)</a> <a href="#ref-for-reject①⑧">(4)</a> <a href="#ref-for-reject①⑨">(5)</a>
     <li><a href="#ref-for-reject②⓪">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-reject②①">(2)</a> <a href="#ref-for-reject②②">(3)</a> <a href="#ref-for-reject②③">(4)</a> <a href="#ref-for-reject②④">(5)</a> <a href="#ref-for-reject②⑤">(6)</a> <a href="#ref-for-reject②⑥">(7)</a>
-    <li><a href="#ref-for-reject②⑦">2.7.3. The truncate() method</a>
-    <li><a href="#ref-for-reject②⑧">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-reject②⑨">(2)</a>
-    <li><a href="#ref-for-reject③⓪">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-reject③①">(2)</a>
-    <li><a href="#ref-for-reject③②">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-reject③③">(2)</a>
+    <li><a href="#ref-for-reject②⑦">2.7.3. The truncate() method</a> <a href="#ref-for-reject②⑧">(2)</a> <a href="#ref-for-reject②⑨">(3)</a>
+    <li><a href="#ref-for-reject③⓪">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-reject③①">(2)</a>
+    <li><a href="#ref-for-reject③②">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-reject③③">(2)</a>
+    <li><a href="#ref-for-reject③④">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-reject③⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-resolve">
@@ -4572,14 +4592,14 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-this②①">2.6.1. The write() method</a>
     <li><a href="#ref-for-this②②">2.6.2. The seek() method</a>
     <li><a href="#ref-for-this②③">2.6.3. The truncate() method</a>
-    <li><a href="#ref-for-this②④">2.7.1. The read() method</a> <a href="#ref-for-this②⑤">(2)</a> <a href="#ref-for-this②⑥">(3)</a>
-    <li><a href="#ref-for-this②⑦">2.7.2. The write() method</a> <a href="#ref-for-this②⑧">(2)</a> <a href="#ref-for-this②⑨">(3)</a> <a href="#ref-for-this③⓪">(4)</a>
-    <li><a href="#ref-for-this③①">2.7.3. The truncate() method</a> <a href="#ref-for-this③②">(2)</a> <a href="#ref-for-this③③">(3)</a> <a href="#ref-for-this③④">(4)</a> <a href="#ref-for-this③⑤">(5)</a> <a href="#ref-for-this③⑥">(6)</a>
-    <li><a href="#ref-for-this③⑦">2.7.4. The getSize() method</a> <a href="#ref-for-this③⑧">(2)</a> <a href="#ref-for-this③⑨">(3)</a>
-    <li><a href="#ref-for-this④⓪">2.7.6. The close() method</a> <a href="#ref-for-this④①">(2)</a>
-    <li><a href="#ref-for-this④②">3.3. The showOpenFilePicker() method</a>
-    <li><a href="#ref-for-this④③">3.4. The showSaveFilePicker() method</a>
-    <li><a href="#ref-for-this④④">3.5. The showDirectoryPicker() method</a>
+    <li><a href="#ref-for-this②④">2.7.1. The read() method</a> <a href="#ref-for-this②⑤">(2)</a>
+    <li><a href="#ref-for-this②⑥">2.7.2. The write() method</a> <a href="#ref-for-this②⑦">(2)</a> <a href="#ref-for-this②⑧">(3)</a> <a href="#ref-for-this②⑨">(4)</a>
+    <li><a href="#ref-for-this③⓪">2.7.3. The truncate() method</a> <a href="#ref-for-this③①">(2)</a> <a href="#ref-for-this③②">(3)</a> <a href="#ref-for-this③③">(4)</a> <a href="#ref-for-this③④">(5)</a> <a href="#ref-for-this③⑤">(6)</a> <a href="#ref-for-this③⑥">(7)</a> <a href="#ref-for-this③⑦">(8)</a>
+    <li><a href="#ref-for-this③⑧">2.7.4. The getSize() method</a> <a href="#ref-for-this③⑨">(2)</a> <a href="#ref-for-this④⓪">(3)</a>
+    <li><a href="#ref-for-this④①">2.7.6. The close() method</a> <a href="#ref-for-this④②">(2)</a>
+    <li><a href="#ref-for-this④③">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-this④④">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-this④⑤">3.5. The showDirectoryPicker() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-undefined">
@@ -5096,11 +5116,11 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-file-entry-binary-data②">2.4.2. The createWritable() method</a>
     <li><a href="#ref-for-file-entry-binary-data③">2.5.2. The getFileHandle() method</a>
     <li><a href="#ref-for-file-entry-binary-data④">2.6. The FileSystemWritableFileStream interface</a>
-    <li><a href="#ref-for-file-entry-binary-data⑤">2.7.1. The read() method</a> <a href="#ref-for-file-entry-binary-data⑥">(2)</a>
-    <li><a href="#ref-for-file-entry-binary-data⑦">2.7.2. The write() method</a> <a href="#ref-for-file-entry-binary-data⑧">(2)</a> <a href="#ref-for-file-entry-binary-data⑨">(3)</a>
-    <li><a href="#ref-for-file-entry-binary-data①⓪">2.7.3. The truncate() method</a> <a href="#ref-for-file-entry-binary-data①①">(2)</a>
-    <li><a href="#ref-for-file-entry-binary-data①②">2.7.4. The getSize() method</a>
-    <li><a href="#ref-for-file-entry-binary-data①③">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-file-entry-binary-data⑤">2.7.1. The read() method</a>
+    <li><a href="#ref-for-file-entry-binary-data⑥">2.7.2. The write() method</a> <a href="#ref-for-file-entry-binary-data⑦">(2)</a> <a href="#ref-for-file-entry-binary-data⑧">(3)</a>
+    <li><a href="#ref-for-file-entry-binary-data⑨">2.7.3. The truncate() method</a> <a href="#ref-for-file-entry-binary-data①⓪">(2)</a> <a href="#ref-for-file-entry-binary-data①①">(3)</a> <a href="#ref-for-file-entry-binary-data①②">(4)</a>
+    <li><a href="#ref-for-file-entry-binary-data①③">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-file-entry-binary-data①④">3.4. The showSaveFilePicker() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="file-entry-modification-timestamp">
@@ -5583,11 +5603,11 @@ than being defined here. So merge this into the table there. <a class="issue-ret
   <aside class="dfn-panel" data-for="filesystemwritablefilestream-file">
    <b><a href="#filesystemwritablefilestream-file">#filesystemwritablefilestream-file</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-filesystemwritablefilestream-file">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemwritablefilestream-file①">(2)</a> <a href="#ref-for-filesystemwritablefilestream-file②">(3)</a>
-    <li><a href="#ref-for-filesystemwritablefilestream-file③">2.7.1. The read() method</a>
-    <li><a href="#ref-for-filesystemwritablefilestream-file④">2.7.2. The write() method</a>
-    <li><a href="#ref-for-filesystemwritablefilestream-file⑤">2.7.3. The truncate() method</a> <a href="#ref-for-filesystemwritablefilestream-file⑥">(2)</a>
-    <li><a href="#ref-for-filesystemwritablefilestream-file⑦">2.7.4. The getSize() method</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemwritablefilestream-file①">(2)</a> <a href="#ref-for-filesystemwritablefilestream-file②">(3)</a> <a href="#ref-for-filesystemwritablefilestream-file③">(4)</a> <a href="#ref-for-filesystemwritablefilestream-file④">(5)</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file⑤">2.7.1. The read() method</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file⑥">2.7.2. The write() method</a> <a href="#ref-for-filesystemwritablefilestream-file⑦">(2)</a> <a href="#ref-for-filesystemwritablefilestream-file⑧">(3)</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file⑨">2.7.3. The truncate() method</a> <a href="#ref-for-filesystemwritablefilestream-file①⓪">(2)</a> <a href="#ref-for-filesystemwritablefilestream-file①①">(3)</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-file①②">2.7.4. The getSize() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="filesystemwritablefilestream-buffer">
@@ -5682,11 +5702,9 @@ than being defined here. So merge this into the table there. <a class="issue-ret
   <aside class="dfn-panel" data-for="filesystemsyncaccesshandle-file">
    <b><a href="#filesystemsyncaccesshandle-file">#filesystemsyncaccesshandle-file</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemsyncaccesshandle-file①">(2)</a> <a href="#ref-for-filesystemsyncaccesshandle-file②">(3)</a>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file③">2.7. The FileSystemSyncAccessHandle interface</a>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file④">2.7.1. The read() method</a>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file⑤">2.7.2. The write() method</a> <a href="#ref-for-filesystemsyncaccesshandle-file⑥">(2)</a>
-    <li><a href="#ref-for-filesystemsyncaccesshandle-file⑦">2.7.3. The truncate() method</a> <a href="#ref-for-filesystemsyncaccesshandle-file⑧">(2)</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file①">2.7. The FileSystemSyncAccessHandle interface</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file②">2.7.3. The truncate() method</a> <a href="#ref-for-filesystemsyncaccesshandle-file③">(2)</a> <a href="#ref-for-filesystemsyncaccesshandle-file④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="filesystemsyncaccesshandle-state">

--- a/index.html
+++ b/index.html
@@ -1,0 +1,6247 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <title>File System Access</title>
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
+  <meta content="Bikeshed version d7036035b, updated Fri Oct 8 17:07:11 2021 -0700" name="generator">
+  <link href="https://wicg.github.io/file-system-access/" rel="canonical">
+<style>
+.domintro dt {
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
+
+    padding-top: 0.5em;
+    padding-bottom: 1em;
+}
+.domintro dt a {
+    color: inherit; border-bottom-style: none;
+}
+.domintro dt code {
+    font-size: inherit;
+}
+.domintro::before {
+    content: 'For web developers (non-normative)';
+    text-transform: initial;
+
+}
+</style>
+<style>/* style-autolinks */
+
+.css.css, .property.property, .descriptor.descriptor {
+    color: var(--a-normal-text);
+    font-size: inherit;
+    font-family: inherit;
+}
+.css::before, .property::before, .descriptor::before {
+    content: "‘";
+}
+.css::after, .property::after, .descriptor::after {
+    content: "’";
+}
+.property, .descriptor {
+    /* Don't wrap property and descriptor names */
+    white-space: nowrap;
+}
+.type { /* CSS value <type> */
+    font-style: italic;
+}
+pre .property::before, pre .property::after {
+    content: "";
+}
+[data-link-type="property"]::before,
+[data-link-type="propdesc"]::before,
+[data-link-type="descriptor"]::before,
+[data-link-type="value"]::before,
+[data-link-type="function"]::before,
+[data-link-type="at-rule"]::before,
+[data-link-type="selector"]::before,
+[data-link-type="maybe"]::before {
+    content: "‘";
+}
+[data-link-type="property"]::after,
+[data-link-type="propdesc"]::after,
+[data-link-type="descriptor"]::after,
+[data-link-type="value"]::after,
+[data-link-type="function"]::after,
+[data-link-type="at-rule"]::after,
+[data-link-type="selector"]::after,
+[data-link-type="maybe"]::after {
+    content: "’";
+}
+
+[data-link-type].production::before,
+[data-link-type].production::after,
+.prod [data-link-type]::before,
+.prod [data-link-type]::after {
+    content: "";
+}
+
+[data-link-type=element],
+[data-link-type=element-attr] {
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    font-size: .9em;
+}
+[data-link-type=element]::before { content: "<" }
+[data-link-type=element]::after  { content: ">" }
+
+[data-link-type=biblio] {
+    white-space: pre;
+}</style>
+<style>/* style-colors */
+
+/* Any --*-text not paired with a --*-bg is assumed to have a transparent bg */
+:root {
+    color-scheme: light dark;
+
+    --text: black;
+    --bg: white;
+
+    --unofficial-watermark: url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
+
+    --logo-bg: #1a5e9a;
+    --logo-active-bg: #c00;
+    --logo-text: white;
+
+    --tocnav-normal-text: #707070;
+    --tocnav-normal-bg: var(--bg);
+    --tocnav-hover-text: var(--tocnav-normal-text);
+    --tocnav-hover-bg: #f8f8f8;
+    --tocnav-active-text: #c00;
+    --tocnav-active-bg: var(--tocnav-normal-bg);
+
+    --tocsidebar-text: var(--text);
+    --tocsidebar-bg: #f7f8f9;
+    --tocsidebar-shadow: rgba(0,0,0,.1);
+    --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+    --toclink-text: var(--text);
+    --toclink-underline: #3980b5;
+    --toclink-visited-text: var(--toclink-text);
+    --toclink-visited-underline: #054572;
+
+    --heading-text: #005a9c;
+
+    --hr-text: var(--text);
+
+    --algo-border: #def;
+
+    --del-text: red;
+    --del-bg: transparent;
+    --ins-text: #080;
+    --ins-bg: transparent;
+
+    --a-normal-text: #034575;
+    --a-normal-underline: #bbb;
+    --a-visited-text: var(--a-normal-text);
+    --a-visited-underline: #707070;
+    --a-hover-bg: rgba(75%, 75%, 75%, .25);
+    --a-active-text: #c00;
+    --a-active-underline: #c00;
+
+    --blockquote-border: silver;
+    --blockquote-bg: transparent;
+    --blockquote-text: currentcolor;
+
+    --issue-border: #e05252;
+    --issue-bg: #fbe9e9;
+    --issue-text: var(--text);
+    --issueheading-text: #831616;
+
+    --example-border: #e0cb52;
+    --example-bg: #fcfaee;
+    --example-text: var(--text);
+    --exampleheading-text: #574b0f;
+
+    --note-border: #52e052;
+    --note-bg: #e9fbe9;
+    --note-text: var(--text);
+    --noteheading-text: hsl(120, 70%, 30%);
+    --notesummary-underline: silver;
+
+    --assertion-border: #aaa;
+    --assertion-bg: #eee;
+    --assertion-text: black;
+
+    --advisement-border: orange;
+    --advisement-bg: #fec;
+    --advisement-text: var(--text);
+    --advisementheading-text: #b35f00;
+
+    --warning-border: red;
+    --warning-bg: hsla(40,100%,50%,0.95);
+    --warning-text: var(--text);
+
+    --amendment-border: #330099;
+    --amendment-bg: #F5F0FF;
+    --amendment-text: var(--text);
+    --amendmentheading-text: #220066;
+
+    --def-border: #8ccbf2;
+    --def-bg: #def;
+    --def-text: var(--text);
+    --defrow-border: #bbd7e9;
+
+    --datacell-border: silver;
+
+    --indexinfo-text: #707070;
+
+    --indextable-hover-text: black;
+    --indextable-hover-bg: #f7f8f9;
+
+    --outdatedspec-bg: rgba(0, 0, 0, .5);
+    --outdatedspec-text: black;
+    --outdated-bg: maroon;
+    --outdated-text: white;
+    --outdated-shadow: red;
+
+    --editedrec-bg: darkorange;
+}</style>
+<style>/* style-counters */
+
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
+
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
+
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}</style>
+<style>/* style-dfn-panel */
+
+:root {
+    --dfnpanel-bg: #ddd;
+    --dfnpanel-text: var(--text);
+}
+.dfn-panel {
+    position: absolute;
+    z-index: 35;
+    height: auto;
+    width: -webkit-fit-content;
+    width: fit-content;
+    max-width: 300px;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.75em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: var(--dfnpanel-bg);
+    color: var(--dfnpanel-text);
+    border: outset 0.2em;
+}
+.dfn-panel:not(.on) { display: none; }
+.dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+.dfn-panel > b { display: block; }
+.dfn-panel a { color: var(--dfnpanel-text); }
+.dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+.dfn-panel > b + b { margin-top: 0.25em; }
+.dfn-panel ul { padding: 0; }
+.dfn-panel li { list-style: inside; }
+.dfn-panel.activated {
+    display: inline-block;
+    position: fixed;
+    left: .5em;
+    bottom: 2em;
+    margin: 0 auto;
+    max-width: calc(100vw - 1.5em - .4em - .5em);
+    max-height: 30vh;
+}
+
+.dfn-paneled { cursor: pointer; }
+</style>
+<style>/* style-issues */
+
+a[href].issue-return {
+    float: right;
+    float: inline-end;
+    color: var(--issueheading-text);
+    font-weight: bold;
+    text-decoration: none;
+}
+</style>
+<style>/* style-md-lists */
+
+/* This is a weird hack for me not yet following the commonmark spec
+   regarding paragraph and lists. */
+[data-md] > :first-child {
+    margin-top: 0;
+}
+[data-md] > :last-child {
+    margin-bottom: 0;
+}</style>
+<style>/* style-mdn-anno */
+
+            @media (max-width: 767px) { .mdn-anno { opacity: .1 } }
+            .mdn-anno { font: 1em sans-serif; padding: 0.3em; position: absolute; z-index: 8; right: 0.3em; background: #EEE; color: black; box-shadow: 0 0 3px #999; overflow: hidden; border-collapse: initial; border-spacing: initial; min-width: 9em; max-width: min-content; white-space: nowrap; word-wrap: normal; hyphens: none}
+            .mdn-anno:not(.wrapped) { opacity: 1}
+            .mdn-anno:hover { z-index: 9 }
+            .mdn-anno.wrapped { min-width: 0 }
+            .mdn-anno.wrapped > :not(button) { display: none; }
+            .mdn-anno > .mdn-anno-btn { cursor: pointer; border: none; color: #000; background: transparent; margin: -8px; float: right; padding: 10px 8px 8px 8px; outline: none; }
+            .mdn-anno > .mdn-anno-btn > .less-than-two-engines-flag { color: red; padding-right: 2px; }
+            .mdn-anno > .mdn-anno-btn > .all-engines-flag { color: green; padding-right: 2px; }
+            .mdn-anno > .mdn-anno-btn > span { color: #fff; background-color: #000; font-weight: normal; font-family: zillaslab, Palatino, "Palatino Linotype", serif; padding: 2px 3px 0px 3px; line-height: 1.3em; vertical-align: top; }
+            .mdn-anno > .feature { margin-top: 20px; }
+            .mdn-anno > .feature:not(:first-of-type) { border-top: 1px solid #999; margin-top: 6px; padding-top: 2px; }
+            .mdn-anno > .feature > .less-than-two-engines-text { color: red }
+            .mdn-anno > .feature > .all-engines-text { color: green }
+            .mdn-anno > .feature > p { font-size: .75em; margin-top: 6px; margin-bottom: 0; }
+            .mdn-anno > .feature > p + p { margin-top: 3px; }
+            .mdn-anno > .feature > .support { display: block; font-size: 0.6em; margin: 0; padding: 0; margin-top: 2px }
+            .mdn-anno > .feature > .support + div { padding-top: 0.5em; }
+            .mdn-anno > .feature > .support > hr { display: block; border: none; border-top: 1px dotted #999; padding: 3px 0px 0px 0px; margin: 2px 3px 0px 3px; }
+            .mdn-anno > .feature > .support > hr::before { content: ""; }
+            .mdn-anno > .feature > .support > span { padding: 0.2em 0; display: block; display: table; }
+            .mdn-anno > .feature > .support > span.no { color: #CCCCCC; filter: grayscale(100%); }
+            .mdn-anno > .feature > .support > span.no::before { opacity: 0.5; }
+            .mdn-anno > .feature > .support > span:first-of-type { padding-top: 0.5em; }
+            .mdn-anno > .feature > .support > span > span { padding: 0 0.5em; display: table-cell; }
+            .mdn-anno > .feature > .support > span > span:first-child { width: 100%; }
+            .mdn-anno > .feature > .support > span > span:last-child { width: 100%; white-space: pre; padding: 0; }
+            .mdn-anno > .feature > .support > span::before { content: ' '; display: table-cell; min-width: 1.5em; height: 1.5em; background: no-repeat center center; background-size: contain; text-align: right; font-size: 0.75em; font-weight: bold; }
+            .mdn-anno > .feature > .support > .chrome_android::before { background-image: url(https://resources.whatwg.org/browser-logos/chrome.svg); }
+            .mdn-anno > .feature > .support > .firefox_android::before { background-image: url(https://resources.whatwg.org/browser-logos/firefox.png); }
+            .mdn-anno > .feature > .support > .chrome::before { background-image: url(https://resources.whatwg.org/browser-logos/chrome.svg); }
+            .mdn-anno > .feature > .support > .edge_blink::before { background-image: url(https://resources.whatwg.org/browser-logos/edge.svg); }
+            .mdn-anno > .feature > .support > .edge::before { background-image: url(https://resources.whatwg.org/browser-logos/edge_legacy.svg); }
+            .mdn-anno > .feature > .support > .firefox::before { background-image: url(https://resources.whatwg.org/browser-logos/firefox.png); }
+            .mdn-anno > .feature > .support > .ie::before { background-image: url(https://resources.whatwg.org/browser-logos/ie.png); }
+            .mdn-anno > .feature > .support > .safari_ios::before { background-image: url(https://resources.whatwg.org/browser-logos/safari-ios.svg); }
+            .mdn-anno > .feature > .support > .nodejs::before { background-image: url(https://nodejs.org/static/images/favicons/favicon.ico); }
+            .mdn-anno > .feature > .support > .opera_android::before { background-image: url(https://resources.whatwg.org/browser-logos/opera.svg); }
+            .mdn-anno > .feature > .support > .opera::before { background-image: url(https://resources.whatwg.org/browser-logos/opera.svg); }
+            .mdn-anno > .feature > .support > .safari::before { background-image: url(https://resources.whatwg.org/browser-logos/safari.png); }
+            .mdn-anno > .feature > .support > .samsunginternet_android::before { background-image: url(https://resources.whatwg.org/browser-logos/samsung.svg); }
+            .mdn-anno > .feature > .support > .webview_android::before { background-image: url(https://resources.whatwg.org/browser-logos/android-webview.png); }
+            .name-slug-mismatch { color: red }
+            .caniuse-status:hover { z-index: 9; }
+
+            /* dt, li, .issue, .note, and .example are "position: relative", so to put annotation at right margin, must move to right of containing block */
+            .h-entry:not(.status-LS) dt > .mdn-anno, .h-entry:not(.status-LS) li > .mdn-anno, .h-entry:not(.status-LS) .issue > .mdn-anno, .h-entry:not(.status-LS) .note > .mdn-anno, .h-entry:not(.status-LS) .example > .mdn-anno { right: -6.7em; }
+            .h-entry p + .mdn-anno { margin-top: 0; }
+            h2 + .mdn-anno.after { margin: -48px 0 0 0; }
+            h3 + .mdn-anno.after { margin: -46px 0 0 0; }
+            h4 + .mdn-anno.after { margin: -42px 0 0 0; }
+            h5 + .mdn-anno.after { margin: -40px 0 0 0; }
+            h6 + .mdn-anno.after { margin: -40px 0 0 0; }
+            </style>
+<style>/* style-selflinks */
+
+:root {
+    --selflink-text: white;
+    --selflink-bg: gray;
+    --selflink-hover-text: black;
+}
+.heading, .issue, .note, .example, li, dt {
+    position: relative;
+}
+a.self-link {
+    position: absolute;
+    top: 0;
+    left: calc(-1 * (3.5rem - 26px));
+    width: calc(3.5rem - 26px);
+    height: 2em;
+    text-align: center;
+    border: none;
+    transition: opacity .2s;
+    opacity: .5;
+}
+a.self-link:hover {
+    opacity: 1;
+}
+.heading > a.self-link {
+    font-size: 83%;
+}
+li > a.self-link {
+    left: calc(-1 * (3.5rem - 26px) - 2em);
+}
+dfn > a.self-link {
+    top: auto;
+    left: auto;
+    opacity: 0;
+    width: 1.5em;
+    height: 1.5em;
+    background: var(--selflink-bg);
+    color: var(--selflink-text);
+    font-style: normal;
+    transition: opacity .2s, background-color .2s, color .2s;
+}
+dfn:hover > a.self-link {
+    opacity: 1;
+}
+dfn > a.self-link:hover {
+    color: var(--selflink-hover-text);
+}
+
+a.self-link::before            { content: "¶"; }
+.heading > a.self-link::before { content: "§"; }
+dfn > a.self-link::before      { content: "#"; }
+</style>
+<style>/* style-syntax-highlighting */
+
+            pre.idl.highlight {
+                background: var(--borderedblock-bg, var(--def-bg));
+            }
+            
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+
+.highlight:not(.idl) { background: rgba(0, 0, 0, .03); }
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
+</style>
+<style>/* style-var-click-highlighting */
+
+    var { cursor: pointer; }
+    var.selected0 { background-color: #F4D200; box-shadow: 0 0 0 2px #F4D200; }
+    var.selected1 { background-color: #FF87A2; box-shadow: 0 0 0 2px #FF87A2; }
+    var.selected2 { background-color: #96E885; box-shadow: 0 0 0 2px #96E885; }
+    var.selected3 { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEED2; }
+    var.selected4 { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
+    var.selected5 { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
+    var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+    </style>
+<style>/* style-darkmode */
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text: #ddd;
+        --bg: black;
+
+        --unofficial-watermark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400'%3E%3Cg fill='%23100808' transform='translate(200 200) rotate(-45) translate(-200 -200)' stroke='%23100808' stroke-width='3'%3E%3Ctext x='50%25' y='220' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EUNOFFICIAL%3C/text%3E%3Ctext x='50%25' y='305' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EDRAFT%3C/text%3E%3C/g%3E%3C/svg%3E");
+
+        --logo-bg: #1a5e9a;
+        --logo-active-bg: #c00;
+        --logo-text: white;
+
+        --tocnav-normal-text: #999;
+        --tocnav-normal-bg: var(--bg);
+        --tocnav-hover-text: var(--tocnav-normal-text);
+        --tocnav-hover-bg: #080808;
+        --tocnav-active-text: #f44;
+        --tocnav-active-bg: var(--tocnav-normal-bg);
+
+        --tocsidebar-text: var(--text);
+        --tocsidebar-bg: #080808;
+        --tocsidebar-shadow: rgba(255,255,255,.1);
+        --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+        --toclink-text: var(--text);
+        --toclink-underline: #6af;
+        --toclink-visited-text: var(--toclink-text);
+        --toclink-visited-underline: #054572;
+
+        --heading-text: #8af;
+
+        --hr-text: var(--text);
+
+        --algo-border: #456;
+
+        --del-text: #f44;
+        --del-bg: transparent;
+        --ins-text: #4a4;
+        --ins-bg: transparent;
+
+        --a-normal-text: #6af;
+        --a-normal-underline: #555;
+        --a-visited-text: var(--a-normal-text);
+        --a-visited-underline: var(--a-normal-underline);
+        --a-hover-bg: rgba(25%, 25%, 25%, .2);
+        --a-active-text: #f44;
+        --a-active-underline: var(--a-active-text);
+
+        --borderedblock-bg: rgba(255, 255, 255, .05);
+
+        --blockquote-border: silver;
+        --blockquote-bg: var(--borderedblock-bg);
+        --blockquote-text: currentcolor;
+
+        --issue-border: #e05252;
+        --issue-bg: var(--borderedblock-bg);
+        --issue-text: var(--text);
+        --issueheading-text: hsl(0deg, 70%, 70%);
+
+        --example-border: hsl(50deg, 90%, 60%);
+        --example-bg: var(--borderedblock-bg);
+        --example-text: var(--text);
+        --exampleheading-text: hsl(50deg, 70%, 70%);
+
+        --note-border: hsl(120deg, 100%, 35%);
+        --note-bg: var(--borderedblock-bg);
+        --note-text: var(--text);
+        --noteheading-text: hsl(120, 70%, 70%);
+        --notesummary-underline: silver;
+
+        --assertion-border: #444;
+        --assertion-bg: var(--borderedblock-bg);
+        --assertion-text: var(--text);
+
+        --advisement-border: orange;
+        --advisement-bg: #222218;
+        --advisement-text: var(--text);
+        --advisementheading-text: #f84;
+
+        --warning-border: red;
+        --warning-bg: hsla(40,100%,20%,0.95);
+        --warning-text: var(--text);
+
+        --amendment-border: #330099;
+        --amendment-bg: #080010;
+        --amendment-text: var(--text);
+        --amendmentheading-text: #cc00ff;
+
+        --def-border: #8ccbf2;
+        --def-bg: #080818;
+        --def-text: var(--text);
+        --defrow-border: #136;
+
+        --datacell-border: silver;
+
+        --indexinfo-text: #aaa;
+
+        --indextable-hover-text: var(--text);
+        --indextable-hover-bg: #181818;
+
+        --outdatedspec-bg: rgba(255, 255, 255, .5);
+        --outdatedspec-text: black;
+        --outdated-bg: maroon;
+        --outdated-text: white;
+        --outdated-shadow: red;
+
+        --editedrec-bg: darkorange;
+    }
+    /* In case a transparent-bg image doesn't expect to be on a dark bg,
+       which is quite common in practice... */
+    img { background: white; }
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --selflink-text: black;
+        --selflink-bg: silver;
+        --selflink-hover-text: white;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --dfnpanel-bg: #222;
+        --dfnpanel-text: var(--text);
+    }
+}
+@media (prefers-color-scheme: dark) {
+    .highlight:not(.idl) { background: rgba(255, 255, 255, .05); }
+
+    c-[a] { color: #d33682 } /* Keyword.Declaration */
+    c-[b] { color: #d33682 } /* Keyword.Type */
+    c-[c] { color: #2aa198 } /* Comment */
+    c-[d] { color: #2aa198 } /* Comment.Multiline */
+    c-[e] { color: #268bd2 } /* Name.Attribute */
+    c-[f] { color: #b58900 } /* Name.Tag */
+    c-[g] { color: #cb4b16 } /* Name.Variable */
+    c-[k] { color: #d33682 } /* Keyword */
+    c-[l] { color: #657b83 } /* Literal */
+    c-[m] { color: #657b83 } /* Literal.Number */
+    c-[n] { color: #268bd2 } /* Name */
+    c-[o] { color: #657b83 } /* Operator */
+    c-[p] { color: #657b83 } /* Punctuation */
+    c-[s] { color: #6c71c4 } /* Literal.String */
+    c-[t] { color: #6c71c4 } /* Literal.String.Single */
+    c-[u] { color: #6c71c4 } /* Literal.String.Double */
+    c-[ch] { color: #2aa198 } /* Comment.Hashbang */
+    c-[cp] { color: #2aa198 } /* Comment.Preproc */
+    c-[cpf] { color: #2aa198 } /* Comment.PreprocFile */
+    c-[c1] { color: #2aa198 } /* Comment.Single */
+    c-[cs] { color: #2aa198 } /* Comment.Special */
+    c-[kc] { color: #d33682 } /* Keyword.Constant */
+    c-[kn] { color: #d33682 } /* Keyword.Namespace */
+    c-[kp] { color: #d33682 } /* Keyword.Pseudo */
+    c-[kr] { color: #d33682 } /* Keyword.Reserved */
+    c-[ld] { color: #657b83 } /* Literal.Date */
+    c-[nc] { color: #268bd2 } /* Name.Class */
+    c-[no] { color: #268bd2 } /* Name.Constant */
+    c-[nd] { color: #268bd2 } /* Name.Decorator */
+    c-[ni] { color: #268bd2 } /* Name.Entity */
+    c-[ne] { color: #268bd2 } /* Name.Exception */
+    c-[nf] { color: #268bd2 } /* Name.Function */
+    c-[nl] { color: #268bd2 } /* Name.Label */
+    c-[nn] { color: #268bd2 } /* Name.Namespace */
+    c-[py] { color: #268bd2 } /* Name.Property */
+    c-[ow] { color: #657b83 } /* Operator.Word */
+    c-[mb] { color: #657b83 } /* Literal.Number.Bin */
+    c-[mf] { color: #657b83 } /* Literal.Number.Float */
+    c-[mh] { color: #657b83 } /* Literal.Number.Hex */
+    c-[mi] { color: #657b83 } /* Literal.Number.Integer */
+    c-[mo] { color: #657b83 } /* Literal.Number.Oct */
+    c-[sa] { color: #6c71c4 } /* Literal.String.Affix */
+    c-[sb] { color: #6c71c4 } /* Literal.String.Backtick */
+    c-[sc] { color: #6c71c4 } /* Literal.String.Char */
+    c-[dl] { color: #6c71c4 } /* Literal.String.Delimiter */
+    c-[sd] { color: #6c71c4 } /* Literal.String.Doc */
+    c-[se] { color: #6c71c4 } /* Literal.String.Escape */
+    c-[sh] { color: #6c71c4 } /* Literal.String.Heredoc */
+    c-[si] { color: #6c71c4 } /* Literal.String.Interpol */
+    c-[sx] { color: #6c71c4 } /* Literal.String.Other */
+    c-[sr] { color: #6c71c4 } /* Literal.String.Regex */
+    c-[ss] { color: #6c71c4 } /* Literal.String.Symbol */
+    c-[fm] { color: #268bd2 } /* Name.Function.Magic */
+    c-[vc] { color: #cb4b16 } /* Name.Variable.Class */
+    c-[vg] { color: #cb4b16 } /* Name.Variable.Global */
+    c-[vi] { color: #cb4b16 } /* Name.Variable.Instance */
+    c-[vm] { color: #cb4b16 } /* Name.Variable.Magic */
+    c-[il] { color: #657b83 } /* Literal.Number.Integer.Long */
+}
+</style>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
+   <h1 class="p-name no-ref" id="title">File System Access</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2021-11-03">3 November 2021</time></span></h2>
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="https://wicg.github.io/file-system-access/">https://wicg.github.io/file-system-access/</a>
+     <dt>Issue Tracking:
+     <dd><a href="https://github.com/wicg/file-system-access/issues/">GitHub</a>
+     <dd><a href="#issues-index">Inline In Spec</a>
+     <dt class="editor">Editor:
+     <dd class="editor p-author h-card vcard" data-editor-id="72440"><a class="p-name fn u-email email" href="mailto:mek@chromium.org">Marijn Kruisselbrink</a> (<span class="p-org org">Google</span>)
+    </dl>
+   </div>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2021 the Contributors to the File System Access Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
+   <hr title="Separator for header">
+  </div>
+  <div class="p-summary" data-fill-with="abstract">
+   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+   <p>This document defines a web platform API that enables developers to build
+
+  powerful web apps that interact with files on the user’s local device.
+  It builds on <a data-link-type="biblio" href="#biblio-file-api">File API</a> for file reading capabilities, and adds new API
+  surface to enable modifying files, as well as working with directories.</p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
+  <div data-fill-with="status">
+   <p> This specification was published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a>.
+  It is not a W3C Standard nor is it on the W3C Standards Track.
+
+  Please note that under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a> there is a limited opt-out and other conditions apply.
+
+  Learn more about <a href="http://www.w3.org/community/">W3C Community and Business Groups</a>. </p>
+   <p></p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li><a href="#introduction"><span class="secno">1</span> <span class="content">Introduction</span></a>
+    <li>
+     <a href="#files-and-directories"><span class="secno">2</span> <span class="content">Files and Directories</span></a>
+     <ol class="toc">
+      <li><a href="#concepts"><span class="secno">2.1</span> <span class="content">Concepts</span></a>
+      <li><a href="#permissions"><span class="secno">2.2</span> <span class="content">Permissions</span></a>
+      <li>
+       <a href="#api-filesystemhandle"><span class="secno">2.3</span> <span class="content">The <code class="idl"><span>FileSystemHandle</span></code> interface</span></a>
+       <ol class="toc">
+        <li><a href="#api-filesystemhandle-issameentry"><span class="secno">2.3.1</span> <span class="content">The <code class="idl"><span>isSameEntry()</span></code> method</span></a>
+        <li><a href="#api-filesystemhandle-querypermission"><span class="secno">2.3.2</span> <span class="content">The <code class="idl"><span>queryPermission()</span></code> method</span></a>
+        <li><a href="#api-filesystemhandle-requestpermission"><span class="secno">2.3.3</span> <span class="content">The <code class="idl"><span>requestPermission()</span></code> method</span></a>
+       </ol>
+      <li>
+       <a href="#api-filesystemfilehandle"><span class="secno">2.4</span> <span class="content">The <code class="idl"><span>FileSystemFileHandle</span></code> interface</span></a>
+       <ol class="toc">
+        <li><a href="#api-filesystemfilehandle-getfile"><span class="secno">2.4.1</span> <span class="content">The <code class="idl"><span>getFile()</span></code> method</span></a>
+        <li><a href="#api-filesystemfilehandle-createwritable"><span class="secno">2.4.2</span> <span class="content">The <code class="idl"><span>createWritable()</span></code> method</span></a>
+        <li><a href="#api-filesystemfilehandle-createsyncaccesshandle"><span class="secno">2.4.3</span> <span class="content">The <code class="idl"><span>createSyncAccessHandle()</span></code> method</span></a>
+       </ol>
+      <li>
+       <a href="#api-filesystemdirectoryhandle"><span class="secno">2.5</span> <span class="content">The <code class="idl"><span>FileSystemDirectoryHandle</span></code> interface</span></a>
+       <ol class="toc">
+        <li><a href="#api-filesystemdirectoryhandle-asynciterable"><span class="secno">2.5.1</span> <span class="content">Directory iteration</span></a>
+        <li><a href="#api-filesystemdirectoryhandle-getfilehandle"><span class="secno">2.5.2</span> <span class="content">The <code class="idl"><span>getFileHandle()</span></code> method</span></a>
+        <li><a href="#api-filesystemdirectoryhandle-getdirectoryhandle"><span class="secno">2.5.3</span> <span class="content">The <code class="idl"><span>getDirectoryHandle()</span></code> method</span></a>
+        <li><a href="#api-filesystemdirectoryhandle-removeentry"><span class="secno">2.5.4</span> <span class="content">The <code class="idl"><span>removeEntry()</span></code> method</span></a>
+        <li><a href="#api-filesystemdirectoryhandle-resolve"><span class="secno">2.5.5</span> <span class="content">The <code class="idl"><span>resolve()</span></code> method</span></a>
+       </ol>
+      <li>
+       <a href="#api-filesystemwritablefilestream"><span class="secno">2.6</span> <span class="content">The <code class="idl"><span>FileSystemWritableFileStream</span></code> interface</span></a>
+       <ol class="toc">
+        <li><a href="#api-filesystemwritablefilestream-write"><span class="secno">2.6.1</span> <span class="content">The <code class="idl"><span>write()</span></code> method</span></a>
+        <li><a href="#api-filesystemwritablefilestream-seek"><span class="secno">2.6.2</span> <span class="content">The <code class="idl"><span>seek()</span></code> method</span></a>
+        <li><a href="#api-filesystemwritablefilestream-truncate"><span class="secno">2.6.3</span> <span class="content">The <code class="idl"><span>truncate()</span></code> method</span></a>
+       </ol>
+      <li>
+       <a href="#api-filesystemsyncaccesshandle"><span class="secno">2.7</span> <span class="content">The <code class="idl"><span>FileSystemSyncAccessHandle</span></code> interface</span></a>
+       <ol class="toc">
+        <li><a href="#api-filesystemsyncaccesshandle-read"><span class="secno">2.7.1</span> <span class="content">The <code class="idl"><span>read()</span></code> method</span></a>
+        <li><a href="#api-filesystemsyncaccesshandle-write"><span class="secno">2.7.2</span> <span class="content">The <code class="idl"><span>write()</span></code> method</span></a>
+        <li><a href="#api-filesystemsyncaccesshandle-truncate"><span class="secno">2.7.3</span> <span class="content">The <code class="idl"><span>truncate()</span></code> method</span></a>
+        <li><a href="#api-filesystemsyncaccesshandle-getsize"><span class="secno">2.7.4</span> <span class="content">The <code class="idl"><span>getSize()</span></code> method</span></a>
+        <li><a href="#api-filesystemsyncaccesshandle-flush"><span class="secno">2.7.5</span> <span class="content">The <code class="idl"><span>flush()</span></code> method</span></a>
+        <li><a href="#api-filesystemsyncaccesshandle-close"><span class="secno">2.7.6</span> <span class="content">The <code class="idl"><span>close()</span></code> method</span></a>
+       </ol>
+     </ol>
+    <li>
+     <a href="#local-filesystem"><span class="secno">3</span> <span class="content">Accessing Local File System</span></a>
+     <ol class="toc">
+      <li><a href="#local-file-system-permissions"><span class="secno">3.1</span> <span class="content">Local File System Permissions</span></a>
+      <li>
+       <a href="#api-filepickeroptions"><span class="secno">3.2</span> <span class="content">File picker options</span></a>
+       <ol class="toc">
+        <li><a href="#api-filepickeroptions-types"><span class="secno">3.2.1</span> <span class="content">Accepted file types</span></a>
+        <li><a href="#api-filepickeroptions-starting-directory"><span class="secno">3.2.2</span> <span class="content">Starting Directory</span></a>
+       </ol>
+      <li><a href="#api-showopenfilepicker"><span class="secno">3.3</span> <span class="content">The <code class="idl"><span>showOpenFilePicker()</span></code> method</span></a>
+      <li><a href="#api-showsavefilepicker"><span class="secno">3.4</span> <span class="content">The <code class="idl"><span>showSaveFilePicker()</span></code> method</span></a>
+      <li><a href="#api-showdirectorypicker"><span class="secno">3.5</span> <span class="content">The <code class="idl"><span>showDirectoryPicker()</span></code> method</span></a>
+      <li><a href="#drag-and-drop"><span class="secno">3.6</span> <span class="content">Drag and Drop</span></a>
+     </ol>
+    <li><a href="#sandboxed-filesystem"><span class="secno">4</span> <span class="content">Accessing the Origin Private File System</span></a>
+    <li><a href="#accessibility-considerations"><span class="secno">5</span> <span class="content">Accessibility Considerations</span></a>
+    <li>
+     <a href="#privacy-considerations"><span class="secno">6</span> <span class="content">Privacy Considerations</span></a>
+     <ol class="toc">
+      <li><a href="#privacy-wide-access"><span class="secno">6.1</span> <span class="content">Users giving access to more, or more sensitive files than they intended.</span></a>
+      <li><a href="#privacy-tracking"><span class="secno">6.2</span> <span class="content">Websites trying to use this API for tracking.</span></a>
+      <li><a href="#privacy-third-party"><span class="secno">6.3</span> <span class="content">First-party vs third-party contexts.</span></a>
+     </ol>
+    <li>
+     <a href="#security-considerations"><span class="secno">7</span> <span class="content">Security Considerations</span></a>
+     <ol class="toc">
+      <li><a href="#security-malware"><span class="secno">7.1</span> <span class="content">Malware</span></a>
+      <li><a href="#security-ransomware"><span class="secno">7.2</span> <span class="content">Ransomware attacks</span></a>
+      <li><a href="#filling-up-disk"><span class="secno">7.3</span> <span class="content">Filling up a users disk</span></a>
+     </ol>
+    <li>
+     <a href="#w3c-conformance"><span class="secno"></span> <span class="content">Conformance</span></a>
+     <ol class="toc">
+      <li><a href="#w3c-conventions"><span class="secno"></span> <span class="content">Document conventions</span></a>
+      <li><a href="#w3c-conformant-algorithms"><span class="secno"></span> <span class="content">Conformant Algorithms</span></a>
+     </ol>
+    <li>
+     <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ol class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+      <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
+     </ol>
+    <li>
+     <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ol class="toc">
+      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
+      <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
+     </ol>
+    <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
+    <li><a href="#issues-index"><span class="secno"></span> <span class="content">Issues Index</span></a>
+   </ol>
+  </nav>
+  <main>
+   <h2 class="heading settled" data-level="1" id="introduction"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
+   <p><em>This section is non-normative.</em></p>
+   <p>This API enables developers to build powerful apps that interact with other
+(non-Web) apps on the user’s device via the device’s file system. Prominent
+examples of applications where users expect this functionality are IDEs,
+photo and video editors, text editors, and more.
+After a user grants a web app access, this API allows the app to read or save
+changes directly to files and folders on the user’s device. Beyond reading and
+writing files, this API provides the ability to open a directory and enumerate
+its contents. Additionally, web apps can use this API to store references to
+files and directories they’ve been given access to, allowing the web apps to
+later regain access to the same content without requiring the user to select the
+same file again.</p>
+   <p>This API is similar to <a href="https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file)"><code>&lt;input type=file></code></a> and <a href="https://wicg.github.io/entries-api/#html-forms"><code>&lt;input type=file webkitdirectory></code></a> <a data-link-type="biblio" href="#biblio-entries-api">[entries-api]</a> in that user interaction happens through file and directory picker dialogs.
+Unlike those APIs, this API is currently purely a javascript API, and
+does not integrate with forms and/or input elements.</p>
+   <p>Additionally this API also makes it possible for websites to get access to some
+directory without having to first prompt the user for access. This enables use
+cases where a website wants to save data to disk before a user has picked a
+location to save to, without forcing the website to use a completely different
+storage mechanism with a different API for such files. It also makes it easier
+to write automated tests for code using this API. The entry point for this is the <code class="idl"><a data-link-type="idl" href="#dom-storagemanager-getdirectory" id="ref-for-dom-storagemanager-getdirectory">navigator.storage.getDirectory()</a></code> method. This
+is similar to the temporary file system as defined in earlier drafts of <a data-link-type="biblio" href="#biblio-file-system-api">File API: Directories and System</a>.</p>
+   <h2 class="heading settled" data-level="2" id="files-and-directories"><span class="secno">2. </span><span class="content">Files and Directories</span><a class="self-link" href="#files-and-directories"></a></h2>
+   <h3 class="heading settled" data-level="2.1" id="concepts"><span class="secno">2.1. </span><span class="content">Concepts</span><a class="self-link" href="#concepts"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="entry">entry</dfn> is either a <a data-link-type="dfn" href="#file" id="ref-for-file">file entry</a> or a <a data-link-type="dfn" href="#directory" id="ref-for-directory">directory entry</a>.</p>
+   <p>Each <a data-link-type="dfn" href="#entry" id="ref-for-entry">entry</a> has an associated <dfn class="dfn-paneled" data-dfn-for="entry" data-dfn-type="dfn" data-noexport id="entry-name">name</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a>).</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="valid-file-name">valid file name</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">string</a> that is not an empty string, is not equal to "." or "..",
+and does not contain '/' or any other character used as path separator on the underlying platform.</p>
+   <p class="note" role="note"><span>Note:</span> This means that '\' is not allowed in names on Windows, but might be allowed on
+other operating systems. Additionally underlying file systems might have further restrictions
+on what names are or aren’t allowed, so a string merely being a <a data-link-type="dfn" href="#valid-file-name" id="ref-for-valid-file-name">valid file name</a> is not
+a guarantee that creating a file or directory with that name will succeed.</p>
+   <p class="issue" id="issue-58d5d75b"><a class="self-link" href="#issue-58d5d75b"></a> We should consider having further normative restrictions on file names that will
+never be allowed using this API, rather than leaving it entirely up to underlying file
+systems.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="valid-suffix-code-point">valid suffix code point</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-point" id="ref-for-code-point">code point</a> that is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-alphanumeric" id="ref-for-ascii-alphanumeric">ASCII alphanumeric</a>,
+U+002B (+), or U+002E (.).</p>
+   <p class="note" role="note"><span>Note:</span> These code points were chosen to support most pre-existing file formats. The vast
+majority of file extensions are purely alphanumeric, but compound extensions (such as <code>.tar.gz</code>) and extensions such as <code>.c++</code> for C++ source code are also fairly common,
+hence the inclusion of + and . as allowed code points.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="file|file entry" data-noexport id="file">file entry</dfn> additionally consists of <dfn class="dfn-paneled" data-dfn-for="file entry" data-dfn-type="dfn" data-noexport id="file-entry-binary-data">binary data</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence">byte sequence</a>), a <dfn class="dfn-paneled" data-dfn-for="file entry" data-dfn-type="dfn" data-noexport id="file-entry-modification-timestamp">modification timestamp</dfn> (a number representing the number of milliseconds since the <a data-link-type="dfn" href="https://w3c.github.io/FileAPI/#UnixEpoch" id="ref-for-UnixEpoch">Unix Epoch</a>)
+and a <dfn class="dfn-paneled" data-dfn-for="file entry" data-dfn-type="dfn" data-noexport id="file-entry-lock">lock</dfn>. A lock is a string that may exclusively be "open", "taken-exclusive" and "taken-shared".</p>
+   <div class="algorithm" data-algorithm="take" data-algorithm-for="file entry/lock">
+     To <dfn class="dfn-paneled" data-dfn-for="file entry/lock" data-dfn-type="dfn" data-noexport id="file-entry-lock-take">take</dfn> a <a data-link-type="dfn" href="#file-entry-lock" id="ref-for-file-entry-lock">lock</a> with a <var>value</var> of "exclusive" or "shared", for a given <var>file</var>,
+run the following steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise">a new promise</a>.</p>
+     <li data-md>
+      <p>Let <var>lock</var> be the <var>file</var>’s associated <a data-link-type="dfn" href="#file-entry-lock" id="ref-for-file-entry-lock①">lock</a></p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>value</var> is "exclusive":</p>
+        <ol>
+         <li data-md>
+          <p>If <var>lock</var> is "open":</p>
+          <ol>
+           <li data-md>
+            <p>Set lock to "taken-exclusive".</p>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve">resolve</a> <var>result</var>.</p>
+          </ol>
+         <li data-md>
+          <p>Else <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject">reject</a> <var>result</var>.</p>
+        </ol>
+       <li data-md>
+        <p>If <var>value</var> is "shared":</p>
+        <ol>
+         <li data-md>
+          <p>If <var>lock</var> is "open":</p>
+          <ol>
+           <li data-md>
+            <p>Set lock to "taken-exclusive".</p>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①">resolve</a> <var>result</var>.</p>
+          </ol>
+         <li data-md>
+          <p>Else if <var>lock</var> is "taken-shared":</p>
+          <ol>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②">resolve</a> <var>result</var>.</p>
+          </ol>
+         <li data-md>
+          <p>Else <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①">reject</a> <var>result</var>.</p>
+        </ol>
+      </ol>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="release" data-algorithm-for="file entry/lock">
+     To <dfn class="dfn-paneled" data-dfn-for="file entry/lock" data-dfn-type="dfn" data-noexport id="file-entry-lock-release">release</dfn> a <a data-link-type="dfn" href="#file-entry-lock" id="ref-for-file-entry-lock②">lock</a> for a given <var>file</var>,
+run the following steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>lock</var> be the <var>file</var>’s associated <a data-link-type="dfn" href="#file-entry-lock" id="ref-for-file-entry-lock③">lock</a></p>
+     <li data-md>
+      <p>Set lock to "open".</p>
+    </ol>
+   </div>
+    //TODO(fivedots): Define algorithm for releasing a lock. 
+   <p class="note" role="note"><span>Note:</span> Locks help prevent concurrent modifications to a file. A <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream">FileSystemWritableFileStream</a></code> requires a shared lock, while a <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle">FileSystemSyncAccessHandle</a></code> requires an exclusive one.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="directory|directory entry" data-noexport id="directory">directory entry</dfn> additionally consists of a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">set</a> of <dfn class="dfn-paneled" data-dfn-for="directory entry" data-dfn-type="dfn" data-noexport id="directory-entry-children">children</dfn>, which are themselves <a data-link-type="dfn" href="#entry" id="ref-for-entry①">entries</a>. Each member is either a <a data-link-type="dfn" href="#file" id="ref-for-file①">file</a> or a <a data-link-type="dfn" href="#directory" id="ref-for-directory①">directory</a>.</p>
+   <p>An <a data-link-type="dfn" href="#entry" id="ref-for-entry②">entry</a> <var>entry</var> should be <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contained</a> in the <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children">children</a> of at most one <a data-link-type="dfn" href="#directory" id="ref-for-directory②">directory entry</a>, and that directory entry is also known as <var>entry</var>’s <dfn class="dfn-paneled" data-dfn-for="entry" data-dfn-type="dfn" data-noexport id="entry-parent">parent</dfn>.
+An <a data-link-type="dfn" href="#entry" id="ref-for-entry③">entry</a>'s <a data-link-type="dfn" href="#entry-parent" id="ref-for-entry-parent">parent</a> is null if no such directory entry exists.</p>
+   <p class="note" role="note"><span>Note:</span> Two different <a data-link-type="dfn" href="#entry" id="ref-for-entry④">entries</a> can represent the same file or directory on disk, in which
+case it is possible for both entries to have a different parent, or for one entry to have a
+parent while the other entry does not have a parent. Typically an entry does not have a parent
+if it was returned by <code class="idl"><a data-link-type="idl" href="#dom-storagemanager-getdirectory" id="ref-for-dom-storagemanager-getdirectory①">navigator.storage.getDirectory()</a></code> or one of the <a data-link-type="dfn" href="#local-file-system-handle-factories" id="ref-for-local-file-system-handle-factories">local file system handle factories</a>,
+and an entry will have a parent in all other cases.</p>
+   <p><a data-link-type="dfn" href="#entry" id="ref-for-entry⑤">Entries</a> can (but don’t have to) be backed by files on the host operating system’s local file system,
+so it is possible for the <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data">binary data</a>, <a data-link-type="dfn" href="#file-entry-modification-timestamp" id="ref-for-file-entry-modification-timestamp">modification timestamp</a>,
+and <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children①">children</a> of entries to be modified by applications outside of this specification.
+Exactly how external changes are reflected in the data structures defined by this specification,
+as well as how changes made to the data structures defined here are reflected externally
+is left up to individual user-agent implementations.</p>
+   <p>An <a data-link-type="dfn" href="#entry" id="ref-for-entry⑥">entry</a> <var>a</var> is <dfn class="dfn-paneled" data-dfn-for="entry" data-dfn-type="dfn" data-noexport id="entry-the-same-as">the same as</dfn> an <a data-link-type="dfn" href="#entry" id="ref-for-entry⑦">entry</a> <var>b</var> if <var>a</var> is equal to <var>b</var>, or
+if <var>a</var> and <var>b</var> are backed by the same file or directory on the local file system.</p>
+   <p class="issue" id="issue-88e7ec9d"><a class="self-link" href="#issue-88e7ec9d"></a> TODO: Explain better how entries map to files on disk (multiple entries can map to the same file or
+directory on disk but an entry doesn’t have to map to any file on disk).</p>
+   <div class="algorithm" data-algorithm="resolve" data-algorithm-for="entry">
+     To <dfn class="dfn-paneled" data-dfn-for="entry" data-dfn-type="dfn" data-noexport id="entry-resolve">resolve</dfn> an <a data-link-type="dfn" href="#entry" id="ref-for-entry⑧">entry</a> <var>child</var> relative to a <a data-link-type="dfn" href="#directory" id="ref-for-directory③">directory entry</a> <var>root</var>,
+run the following steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①">a new promise</a>.</p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>child</var> is <a data-link-type="dfn" href="#entry-the-same-as" id="ref-for-entry-the-same-as">the same as</a> <var>root</var>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve③">resolve</a> <var>result</var> with an empty list, and abort.</p>
+       <li data-md>
+        <p>Let <var>childPromises</var> be « ».</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate">For each</a> <var>entry</var> of <var>root</var>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry">entry</a>'s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children②">children</a>:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>p</var> be the result of <a data-link-type="dfn" href="#entry-resolve" id="ref-for-entry-resolve">resolving</a> <var>child</var> relative to <var>entry</var>.</p>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append">Append</a> <var>p</var> to <var>childPromises</var>.</p>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#upon-fulfillment" id="ref-for-upon-fulfillment">Upon fulfillment</a> of <var>p</var> with value <var>path</var>:</p>
+          <ol>
+           <li data-md>
+            <p>If <var>path</var> is not null:</p>
+            <ol>
+             <li data-md>
+              <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-prepend" id="ref-for-list-prepend">Prepend</a> <var>entry</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name">name</a> to <var>path</var>.</p>
+             <li data-md>
+              <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve④">Resolve</a> <var>result</var> with <var>path</var>.</p>
+            </ol>
+          </ol>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#wait-for-all" id="ref-for-wait-for-all">Wait for all</a> <var>childPromises</var>, with the following success steps:</p>
+        <ol>
+         <li data-md>
+          <p>If <var>result</var> hasn’t been resolved yet, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑤">resolve</a> <var>result</var> with <code>null</code>.</p>
+        </ol>
+      </ol>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="2.2" id="permissions"><span class="secno">2.2. </span><span class="content">Permissions</span><a class="self-link" href="#permissions"></a></h3>
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="PermissionName" data-dfn-type="enum-value" data-export id="dom-permissionname-file-system"><code>"file-system"</code></dfn> <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-powerful-feature" id="ref-for-dfn-powerful-feature">powerful feature</a>'s
+permission-related algorithms and types are defined as follows:</p>
+   <dl>
+    <dt data-md><a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type" id="ref-for-dfn-permission-descriptor-type">permission descriptor type</a>
+    <dd data-md>
+     <p><code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor">FileSystemPermissionDescriptor</a></code>, defined as:</p>
+<pre class="idl highlight def"><c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-filesystempermissionmode"><code><c- g>FileSystemPermissionMode</c-></code></dfn> {
+  <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemPermissionMode" data-dfn-type="enum-value" data-export id="dom-filesystempermissionmode-read"><code><c- s>"read"</c-></code></dfn>,
+  <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemPermissionMode" data-dfn-type="enum-value" data-export id="dom-filesystempermissionmode-readwrite"><code><c- s>"readwrite"</c-></code></dfn>
+};
+
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystempermissiondescriptor"><code><c- g>FileSystemPermissionDescriptor</c-></code></dfn> : <a data-link-type="idl-name" href="https://w3c.github.io/permissions/#dom-permissiondescriptor" id="ref-for-dom-permissiondescriptor"><c- n>PermissionDescriptor</c-></a> {
+  <c- b>required</c-> <a data-link-type="idl-name" href="#filesystemhandle" id="ref-for-filesystemhandle"><c- n>FileSystemHandle</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemPermissionDescriptor" data-dfn-type="dict-member" data-export data-type="FileSystemHandle " id="dom-filesystempermissiondescriptor-handle"><code><c- g>handle</c-></code></dfn>;
+  <a data-link-type="idl-name" href="#enumdef-filesystempermissionmode" id="ref-for-enumdef-filesystempermissionmode"><c- n>FileSystemPermissionMode</c-></a> <dfn class="dfn-paneled idl-code" data-default="&quot;read&quot;" data-dfn-for="FileSystemPermissionDescriptor" data-dfn-type="dict-member" data-export data-type="FileSystemPermissionMode " id="dom-filesystempermissiondescriptor-mode"><code><c- g>mode</c-></code></dfn> = "read";
+};
+</pre>
+    <dt data-md><a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state-constraints" id="ref-for-dfn-permission-state-constraints">permission state constraints</a>
+    <dd data-md>
+     <div class="algorithm" data-algorithm="permission state constraints">
+       To determine <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state-constraints" id="ref-for-dfn-permission-state-constraints①">permission state constraints</a> for a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor①">FileSystemPermissionDescriptor</a></code> <var>desc</var>,
+run these steps: 
+      <ol>
+       <li data-md>
+        <p>Let <var>entry</var> be <var>desc</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle">handle</a></code>'s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①">entry</a>.</p>
+       <li data-md>
+        <p>If <var>entry</var> represents an <a data-link-type="dfn" href="#entry" id="ref-for-entry⑨">entry</a> in an <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system">origin private file system</a>,
+this descriptor’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state">permission state</a> must always be <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted">"granted"</a></code>.</p>
+       <li data-md>
+        <p>Otherwise, if <var>entry</var>’s <a data-link-type="dfn" href="#entry-parent" id="ref-for-entry-parent①">parent</a> is not null, this descriptor’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state①">permission state</a> must be
+equal to the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state②">permission state</a> for a descriptor with the same <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode">mode</a></code>,
+and a <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle①">handle</a></code> representing <var>entry</var>’s <a data-link-type="dfn" href="#entry-parent" id="ref-for-entry-parent②">parent</a>.</p>
+       <li data-md>
+        <p>Otherwise, if <var>desc</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode①">mode</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite">"readwrite"</a></code>:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>read state</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state③">permission state</a> for a descriptor
+with the same <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle②">handle</a></code>,
+but <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode②">mode</a></code> = <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read">"read"</a></code>.</p>
+         <li data-md>
+          <p>If <var>read state</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①">"granted"</a></code>, this descriptor’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state④">permission state</a> must be equal to <var>read state</var>.</p>
+        </ol>
+      </ol>
+     </div>
+    <dt data-md><a data-link-type="dfn" href="https://wicg.github.io/permissions-request/#permission-request-algorithm" id="ref-for-permission-request-algorithm">permission request algorithm</a>
+    <dd data-md>
+     <div class="algorithm" data-algorithm="permission request algorithm">
+       Given a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor②">FileSystemPermissionDescriptor</a></code> <var>desc</var> and a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstatus" id="ref-for-dom-permissionstatus">PermissionStatus</a></code> <var>status</var>,
+run these steps: 
+      <ol>
+       <li data-md>
+        <p>Run the <a data-link-type="dfn">boolean permission query algorithm</a> on <var>desc</var> and <var>status</var>.</p>
+       <li data-md>
+        <p>If <var>status</var>.<code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstatus-state" id="ref-for-dom-permissionstatus-state">state</a></code> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-prompt" id="ref-for-dom-permissionstate-prompt">"prompt"</a></code>, abort.</p>
+       <li data-md>
+        <p>Let <var>settings</var> be <var>desc</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle③">handle</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object">relevant settings object</a>.</p>
+       <li data-md>
+        <p>Let <var>global</var> be <var>settings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global">global object</a>.</p>
+       <li data-md>
+        <p>If <var>global</var> is not a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window">Window</a></code>, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#securityerror" id="ref-for-securityerror">SecurityError</a></code>.</p>
+       <li data-md>
+        <p>If <var>global</var> does not have <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation" id="ref-for-transient-activation">transient activation</a>, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#securityerror" id="ref-for-securityerror①">SecurityError</a></code>.</p>
+       <li data-md>
+        <p>If <var>settings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin">origin</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin">same origin</a> with <var>settings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin" id="ref-for-concept-environment-top-level-origin">top-level origin</a>,
+ throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#securityerror" id="ref-for-securityerror②">SecurityError</a></code>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-request-permission-to-use" id="ref-for-dfn-request-permission-to-use">Request permission to use</a> <var>desc</var>.</p>
+       <li data-md>
+        <p>Run the <a data-link-type="dfn">boolean permission query algorithm</a> on <var>desc</var> and <var>status</var>.</p>
+      </ol>
+      <p class="issue" id="issue-88417955"><a class="self-link" href="#issue-88417955"></a> Ideally this user activation requirement would be defined upstream. <a href="https://github.com/WICG/permissions-request/issues/2">[Issue #WICG/permissions-request#2]</a></p>
+     </div>
+   </dl>
+   <div class="algorithm" data-algorithm="querying file system permission">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="querying file system permission|query file system permission" data-noexport id="querying-file-system-permission">query file system permission</dfn> given a <code class="idl"><a data-link-type="idl" href="#filesystemhandle" id="ref-for-filesystemhandle①">FileSystemHandle</a></code> <var>handle</var> and a <code class="idl"><a data-link-type="idl" href="#enumdef-filesystempermissionmode" id="ref-for-enumdef-filesystempermissionmode①">FileSystemPermissionMode</a></code> <var>mode</var>, run these steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>desc</var> be a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor③">FileSystemPermissionDescriptor</a></code>.</p>
+     <li data-md>
+      <p>Set <var>desc</var>.<code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name" id="ref-for-dom-permissiondescriptor-name">name</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-permissionname-file-system" id="ref-for-dom-permissionname-file-system">"file-system"</a></code>.</p>
+     <li data-md>
+      <p>Set <var>desc</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle④">handle</a></code> to <var>handle</var>.</p>
+     <li data-md>
+      <p>Set <var>desc</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode③">mode</a></code> to <var>mode</var>.</p>
+     <li data-md>
+      <p>Return <var>desc</var>’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state⑤">permission state</a>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="requesting file system permission">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="requesting file system permission|request file system permission" data-noexport id="requesting-file-system-permission">request file system permission</dfn> given a <code class="idl"><a data-link-type="idl" href="#filesystemhandle" id="ref-for-filesystemhandle②">FileSystemHandle</a></code> <var>handle</var> and a <code class="idl"><a data-link-type="idl" href="#enumdef-filesystempermissionmode" id="ref-for-enumdef-filesystempermissionmode②">FileSystemPermissionMode</a></code> <var>mode</var>, run these steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>desc</var> be a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor④">FileSystemPermissionDescriptor</a></code>.</p>
+     <li data-md>
+      <p>Set <var>desc</var>.<code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name" id="ref-for-dom-permissiondescriptor-name①">name</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-permissionname-file-system" id="ref-for-dom-permissionname-file-system①">"file-system"</a></code>.</p>
+     <li data-md>
+      <p>Set <var>desc</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑤">handle</a></code> to <var>handle</var>.</p>
+     <li data-md>
+      <p>Set <var>desc</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode④">mode</a></code> to <var>mode</var>.</p>
+     <li data-md>
+      <p>Let <var>status</var> be the result of running <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-create-a-permissionstatus" id="ref-for-dfn-create-a-permissionstatus">create a PermissionStatus</a> for <var>desc</var>.</p>
+     <li data-md>
+      <p>Run the <a data-link-type="dfn" href="https://wicg.github.io/permissions-request/#permission-request-algorithm" id="ref-for-permission-request-algorithm①">permission request algorithm</a> for the <code class="idl"><a data-link-type="idl" href="#dom-permissionname-file-system" id="ref-for-dom-permissionname-file-system②">"file-system"</a></code> feature, given <var>desc</var> and <var>status</var>.</p>
+     <li data-md>
+      <p>Return <var>desc</var>’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state⑥">permission state</a>.</p>
+    </ol>
+   </div>
+   <p class="issue" id="issue-7fc2f5c7"><a class="self-link" href="#issue-7fc2f5c7"></a> Currently <code class="idl"><a data-link-type="idl" href="#enumdef-filesystempermissionmode" id="ref-for-enumdef-filesystempermissionmode③">FileSystemPermissionMode</a></code> can only be <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read①">"read"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite①">"readwrite"</a></code>. In
+the future we might want to add a "write" mode as well to support write-only handles. <a href="https://github.com/wicg/file-system-access/issues/119">[Issue #119]</a></p>
+   <h3 class="heading settled" data-level="2.3" id="api-filesystemhandle"><span class="secno">2.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#filesystemhandle" id="ref-for-filesystemhandle③">FileSystemHandle</a></code> interface</span><a class="self-link" href="#api-filesystemhandle"></a></h3>
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle" title="The FileSystemHandle interface of the File System Access API is an object which represents a file or directory entry. Multiple handles can represent the same entry. For the most part you do not work with FileSystemHandle directly but rather its child interfaces FileSystemFileHandle and FileSystemDirectoryHandle.">FileSystemHandle</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystemhandlepermissiondescriptor"><code><c- g>FileSystemHandlePermissionDescriptor</c-></code></dfn> {
+  <a data-link-type="idl-name" href="#enumdef-filesystempermissionmode" id="ref-for-enumdef-filesystempermissionmode④"><c- n>FileSystemPermissionMode</c-></a> <dfn class="dfn-paneled idl-code" data-default="&quot;read&quot;" data-dfn-for="FileSystemHandlePermissionDescriptor" data-dfn-type="dict-member" data-export data-type="FileSystemPermissionMode " id="dom-filesystemhandlepermissiondescriptor-mode"><code><c- g>mode</c-></code></dfn> = "read";
+};
+
+<c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-filesystemhandlekind"><code><c- g>FileSystemHandleKind</c-></code></dfn> {
+  <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemHandleKind" data-dfn-type="enum-value" data-export id="dom-filesystemhandlekind-file"><code><c- s>"file"</c-></code></dfn>,
+  <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemHandleKind" data-dfn-type="enum-value" data-export id="dom-filesystemhandlekind-directory"><code><c- s>"directory"</c-></code></dfn>,
+};
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->), <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext" id="ref-for-SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable" id="ref-for-serializable"><c- g>Serializable</c-></a>]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="filesystemhandle"><code><c- g>FileSystemHandle</c-></code></dfn> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#enumdef-filesystemhandlekind" id="ref-for-enumdef-filesystemhandlekind"><c- n>FileSystemHandleKind</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="FileSystemHandleKind" href="#dom-filesystemhandle-kind" id="ref-for-dom-filesystemhandle-kind"><c- g>kind</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString"><c- b>USVString</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="USVString" href="#dom-filesystemhandle-name" id="ref-for-dom-filesystemhandle-name"><c- g>name</c-></a>;
+
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean"><c- b>boolean</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemhandle-issameentry" id="ref-for-dom-filesystemhandle-issameentry"><c- g>isSameEntry</c-></a>(<a data-link-type="idl-name" href="#filesystemhandle" id="ref-for-filesystemhandle④"><c- n>FileSystemHandle</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemHandle/isSameEntry(other)" data-dfn-type="argument" data-export id="dom-filesystemhandle-issameentry-other-other"><code><c- g>other</c-></code><a class="self-link" href="#dom-filesystemhandle-issameentry-other-other"></a></dfn>);
+
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="https://w3c.github.io/permissions/#dom-permissionstate" id="ref-for-dom-permissionstate"><c- n>PermissionState</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemhandle-querypermission" id="ref-for-dom-filesystemhandle-querypermission"><c- g>queryPermission</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemhandlepermissiondescriptor" id="ref-for-dictdef-filesystemhandlepermissiondescriptor"><c- n>FileSystemHandlePermissionDescriptor</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemHandle/queryPermission(descriptor), FileSystemHandle/queryPermission()" data-dfn-type="argument" data-export id="dom-filesystemhandle-querypermission-descriptor-descriptor"><code><c- g>descriptor</c-></code><a class="self-link" href="#dom-filesystemhandle-querypermission-descriptor-descriptor"></a></dfn> = {});
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise②"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="https://w3c.github.io/permissions/#dom-permissionstate" id="ref-for-dom-permissionstate①"><c- n>PermissionState</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemhandle-requestpermission" id="ref-for-dom-filesystemhandle-requestpermission"><c- g>requestPermission</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemhandlepermissiondescriptor" id="ref-for-dictdef-filesystemhandlepermissiondescriptor①"><c- n>FileSystemHandlePermissionDescriptor</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemHandle/requestPermission(descriptor), FileSystemHandle/requestPermission()" data-dfn-type="argument" data-export id="dom-filesystemhandle-requestpermission-descriptor-descriptor"><code><c- g>descriptor</c-></code><a class="self-link" href="#dom-filesystemhandle-requestpermission-descriptor-descriptor"></a></dfn> = {});
+};
+</pre>
+   <p>A <code class="idl"><a data-link-type="idl" href="#filesystemhandle" id="ref-for-filesystemhandle⑤">FileSystemHandle</a></code> object represents an <a data-link-type="dfn" href="#entry" id="ref-for-entry①⓪">entry</a>. Each <code class="idl"><a data-link-type="idl" href="#filesystemhandle" id="ref-for-filesystemhandle⑥">FileSystemHandle</a></code> object is associated
+with an <dfn class="dfn-paneled" data-dfn-for="FileSystemHandle" data-dfn-type="dfn" data-noexport id="filesystemhandle-entry">entry</dfn> (an <a data-link-type="dfn" href="#entry" id="ref-for-entry①①">entry</a>). Multiple separate objects implementing
+the <code class="idl"><a data-link-type="idl" href="#filesystemhandle" id="ref-for-filesystemhandle⑦">FileSystemHandle</a></code> interface can all be associated with the same <a data-link-type="dfn" href="#entry" id="ref-for-entry①②">entry</a> simultaneously.</p>
+   <div class="algorithm" data-algorithm="serialization steps">
+     <code class="idl"><a data-link-type="idl" href="#filesystemhandle" id="ref-for-filesystemhandle⑧">FileSystemHandle</a></code> objects are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects" id="ref-for-serializable-objects">serializable objects</a>. 
+    <p><strong class="advisement"> In the Origin Trial as available in Chrome 78, these objects are not yet serializable.
+In Chrome 82 they are.</strong></p>
+    <p>Their <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps" id="ref-for-serialization-steps">serialization steps</a>, given <var>value</var>, <var>serialized</var> and <var>forStorage</var> are:</p>
+    <ol>
+     <li data-md>
+      <p>Set <var>serialized</var>.[[Origin]] to <var>value</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object①">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a>.</p>
+     <li data-md>
+      <p>Set <var>serialized</var>.[[Entry]] to <var>value</var>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②">entry</a>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="deserialization steps">
+     Their <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps" id="ref-for-deserialization-steps">deserialization steps</a>, given <var>serialized</var> and <var>value</var> are: 
+    <ol>
+     <li data-md>
+      <p>If <var>serialized</var>.[[Origin]] is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin①">same origin</a> with <var>value</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object②">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②">origin</a>,
+ then throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#datacloneerror" id="ref-for-datacloneerror">DataCloneError</a></code>.</p>
+     <li data-md>
+      <p>Set <var>value</var>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry③">entry</a> to <var>serialized</var>.[[Entry]]</p>
+    </ol>
+   </div>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md>
+      <div class="mdn-anno wrapped">
+       <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+       <div class="feature">
+        <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/kind" title="The kind read-only property of the FileSystemHandle interface returns the type of entry. This is &apos;file&apos; if the associated entry is a file or &apos;directory&apos;. It is used to distinguish files from directories when iterating over the contents of a directory.">FileSystemHandle/kind</a></p>
+        <p class="less-than-two-engines-text">In only one current engine.</p>
+        <div class="support">
+         <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+         <hr>
+         <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+         <hr>
+         <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+         <hr>
+         <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+        </div>
+       </div>
+      </div>
+      <p><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-kind" id="ref-for-dom-filesystemhandle-kind①">kind</a></code></p>
+     <dd data-md>
+      <p>Returns <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlekind-file" id="ref-for-dom-filesystemhandlekind-file">"file"</a></code> if <var>handle</var> is a <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle">FileSystemFileHandle</a></code>,
+ or <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlekind-directory" id="ref-for-dom-filesystemhandlekind-directory">"directory"</a></code> if <var>handle</var> is a <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle">FileSystemDirectoryHandle</a></code>.</p>
+      <p>This can be used to distinguish files from directories when iterating over the contents
+ of a directory.</p>
+     <dt data-md>
+      <div class="mdn-anno wrapped">
+       <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+       <div class="feature">
+        <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/name" title="The name read-only property of the FileSystemHandle interface returns the name of the entry represented by handle.">FileSystemHandle/name</a></p>
+        <p class="less-than-two-engines-text">In only one current engine.</p>
+        <div class="support">
+         <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+         <hr>
+         <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+         <hr>
+         <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+         <hr>
+         <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+        </div>
+       </div>
+      </div>
+      <p><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-name" id="ref-for-dom-filesystemhandle-name①">name</a></code></p>
+     <dd data-md>
+      <p>Returns the <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name①">name</a> of the entry represented by <var>handle</var>.</p>
+    </dl>
+   </div>
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemHandle" data-dfn-type="attribute" data-export id="dom-filesystemhandle-kind"><code>kind</code></dfn> attribute must
+return <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlekind-file" id="ref-for-dom-filesystemhandlekind-file①">"file"</a></code> if the associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry④">entry</a> is a <a data-link-type="dfn" href="#file" id="ref-for-file②">file entry</a>,
+and return <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlekind-directory" id="ref-for-dom-filesystemhandlekind-directory①">"directory"</a></code> otherwise.</p>
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemHandle" data-dfn-type="attribute" data-export id="dom-filesystemhandle-name"><code>name</code></dfn> attribute must return the <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name②">name</a> of the
+associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry⑤">entry</a>.</p>
+   <h4 class="heading settled" data-level="2.3.1" id="api-filesystemhandle-issameentry"><span class="secno">2.3.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-issameentry" id="ref-for-dom-filesystemhandle-issameentry①">isSameEntry()</a></code> method</span><a class="self-link" href="#api-filesystemhandle-issameentry"></a></h4>
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/isSameEntry" title="The isSameEntry() method of the FileSystemHandle interface compares two handles to see if the associated entries (either a file or directory) match.">FileSystemHandle/isSameEntry</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>same</var> = await <var>handle1</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-issameentry" id="ref-for-dom-filesystemhandle-issameentry②">isSameEntry</a></code>( <var>handle2</var> )
+     <dd data-md>
+      <p>Returns true if <var>handle1</var> and <var>handle2</var> represent the same file or directory.</p>
+    </dl>
+   </div>
+   <p><strong class="advisement"> This method is first available in Chrome 82.</strong></p>
+   <div class="algorithm" data-algorithm="isSameEntry(other)" data-algorithm-for="FileSystemHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemHandle" data-dfn-type="method" data-export id="dom-filesystemhandle-issameentry"><code>isSameEntry(<var>other</var>)</code></dfn> method, when invoked, must run these steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>realm</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this">this</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm">relevant Realm</a>.</p>
+     <li data-md>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise②">a new promise</a> in <var>realm</var>.</p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①">this</a>'s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry⑥">entry</a> is <a data-link-type="dfn" href="#entry-the-same-as" id="ref-for-entry-the-same-as①">the same as</a> <var>other</var>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry⑦">entry</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑥">resolve</a> <var>p</var> with <code>true</code>.</p>
+       <li data-md>
+        <p>Else <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑦">resolve</a> <var>p</var> with <code>false</code>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>p</var>.</p>
+    </ol>
+   </div>
+   <h4 class="heading settled" data-level="2.3.2" id="api-filesystemhandle-querypermission"><span class="secno">2.3.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-querypermission" id="ref-for-dom-filesystemhandle-querypermission①">queryPermission()</a></code> method</span><a class="self-link" href="#api-filesystemhandle-querypermission"></a></h4>
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/queryPermission" title="The queryPermission() method of the FileSystemHandle interface queries the current permission state of the current handle.">FileSystemHandle/queryPermission</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>status</var> = await <var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-querypermission" id="ref-for-dom-filesystemhandle-querypermission②">queryPermission</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlepermissiondescriptor-mode" id="ref-for-dom-filesystemhandlepermissiondescriptor-mode">mode</a></code> : <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read②">"read"</a></code> })
+     <dt data-md><var>status</var> = await <var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-querypermission" id="ref-for-dom-filesystemhandle-querypermission③">queryPermission()</a></code>
+     <dt data-md><var>status</var> = (await navigator.<code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-navigator-permissions" id="ref-for-dom-navigator-permissions">permissions</a></code>.<code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissions-query" id="ref-for-dom-permissions-query">query</a></code>({ <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name" id="ref-for-dom-permissiondescriptor-name②">name</a></code> : "file-system", <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑥">handle</a></code> : <var>handle</var> })).<code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstatus-state" id="ref-for-dom-permissionstatus-state①">state</a></code>
+     <dd data-md>
+      <p>Queries the current state of the read permission of this handle. If this returns <code>"prompt"</code> the website will have to call <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-requestpermission" id="ref-for-dom-filesystemhandle-requestpermission①">requestPermission()</a></code> before any
+ operations on the handle can be done. If this returns <code>"denied"</code> any operations will reject.</p>
+      <p>Usually handles returned by the <a data-link-type="dfn" href="#local-file-system-handle-factories" id="ref-for-local-file-system-handle-factories①">local file system handle factories</a> will initially return <code>"granted"</code> for
+ their read permission state, however other than through the user revoking permission, a handle
+ retrieved from IndexedDB is also likely to return <code>"prompt"</code>.</p>
+     <dt data-md><var>status</var> = await <var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-querypermission" id="ref-for-dom-filesystemhandle-querypermission④">queryPermission</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlepermissiondescriptor-mode" id="ref-for-dom-filesystemhandlepermissiondescriptor-mode①">mode</a></code> : <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite②">"readwrite"</a></code> })
+     <dt data-md><var>status</var> = (await navigator.<code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-navigator-permissions" id="ref-for-dom-navigator-permissions①">permissions</a></code>.<code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissions-query" id="ref-for-dom-permissions-query①">query</a></code>({ <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name" id="ref-for-dom-permissiondescriptor-name③">name</a></code> : "file-system", <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑦">handle</a></code> : <var>handle</var>, <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode⑤">mode</a></code> : <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite③">"readwrite"</a></code>}).<code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstatus-state" id="ref-for-dom-permissionstatus-state②">state</a></code>
+     <dd data-md>
+      <p>Queries the current state of the write permission of this handle. If this returns <code>"prompt"</code>,
+ attempting to modify the file or directory this handle represents will require user activation
+ and will result in a confirmation prompt being shown to the user. However if the state of the
+ read permission of this handle is also <code>"prompt"</code> the website will need to call <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-requestpermission" id="ref-for-dom-filesystemhandle-requestpermission②">requestPermission()</a></code>. There is no automatic prompting for read access when
+ attempting to read from a file or directory.</p>
+    </dl>
+   </div>
+   <p><strong class="advisement"> The integration with the permissions API’s <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissions-query" id="ref-for-dom-permissions-query②">query()</a></code> method is not yet implemented in Chrome.</strong></p>
+   <div class="algorithm" data-algorithm="queryPermission(descriptor)" data-algorithm-for="FileSystemHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemHandle" data-dfn-type="method" data-export data-lt="queryPermission(descriptor)|queryPermission()" id="dom-filesystemhandle-querypermission"><code>queryPermission(<var>descriptor</var>)</code></dfn> method, when invoked, must run these steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise③">a new promise</a>.</p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>state</var> be the result of <a data-link-type="dfn" href="#querying-file-system-permission" id="ref-for-querying-file-system-permission">querying file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②">this</a></b> and <var>descriptor</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlepermissiondescriptor-mode" id="ref-for-dom-filesystemhandlepermissiondescriptor-mode②">mode</a></code>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑧">Resolve</a> <var>result</var> with <var>state</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <h4 class="heading settled" data-level="2.3.3" id="api-filesystemhandle-requestpermission"><span class="secno">2.3.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-requestpermission" id="ref-for-dom-filesystemhandle-requestpermission③">requestPermission()</a></code> method</span><a class="self-link" href="#api-filesystemhandle-requestpermission"></a></h4>
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/requestPermission" title="The requestPermission() method of the FileSystemHandle interface requests read or readwrite permissions for the file handle.">FileSystemHandle/requestPermission</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>status</var> = await <var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-requestpermission" id="ref-for-dom-filesystemhandle-requestpermission④">requestPermission</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlepermissiondescriptor-mode" id="ref-for-dom-filesystemhandlepermissiondescriptor-mode③">mode</a></code> : <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read③">"read"</a></code> })
+     <dt data-md><var>status</var> = await <var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-requestpermission" id="ref-for-dom-filesystemhandle-requestpermission⑤">requestPermission()</a></code>
+     <dd data-md>
+      <p>If the state of the read permission of this handle is anything other than <code>"prompt"</code>, this
+ will return that state directly. If it is <code>"prompt"</code> however, user activation is needed and
+ this will show a confirmation prompt to the user. The new read permission state is then
+ returned, depending on the user’s response to the prompt.</p>
+     <dt data-md><var>status</var> = await <var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-requestpermission" id="ref-for-dom-filesystemhandle-requestpermission⑥">requestPermission</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlepermissiondescriptor-mode" id="ref-for-dom-filesystemhandlepermissiondescriptor-mode④">mode</a></code> : <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite④">"readwrite"</a></code> })
+     <dd data-md>
+      <p>If the state of the write permission of this handle is anything other than <code>"prompt"</code>, this
+ will return that state directly. If the status of the read permission of this handle is <code>"denied"</code> this will return that.</p>
+      <p>Otherwise the state of the write permission is <code>"prompt"</code> and this will show a confirmation
+ prompt to the user. The new write permission state is then returned, depending on what the user
+ selected.</p>
+    </dl>
+   </div>
+   <div class="algorithm" data-algorithm="requestPermission(descriptor)" data-algorithm-for="FileSystemHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemHandle" data-dfn-type="method" data-export data-lt="requestPermission(descriptor)|requestPermission()" id="dom-filesystemhandle-requestpermission"><code>requestPermission(<var>descriptor</var>)</code></dfn> method, when invoked, must run these steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise④">a new promise</a>.</p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel④">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>state</var> be the result of <a data-link-type="dfn" href="#requesting-file-system-permission" id="ref-for-requesting-file-system-permission">requesting file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③">this</a></b> and <var>descriptor</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemhandlepermissiondescriptor-mode" id="ref-for-dom-filesystemhandlepermissiondescriptor-mode⑤">mode</a></code>.
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②">reject</a> <var>result</var> with that exception and abort.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve⑨">Resolve</a> <var>result</var> with <var>state</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="2.4" id="api-filesystemfilehandle"><span class="secno">2.4. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①">FileSystemFileHandle</a></code> interface</span><a class="self-link" href="#api-filesystemfilehandle"></a></h3>
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle" title="The FileSystemFileHandle interface of the File System Access API represents a handle to a file system entry. The interface is accessed thought the window.showOpenFilePicker() method.">FileSystemFileHandle</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystemcreatewritableoptions"><code><c- g>FileSystemCreateWritableOptions</c-></code></dfn> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean①"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-default="false" data-dfn-for="FileSystemCreateWritableOptions" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-filesystemcreatewritableoptions-keepexistingdata"><code><c- g>keepExistingData</c-></code></dfn> = <c- b>false</c->;
+};
+
+<c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-accesshandlemode"><code><c- g>AccessHandleMode</c-></code></dfn> { <dfn class="idl-code" data-dfn-for="AccessHandleMode" data-dfn-type="enum-value" data-export id="dom-accesshandlemode-in-place"><code><c- s>"in-place"</c-></code><a class="self-link" href="#dom-accesshandlemode-in-place"></a></dfn> };
+
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystemfilehandlecreateaccesshandleoptions"><code><c- g>FileSystemFileHandleCreateAccessHandleOptions</c-></code></dfn> {
+  <c- b>required</c-> <a data-link-type="idl-name" href="#enumdef-accesshandlemode" id="ref-for-enumdef-accesshandlemode"><c- n>AccessHandleMode</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemFileHandleCreateAccessHandleOptions" data-dfn-type="dict-member" data-export data-type="AccessHandleMode " id="dom-filesystemfilehandlecreateaccesshandleoptions-mode"><code><c- g>mode</c-></code></dfn>;
+};
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->), <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext" id="ref-for-SecureContext①"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable" id="ref-for-serializable①"><c- g>Serializable</c-></a>]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="filesystemfilehandle"><code><c- g>FileSystemFileHandle</c-></code></dfn> : <a data-link-type="idl-name" href="#filesystemhandle" id="ref-for-filesystemhandle⑨"><c- n>FileSystemHandle</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise③"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-file" id="ref-for-dfn-file"><c- n>File</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-getfile" id="ref-for-dom-filesystemfilehandle-getfile"><c- g>getFile</c-></a>();
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise④"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream①"><c- n>FileSystemWritableFileStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createwritable" id="ref-for-dom-filesystemfilehandle-createwritable"><c- g>createWritable</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemcreatewritableoptions" id="ref-for-dictdef-filesystemcreatewritableoptions"><c- n>FileSystemCreateWritableOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemFileHandle/createWritable(options), FileSystemFileHandle/createWritable()" data-dfn-type="argument" data-export id="dom-filesystemfilehandle-createwritable-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemfilehandle-createwritable-options-options"></a></dfn> = {});
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed②"><c- g>Exposed</c-></a>=<c- n>DedicatedWorker</c->]
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑤"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle①"><c- n>FileSystemSyncAccessHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createsyncaccesshandle" id="ref-for-dom-filesystemfilehandle-createsyncaccesshandle"><c- g>createSyncAccessHandle</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemfilehandlecreateaccesshandleoptions" id="ref-for-dictdef-filesystemfilehandlecreateaccesshandleoptions"><c- n>FileSystemFileHandleCreateAccessHandleOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemFileHandle/createSyncAccessHandle(options), FileSystemFileHandle/createSyncAccessHandle()" data-dfn-type="argument" data-export id="dom-filesystemfilehandle-createsyncaccesshandle-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemfilehandle-createsyncaccesshandle-options-options"></a></dfn> = {});
+};
+</pre>
+   <p>A <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle②">FileSystemFileHandle</a></code>'s associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry⑧">entry</a> must be a <a data-link-type="dfn" href="#file" id="ref-for-file③">file entry</a>.</p>
+   <p><code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle③">FileSystemFileHandle</a></code> objects are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects" id="ref-for-serializable-objects①">serializable objects</a>. Their <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps" id="ref-for-serialization-steps①">serialization steps</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps" id="ref-for-deserialization-steps①">deserialization steps</a> are the same as those for <code class="idl"><a data-link-type="idl" href="#filesystemhandle" id="ref-for-filesystemhandle①⓪">FileSystemHandle</a></code>.</p>
+   <p><strong class="advisement"> In the Origin Trial as available in Chrome 78, these objects are not yet serializable.
+In Chrome 82 they are.</strong></p>
+   <h4 class="heading settled" data-level="2.4.1" id="api-filesystemfilehandle-getfile"><span class="secno">2.4.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-getfile" id="ref-for-dom-filesystemfilehandle-getfile①">getFile()</a></code> method</span><a class="self-link" href="#api-filesystemfilehandle-getfile"></a></h4>
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle/getFile" title="The getFile() method of the FileSystemFileHandle interface returns a Promise which resolves to a File object representing the state on disk of the entry represented by the handle.">FileSystemFileHandle/getFile</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>file</var> = await <var>fileHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-getfile" id="ref-for-dom-filesystemfilehandle-getfile②">getFile()</a></code>
+     <dd data-md>
+      <p>Returns a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-file" id="ref-for-dfn-file①">File</a></code> representing the state on disk of the entry represented by <var>handle</var>.
+ If the file on disk changes or is removed after this method is called, the returned <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-file" id="ref-for-dfn-file②">File</a></code> object will likely be no longer readable.</p>
+    </dl>
+   </div>
+   <div class="algorithm" data-algorithm="getFile()" data-algorithm-for="FileSystemFileHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemFileHandle" data-dfn-type="method" data-export id="dom-filesystemfilehandle-getfile"><code>getFile()</code></dfn> method, when invoked, must run these steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑤">a new promise</a>.</p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑤">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#querying-file-system-permission" id="ref-for-querying-file-system-permission①">querying file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④">this</a></b> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read④">"read"</a></code>.</p>
+       <li data-md>
+        <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted②">"granted"</a></code>,
+ reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror">NotAllowedError</a></code> and abort.</p>
+       <li data-md>
+        <p>Let <var>entry</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑤">this</a></b>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry⑨">entry</a>.</p>
+       <li data-md>
+        <p>Let <var>f</var> be a new <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-file" id="ref-for-dfn-file③">File</a></code>.</p>
+       <li data-md>
+        <p>Set <var>f</var>’s <a data-link-type="dfn" href="https://w3c.github.io/FileAPI/#snapshot-state" id="ref-for-snapshot-state">snapshot state</a> to the current state of <var>entry</var>.</p>
+       <li data-md>
+        <p>Set <var>f</var>’s underlying byte sequence to a copy of <var>entry</var>’s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data①">binary data</a>.</p>
+       <li data-md>
+        <p>Initialize the value of <var>f</var>’s <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-name" id="ref-for-dfn-name">name</a></code> attribute to <var>entry</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name③">name</a>.</p>
+       <li data-md>
+        <p>Initialize the value of <var>f</var>’s <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-lastModified" id="ref-for-dfn-lastModified">lastModified</a></code> attribute to <var>entry</var>’s <a data-link-type="dfn" href="#file-entry-modification-timestamp" id="ref-for-file-entry-modification-timestamp①">modification timestamp</a>.</p>
+       <li data-md>
+        <p>Initialize the value of <var>f</var>’s <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-type" id="ref-for-dfn-type">type</a></code> attribute to an implementation defined value, based on for example <var>entry</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name④">name</a> and/or its file extension.</p>
+        <p class="issue" id="issue-1fb8bcae"><a class="self-link" href="#issue-1fb8bcae"></a> The reading and snapshotting behavior needs to be better specified in the <a data-link-type="biblio" href="#biblio-file-api">[FILE-API]</a> spec,
+ for now this is kind of hand-wavy.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⓪">Resolve</a> <var>result</var> with <var>f</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <h4 class="heading settled" data-level="2.4.2" id="api-filesystemfilehandle-createwritable"><span class="secno">2.4.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-createwritable" id="ref-for-dom-filesystemfilehandle-createwritable①">createWritable()</a></code> method</span><a class="self-link" href="#api-filesystemfilehandle-createwritable"></a></h4>
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle/createWritable" title="The createWritable() method of the FileSystemFileHandle interface creates a FileSystemWritableFileStream that can be used to write to a file. The method returns a Promise which resolves to this created stream.">FileSystemFileHandle/createWritable</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+   <p><strong class="advisement"> In the Origin Trial as available in Chrome 82, createWritable replaces the createWriter method.</strong></p>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>stream</var> = await <var>fileHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-createwritable" id="ref-for-dom-filesystemfilehandle-createwritable②">createWritable()</a></code>
+     <dt data-md><var>stream</var> = await <var>fileHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-createwritable" id="ref-for-dom-filesystemfilehandle-createwritable③">createWritable</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-filesystemcreatewritableoptions-keepexistingdata" id="ref-for-dom-filesystemcreatewritableoptions-keepexistingdata">keepExistingData</a></code>: true/false })
+     <dd data-md>
+      <p>Returns a <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream②">FileSystemWritableFileStream</a></code> that can be used to write to the file. Any changes made through <var>stream</var> won’t be reflected in the file represented by <var>fileHandle</var> until the stream has been closed.
+ User agents try to ensure that no partial writes happen, i.e. the file represented by <var>fileHandle</var> will either contain its old contents or it will contain whatever data was written
+ through <var>stream</var> up until the stream has been closed.</p>
+      <p>This is typically implemented by writing data to a temporary file, and only replacing the file
+ represented by <var>fileHandle</var> with the temporary file when the writable filestream is closed.</p>
+      <p>If <code class="idl"><a data-link-type="idl" href="#dom-filesystemcreatewritableoptions-keepexistingdata" id="ref-for-dom-filesystemcreatewritableoptions-keepexistingdata①">keepExistingData</a></code> is <code>false</code> or not specified,
+ the temporary file starts out empty,
+ otherwise the existing file is first copied to this temporary file.</p>
+      <p>Creating a <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream③">FileSystemWritableFileStream</a></code> <a data-link-type="dfn" href="#file-entry-lock-take" id="ref-for-file-entry-lock-take">takes a shared lock</a> on the <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①⓪">entry</a> associated with <var>fileHandle</var>. This prevents the creation of <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle②">FileSystemSyncAccessHandles</a></code> for the entry, until the stream is closed.</p>
+    </dl>
+   </div>
+   <p class="issue" id="issue-0693bc11"><a class="self-link" href="#issue-0693bc11"></a> There has been some discussion around and desire for a "inPlace" mode for createWritable
+(where changes will be written to the actual underlying file as they are written to the writer, for
+example to support in-place modification of large files or things like databases). This is not
+currently implemented in Chrome. Implementing this is currently blocked on figuring out how to
+combine the desire to run malware checks with the desire to let websites make fast in-place
+modifications to existing large files. <a href="https://github.com/wicg/file-system-access/issues/67">[Issue #67]</a></p>
+   <p>// TODO(fivedots): release lock once the stream is closed.</p>
+   <div class="algorithm" data-algorithm="createWritable(options)" data-algorithm-for="FileSystemFileHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemFileHandle" data-dfn-type="method" data-export data-lt="createWritable(options)|createWritable()" id="dom-filesystemfilehandle-createwritable"><code>createWritable(<var>options</var>)</code></dfn> method, when invoked, must run these steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑥">a new promise</a>.</p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑥">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#requesting-file-system-permission" id="ref-for-requesting-file-system-permission①">requesting file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑥">this</a></b> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite⑤">"readwrite"</a></code>.
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③">reject</a> <var>result</var> with that exception and abort.</p>
+       <li data-md>
+        <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted③">"granted"</a></code>,
+ reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror①">NotAllowedError</a></code> and abort.</p>
+       <li data-md>
+        <p>Let <var>entry</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑦">this</a></b>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①①">entry</a>.</p>
+       <li data-md>
+        <p>Let <var>lockValue</var> be "shared".</p>
+       <li data-md>
+        <p>Let <var>lockResult</var> be the result of <a data-link-type="dfn" href="#file-entry-lock-take" id="ref-for-file-entry-lock-take①">taking a lock</a> with <var>lockValue</var> on <var>entry</var>.
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject④">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#nomodificationallowederror" id="ref-for-nomodificationallowederror">NoModificationAllowedError</a></code> and abort.</p>
+       <li data-md>
+        <p>Let <var>stream</var> be the result of <a data-link-type="dfn" href="#create-a-new-filesystemwritablefilestream" id="ref-for-create-a-new-filesystemwritablefilestream">creating a new FileSystemWritableFileStream</a> for <var>entry</var> in <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑧">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm①">relevant realm</a>.</p>
+       <li data-md>
+        <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemcreatewritableoptions-keepexistingdata" id="ref-for-dom-filesystemcreatewritableoptions-keepexistingdata②">keepExistingData</a></code> is <code>true</code>:</p>
+        <ol>
+         <li data-md>
+          <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer">[[buffer]]</a> to a copy of <var>entry</var>’s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data②">binary data</a>.</p>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①①">Resolve</a> <var>result</var> with <var>stream</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <h4 class="heading settled" data-level="2.4.3" id="api-filesystemfilehandle-createsyncaccesshandle"><span class="secno">2.4.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-createsyncaccesshandle" id="ref-for-dom-filesystemfilehandle-createsyncaccesshandle①">createSyncAccessHandle()</a></code> method</span><a class="self-link" href="#api-filesystemfilehandle-createsyncaccesshandle"></a></h4>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>handle</var> = await <var>fileHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandle-createsyncaccesshandle" id="ref-for-dom-filesystemfilehandle-createsyncaccesshandle②">createSyncAccessHandle</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandlecreateaccesshandleoptions-mode" id="ref-for-dom-filesystemfilehandlecreateaccesshandleoptions-mode">mode</a></code>: "in-place" })
+     <dd data-md>
+      <p>Returns a <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle③">FileSystemSyncAccessHandle</a></code> that can be used to read/write from/to the file.
+ Changes made through <var>handle</var> might be immediately reflected in the file represented by <var>fileHandle</var>.
+ To ensure the changes are reflected in this file, the handle must be flushed or closed.</p>
+      <p>Creating a <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle④">FileSystemSyncAccessHandle</a></code> <a data-link-type="dfn" href="#file-entry-lock-take" id="ref-for-file-entry-lock-take②">takes an exclusive lock</a> on the <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①②">entry</a> associated with <var>fileHandle</var>. This prevents the creation of
+further <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑤">FileSystemSyncAccessHandles</a></code> or <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream④">FileSystemWritableFileStreams</a></code> for the entry, until the access handle is closed.</p>
+      <p>The returned <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑥">FileSystemSyncAccessHandle</a></code> offers synchronous <code class="idl"><a data-link-type="idl">read()</a></code> and <code class="idl"><a data-link-type="idl">write()</a></code> methods. This allows for higher performance for critical methods on
+contexts where asynchronous operations come with high overhead i.e., WebAssembly.</p>
+      <p>For the time being, this method will only succeed when the <var>fileHandle</var> belongs to the <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system①">origin private file system</a>. Also temporarily, the <code class="idl"><a data-link-type="idl" href="#dom-filesystemfilehandlecreateaccesshandleoptions-mode" id="ref-for-dom-filesystemfilehandlecreateaccesshandleoptions-mode①">mode</a></code> parameter
+must be set to "in-place". This prevents us from setting a default behavior and allows us to bring access handles to
+other filesytems in the future.</p>
+    </dl>
+   </div>
+   <div class="algorithm" data-algorithm="createSyncAccessHandle(options)" data-algorithm-for="FileSystemFileHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemFileHandle" data-dfn-type="method" data-export data-lt="createSyncAccessHandle(options)|createSyncAccessHandle()" id="dom-filesystemfilehandle-createsyncaccesshandle"><code>createSyncAccessHandle(<var>options</var>)</code></dfn> method, when invoked, must run these steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑦">a new promise</a>.</p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑦">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#requesting-file-system-permission" id="ref-for-requesting-file-system-permission②">requesting file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑨">this</a></b> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite⑥">"readwrite"</a></code>.
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑤">reject</a> <var>result</var> with that exception and abort.</p>
+       <li data-md>
+        <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted④">"granted"</a></code>,
+ reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror②">NotAllowedError</a></code> and abort.</p>
+       <li data-md>
+        <p>Let <var>entry</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⓪">this</a></b>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①③">entry</a>.</p>
+       <li data-md>
+        <p>If <var>entry</var> does not represent an <a data-link-type="dfn" href="#entry" id="ref-for-entry①③">entry</a> in an <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system②">origin private file system</a>,
+ reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code> and abort.</p>
+       <li data-md>
+        <p>Let <var>lockValue</var> be "exclusive".</p>
+       <li data-md>
+        <p>Let <var>lockResult</var> be the result of <a data-link-type="dfn" href="#file-entry-lock-take" id="ref-for-file-entry-lock-take③">taking a lock</a> with <var>lockValue</var> on <var>entry</var>.
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑥">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#nomodificationallowederror" id="ref-for-nomodificationallowederror①">NoModificationAllowedError</a></code> and abort.</p>
+       <li data-md>
+        <p>Let <var>handle</var> be the result of <a data-link-type="dfn" href="#create-a-new-filesystemsyncaccesshandle" id="ref-for-create-a-new-filesystemsyncaccesshandle">creating a new FileSystemSyncAccessHandle</a> for <var>entry</var> in <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①①">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm②">relevant realm</a>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①②">Resolve</a> <var>result</var> with <var>handle</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="2.5" id="api-filesystemdirectoryhandle"><span class="secno">2.5. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①">FileSystemDirectoryHandle</a></code> interface</span><a class="self-link" href="#api-filesystemdirectoryhandle"></a></h3>
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle" title="The FileSystemDirectoryHandle interface of the File System Access API provides a handle to a file system directory. The interface is accessed via the window.showDirectoryPicker() method.">FileSystemDirectoryHandle</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystemgetfileoptions"><code><c- g>FileSystemGetFileOptions</c-></code></dfn> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean②"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-default="false" data-dfn-for="FileSystemGetFileOptions" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-filesystemgetfileoptions-create"><code><c- g>create</c-></code></dfn> = <c- b>false</c->;
+};
+
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystemgetdirectoryoptions"><code><c- g>FileSystemGetDirectoryOptions</c-></code></dfn> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean③"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-default="false" data-dfn-for="FileSystemGetDirectoryOptions" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-filesystemgetdirectoryoptions-create"><code><c- g>create</c-></code></dfn> = <c- b>false</c->;
+};
+
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystemremoveoptions"><code><c- g>FileSystemRemoveOptions</c-></code></dfn> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean④"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-default="false" data-dfn-for="FileSystemRemoveOptions" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-filesystemremoveoptions-recursive"><code><c- g>recursive</c-></code></dfn> = <c- b>false</c->;
+};
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed③"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->), <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext" id="ref-for-SecureContext②"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable" id="ref-for-serializable②"><c- g>Serializable</c-></a>]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="filesystemdirectoryhandle"><code><c- g>FileSystemDirectoryHandle</c-></code></dfn> : <a data-link-type="idl-name" href="#filesystemhandle" id="ref-for-filesystemhandle①①"><c- n>FileSystemHandle</c-></a> {
+  <c- b>async</c-> <c- b>iterable</c->&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString①"><c- b>USVString</c-></a>, <a data-link-type="idl-name" href="#filesystemhandle" id="ref-for-filesystemhandle①②"><c- n>FileSystemHandle</c-></a>>;
+
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑥"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle④"><c- n>FileSystemFileHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemdirectoryhandle-getfilehandle" id="ref-for-dom-filesystemdirectoryhandle-getfilehandle"><c- g>getFileHandle</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString②"><c- b>USVString</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemDirectoryHandle/getFileHandle(name, options), FileSystemDirectoryHandle/getFileHandle(name)" data-dfn-type="argument" data-export id="dom-filesystemdirectoryhandle-getfilehandle-name-options-name"><code><c- g>name</c-></code><a class="self-link" href="#dom-filesystemdirectoryhandle-getfilehandle-name-options-name"></a></dfn>, <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemgetfileoptions" id="ref-for-dictdef-filesystemgetfileoptions"><c- n>FileSystemGetFileOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemDirectoryHandle/getFileHandle(name, options), FileSystemDirectoryHandle/getFileHandle(name)" data-dfn-type="argument" data-export id="dom-filesystemdirectoryhandle-getfilehandle-name-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemdirectoryhandle-getfilehandle-name-options-options"></a></dfn> = {});
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑦"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle②"><c- n>FileSystemDirectoryHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemdirectoryhandle-getdirectoryhandle" id="ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle"><c- g>getDirectoryHandle</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString③"><c- b>USVString</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemDirectoryHandle/getDirectoryHandle(name, options), FileSystemDirectoryHandle/getDirectoryHandle(name)" data-dfn-type="argument" data-export id="dom-filesystemdirectoryhandle-getdirectoryhandle-name-options-name"><code><c- g>name</c-></code><a class="self-link" href="#dom-filesystemdirectoryhandle-getdirectoryhandle-name-options-name"></a></dfn>, <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemgetdirectoryoptions" id="ref-for-dictdef-filesystemgetdirectoryoptions"><c- n>FileSystemGetDirectoryOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemDirectoryHandle/getDirectoryHandle(name, options), FileSystemDirectoryHandle/getDirectoryHandle(name)" data-dfn-type="argument" data-export id="dom-filesystemdirectoryhandle-getdirectoryhandle-name-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemdirectoryhandle-getdirectoryhandle-name-options-options"></a></dfn> = {});
+
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑧"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemdirectoryhandle-removeentry" id="ref-for-dom-filesystemdirectoryhandle-removeentry"><c- g>removeEntry</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString④"><c- b>USVString</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemDirectoryHandle/removeEntry(name, options), FileSystemDirectoryHandle/removeEntry(name)" data-dfn-type="argument" data-export id="dom-filesystemdirectoryhandle-removeentry-name-options-name"><code><c- g>name</c-></code><a class="self-link" href="#dom-filesystemdirectoryhandle-removeentry-name-options-name"></a></dfn>, <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemremoveoptions" id="ref-for-dictdef-filesystemremoveoptions"><c- n>FileSystemRemoveOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemDirectoryHandle/removeEntry(name, options), FileSystemDirectoryHandle/removeEntry(name)" data-dfn-type="argument" data-export id="dom-filesystemdirectoryhandle-removeentry-name-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemdirectoryhandle-removeentry-name-options-options"></a></dfn> = {});
+
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑨"><c- b>Promise</c-></a>&lt;<a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence" id="ref-for-idl-sequence"><c- b>sequence</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString⑤"><c- b>USVString</c-></a>>?> <a class="idl-code" data-link-type="method" href="#dom-filesystemdirectoryhandle-resolve" id="ref-for-dom-filesystemdirectoryhandle-resolve"><c- g>resolve</c-></a>(<a data-link-type="idl-name" href="#filesystemhandle" id="ref-for-filesystemhandle①③"><c- n>FileSystemHandle</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemDirectoryHandle/resolve(possibleDescendant)" data-dfn-type="argument" data-export id="dom-filesystemdirectoryhandle-resolve-possibledescendant-possibledescendant"><code><c- g>possibleDescendant</c-></code><a class="self-link" href="#dom-filesystemdirectoryhandle-resolve-possibledescendant-possibledescendant"></a></dfn>);
+};
+</pre>
+   <p>A <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle③">FileSystemDirectoryHandle</a></code>'s associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①④">entry</a> must be a <a data-link-type="dfn" href="#directory" id="ref-for-directory④">directory entry</a>.</p>
+   <p><code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle④">FileSystemDirectoryHandle</a></code> objects are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects" id="ref-for-serializable-objects②">serializable objects</a>. Their <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps" id="ref-for-serialization-steps②">serialization steps</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps" id="ref-for-deserialization-steps②">deserialization steps</a> are the same as those for <code class="idl"><a data-link-type="idl" href="#filesystemhandle" id="ref-for-filesystemhandle①④">FileSystemHandle</a></code>.</p>
+   <p><strong class="advisement"> In the Origin Trial as available in Chrome 78, these objects are not yet serializable.
+In Chrome 82 they are.</strong></p>
+   <p><strong class="advisement"> In Chrome versions upto Chrome 85 <code>getFileHandle</code> and <code>getDirectoryHandle</code> where
+called <code>getFile</code> and <code>getDirectory</code> instead.</strong></p>
+   <h4 class="heading settled" data-level="2.5.1" id="api-filesystemdirectoryhandle-asynciterable"><span class="secno">2.5.1. </span><span class="content">Directory iteration</span><a class="self-link" href="#api-filesystemdirectoryhandle-asynciterable"></a></h4>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md>for await (let [<var>name</var>, <var>handle</var>] of <var>directoryHandle</var>) {}
+     <dt data-md>for await (let [<var>name</var>, <var>handle</var>] of <var>directoryHandle</var> . entries()) {}
+     <dt data-md>for await (let <var>handle</var> of <var>directoryHandle</var> . values()) {}
+     <dt data-md>for await (let <var>name</var> of <var>directoryHandle</var> . keys()) {}
+     <dd data-md>
+      <p>Iterates over all entries whose parent is the entry represented by <var>directoryHandle</var>. Entries
+ that are created or deleted while the iteration is in progress might or might not be included.
+ No guarantees are given either way.</p>
+    </dl>
+   </div>
+   <p><strong class="advisement"> In Chrome this is currently implemented as a <code>directoryHandle.getEntries()</code> method that can be used in a <code>for await..of</code> loop.
+This <code>getEntries()</code> method returns more or less the same async iterable as what is returned by <code>values()</code> in this specification.
+The proper async iterable declaration is not yet implemented.</strong></p>
+   <p class="issue" id="issue-cce0bb28"><a class="self-link" href="#issue-cce0bb28"></a> In the future we might want to add arguments to the async iterable declaration to
+support for example recursive iteration. <a href="https://github.com/wicg/file-system-access/issues/173">[Issue #173]</a></p>
+   <div class="algorithm" data-algorithm="iterator initialization">
+     The <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps" id="ref-for-asynchronous-iterator-initialization-steps">asynchronous iterator initialization steps</a> for a <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle⑤">FileSystemDirectoryHandle</a></code> <var>handle</var> ant its async iterator <var>iterator</var> are: 
+    <ol>
+     <li data-md>
+      <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#querying-file-system-permission" id="ref-for-querying-file-system-permission②">querying file system permission</a> given <var>handle</var> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read⑤">"read"</a></code>.</p>
+     <li data-md>
+      <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted⑤">"granted"</a></code>,
+ throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror③">NotAllowedError</a></code>.</p>
+     <li data-md>
+      <p>Set <var>iterator</var>’s <dfn class="dfn-paneled" data-dfn-for="FileSystemDirectoryHandle-iterator" data-dfn-type="dfn" data-noexport id="filesystemdirectoryhandle-iterator-past-results">past results</dfn> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">set</a>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="next iteration result">
+     To <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result" id="ref-for-dfn-get-the-next-iteration-result">get the next iteration result</a> for a <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle⑥">FileSystemDirectoryHandle</a></code> <var>handle</var> and its async iterator <var>iterator</var>: 
+    <ol>
+     <li data-md>
+      <p>Let <var>promise</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑧">a new promise</a>.</p>
+     <li data-md>
+      <p>Let <var>directory</var> be <var>handle</var>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①⑤">entry</a>.</p>
+     <li data-md>
+      <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#querying-file-system-permission" id="ref-for-querying-file-system-permission③">querying file system permission</a> given <var>handle</var> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read⑥">"read"</a></code>.</p>
+     <li data-md>
+      <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted⑥">"granted"</a></code>,
+ reject <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror④">NotAllowedError</a></code> and return <var>promise</var>.</p>
+     <li data-md>
+      <p>Let <var>child</var> be an <a data-link-type="dfn" href="#entry" id="ref-for-entry①④">entry</a> in <var>directory</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children③">children</a>,
+ such that <var>child</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name⑤">name</a> is not contained in <var>iterator</var>’s <a data-link-type="dfn" href="#filesystemdirectoryhandle-iterator-past-results" id="ref-for-filesystemdirectoryhandle-iterator-past-results">past results</a>,
+ or <code>null</code> if no such entry exists.</p>
+      <p class="note" role="note"><span>Note:</span> This is intentionally very vague about the iteration order. Different platforms
+ and file systems provide different guarantees about iteration order, and we want it to
+ be possible to efficiently implement this on all platforms. As such no guarantees are given
+ about the exact order in which elements are returned.</p>
+     <li data-md>
+      <p>If <var>child</var> is <code>null</code>, then:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①③">Resolve</a> <var>promise</var> with <code>undefined</code>.</p>
+      </ol>
+     <li data-md>
+      <p>Otherwise:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>child</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name⑥">name</a> to <var>iterator</var>’s <a data-link-type="dfn" href="#filesystemdirectoryhandle-iterator-past-results" id="ref-for-filesystemdirectoryhandle-iterator-past-results①">past results</a>.</p>
+       <li data-md>
+        <p>If <var>child</var> is a <a data-link-type="dfn" href="#file" id="ref-for-file④">file entry</a>:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>result</var> be a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle⑤">FileSystemFileHandle</a></code> associated with <var>child</var>.</p>
+        </ol>
+       <li data-md>
+        <p>Otherwise:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>result</var> be a new <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle⑦">FileSystemDirectoryHandle</a></code> associated with <var>child</var>.</p>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①④">Resolve</a> <var>promise</var> with (<var>child</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name⑦">name</a>, <var>result</var>).</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>promise</var>.</p>
+    </ol>
+   </div>
+   <h4 class="heading settled" data-level="2.5.2" id="api-filesystemdirectoryhandle-getfilehandle"><span class="secno">2.5.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-getfilehandle" id="ref-for-dom-filesystemdirectoryhandle-getfilehandle①">getFileHandle()</a></code> method</span><a class="self-link" href="#api-filesystemdirectoryhandle-getfilehandle"></a></h4>
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/getFileHandle" title="The getFileHandle() method of the FileSystemDirectoryHandle interface returns a FileSystemFileHandle for a file with the specified name, within the directory the method is called.">FileSystemDirectoryHandle/getFileHandle</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>fileHandle</var> = await <var>directoryHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-getfilehandle" id="ref-for-dom-filesystemdirectoryhandle-getfilehandle②">getFileHandle</a></code>(<var>name</var>)
+     <dt data-md><var>fileHandle</var> = await <var>directoryHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-getfilehandle" id="ref-for-dom-filesystemdirectoryhandle-getfilehandle③">getFileHandle</a></code>(<var>name</var>, { <code class="idl"><a data-link-type="idl" href="#dom-filesystemgetfileoptions-create" id="ref-for-dom-filesystemgetfileoptions-create">create</a></code>: false })
+     <dd data-md>
+      <p>Returns a handle for a file named <var>name</var> in the directory represented by <var>directoryHandle</var>. If
+ no such file exists, this rejects.</p>
+     <dt data-md><var>fileHandle</var> = await <var>directoryHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-getfilehandle" id="ref-for-dom-filesystemdirectoryhandle-getfilehandle④">getFileHandle</a></code>(<var>name</var>, { <code class="idl"><a data-link-type="idl" href="#dom-filesystemgetfileoptions-create" id="ref-for-dom-filesystemgetfileoptions-create①">create</a></code>: true })
+     <dd data-md>
+      <p>Returns a handle for a file named <var>name</var> in the directory represented by <var>directoryHandle</var>. If
+ no such file exists, this creates a new file. If no file with named <var>name</var> can be created this
+ rejects. Creation can fail because there already is a directory with the same name, because the
+ name uses characters that aren’t supported in file names on the underlying file system, or
+ because the user agent for security reasons decided not to allow creation of the file.</p>
+      <p>This operation requires write permission, even if the file being returned already exists. If
+ this handle doesn’t already have write permission, this could result in a prompt being shown to
+ the user. To get an existing file without needing write permission, call this method
+ with <code>{ <code class="idl"><a data-link-type="idl" href="#dom-filesystemgetfileoptions-create" id="ref-for-dom-filesystemgetfileoptions-create②">create</a></code>: false }</code>.</p>
+    </dl>
+   </div>
+   <div class="algorithm" data-algorithm="getFileHandle(name, options)" data-algorithm-for="FileSystemDirectoryHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemDirectoryHandle" data-dfn-type="method" data-export data-lt="getFileHandle(name, options)|getFileHandle(name)" id="dom-filesystemdirectoryhandle-getfilehandle"><code>getFileHandle(<var>name</var>, <var>options</var>)</code></dfn> method, when invoked,
+must run these steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise⑨">a new promise</a>.</p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑧">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>name</var> is not a <a data-link-type="dfn" href="#valid-file-name" id="ref-for-valid-file-name①">valid file name</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑦">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror">TypeError</a></code> and abort.</p>
+       <li data-md>
+        <p>Let <var>entry</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①②">this</a></b>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①⑥">entry</a>.</p>
+       <li data-md>
+        <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemgetfileoptions-create" id="ref-for-dom-filesystemgetfileoptions-create③">create</a></code> is <code>true</code>:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#requesting-file-system-permission" id="ref-for-requesting-file-system-permission③">requesting file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①③">this</a></b> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite⑦">"readwrite"</a></code>.
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑧">reject</a> <var>result</var> with that exception and abort.</p>
+        </ol>
+       <li data-md>
+        <p>Otherwise:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#querying-file-system-permission" id="ref-for-querying-file-system-permission④">querying file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①④">this</a></b> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read⑦">"read"</a></code>.</p>
+        </ol>
+       <li data-md>
+        <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted⑦">"granted"</a></code>,
+ reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑤">NotAllowedError</a></code> and abort.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①">For each</a> <var>child</var> of <var>entry</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children④">children</a>:</p>
+        <ol>
+         <li data-md>
+          <p>If <var>child</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name⑧">name</a> equals <var>name</var>:</p>
+          <ol>
+           <li data-md>
+            <p>If <var>child</var> is a <a data-link-type="dfn" href="#directory" id="ref-for-directory⑤">directory entry</a>:</p>
+            <ol>
+             <li data-md>
+              <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject⑨">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#typemismatcherror" id="ref-for-typemismatcherror">TypeMismatchError</a></code> and abort.</p>
+            </ol>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑤">Resolve</a> <var>result</var> with a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle⑥">FileSystemFileHandle</a></code> whose <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①⑦">entry</a> is <var>child</var> and abort.</p>
+          </ol>
+        </ol>
+       <li data-md>
+        <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemgetfileoptions-create" id="ref-for-dom-filesystemgetfileoptions-create④">create</a></code> is <code>false</code>:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⓪">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notfounderror" id="ref-for-notfounderror">NotFoundError</a></code> and abort.</p>
+        </ol>
+       <li data-md>
+        <p>Let <var>child</var> be a new <a data-link-type="dfn" href="#file" id="ref-for-file⑤">file entry</a>.</p>
+       <li data-md>
+        <p>Set <var>child</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name⑨">name</a> to <var>name</var>.</p>
+       <li data-md>
+        <p>Set <var>child</var>’s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data③">binary data</a> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence①">byte sequence</a>.</p>
+       <li data-md>
+        <p>Set <var>child</var>’s <a data-link-type="dfn" href="#file-entry-modification-timestamp" id="ref-for-file-entry-modification-timestamp②">modification timestamp</a> to the current time.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append①">Append</a> <var>child</var> to <var>entry</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children⑤">children</a>.</p>
+       <li data-md>
+        <p>If creating <var>child</var> in the underlying file system throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①①">reject</a> <var>result</var> with that exception and abort.</p>
+        <p class="issue" id="issue-721a33e4"><a class="self-link" href="#issue-721a33e4"></a> Better specify what possible exceptions this could throw. <a href="https://github.com/wicg/file-system-access/issues/68">[Issue #68]</a></p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑥">Resolve</a> <var>result</var> with a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle⑦">FileSystemFileHandle</a></code> whose <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①⑧">entry</a> is <var>child</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <h4 class="heading settled" data-level="2.5.3" id="api-filesystemdirectoryhandle-getdirectoryhandle"><span class="secno">2.5.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-getdirectoryhandle" id="ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle①">getDirectoryHandle()</a></code> method</span><a class="self-link" href="#api-filesystemdirectoryhandle-getdirectoryhandle"></a></h4>
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/getDirectoryHandle" title="The getDirectoryHandle() method of the FileSystemDirectoryHandle interface returns a FileSystemDirectoryHandle for a subdirectory with the specified name within the directory handle on which the method is called.">FileSystemDirectoryHandle/getDirectoryHandle</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>subdirHandle</var> = await <var>directoryHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-getdirectoryhandle" id="ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle②">getDirectoryHandle</a></code>(<var>name</var>)
+     <dt data-md><var>subdirHandle</var> = await <var>directoryHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-getdirectoryhandle" id="ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle③">getDirectoryHandle</a></code>(<var>name</var>, { <code class="idl"><a data-link-type="idl" href="#dom-filesystemgetdirectoryoptions-create" id="ref-for-dom-filesystemgetdirectoryoptions-create">create</a></code>: false })
+     <dd data-md>
+      <p>Returns a handle for a directory named <var>name</var> in the directory represented by <var>directoryHandle</var>. If no such directory exists, this rejects.</p>
+     <dt data-md><var>subdirHandle</var> = await <var>directoryHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-getdirectoryhandle" id="ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle④">getDirectoryHandle</a></code>(<var>name</var>, { <code class="idl"><a data-link-type="idl" href="#dom-filesystemgetdirectoryoptions-create" id="ref-for-dom-filesystemgetdirectoryoptions-create①">create</a></code>: true })
+     <dd data-md>
+      <p>Returns a handle for a directory named <var>name</var> in the directory represented by <var>directoryHandle</var>. If no such directory exists, this creates a new directory. If creating the
+ directory failed, this rejects. Creation can fail because there already is a file with the same
+ name, or because the name uses characters that aren’t supported in file names on the underlying
+ file system.</p>
+      <p>This operation requires write permission, even if the directory being returned already exists.
+ If this handle doesn’t already have write permission, this could result in a prompt being shown
+ to the user. To get an existing directory without needing write permission, call this method
+ with <code>{ <code class="idl"><a data-link-type="idl" href="#dom-filesystemgetdirectoryoptions-create" id="ref-for-dom-filesystemgetdirectoryoptions-create②">create</a></code>: false }</code>.</p>
+    </dl>
+   </div>
+   <div class="algorithm" data-algorithm="getDirectoryHandle(name, options)" data-algorithm-for="FileSystemDirectoryHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemDirectoryHandle" data-dfn-type="method" data-export data-lt="getDirectoryHandle(name, options)|getDirectoryHandle(name)" id="dom-filesystemdirectoryhandle-getdirectoryhandle"><code>getDirectoryHandle(<var>name</var>, <var>options</var>)</code></dfn> method, when
+invoked, must run these steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⓪">a new promise</a>.</p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel⑨">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>name</var> is not a <a data-link-type="dfn" href="#valid-file-name" id="ref-for-valid-file-name②">valid file name</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①②">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①">TypeError</a></code> and abort.</p>
+       <li data-md>
+        <p>Let <var>entry</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑤">this</a></b>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry①⑨">entry</a>.</p>
+       <li data-md>
+        <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemgetdirectoryoptions-create" id="ref-for-dom-filesystemgetdirectoryoptions-create③">create</a></code> is <code>true</code>:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#requesting-file-system-permission" id="ref-for-requesting-file-system-permission④">requesting file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑥">this</a></b> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite⑧">"readwrite"</a></code>.
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①③">reject</a> <var>result</var> with that exception and abort.</p>
+        </ol>
+       <li data-md>
+        <p>Otherwise:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#querying-file-system-permission" id="ref-for-querying-file-system-permission⑤">querying file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑦">this</a></b> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read⑧">"read"</a></code>.</p>
+        </ol>
+       <li data-md>
+        <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted⑧">"granted"</a></code>,
+ reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑥">NotAllowedError</a></code> and abort.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate②">For each</a> <var>child</var> of <var>entry</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children⑥">children</a>:</p>
+        <ol>
+         <li data-md>
+          <p>If <var>child</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name①⓪">name</a> equals <var>name</var>:</p>
+          <ol>
+           <li data-md>
+            <p>If <var>child</var> is a <a data-link-type="dfn" href="#file" id="ref-for-file⑥">file entry</a>:</p>
+            <ol>
+             <li data-md>
+              <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①④">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#typemismatcherror" id="ref-for-typemismatcherror①">TypeMismatchError</a></code> and abort.</p>
+            </ol>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑦">Resolve</a> <var>result</var> with a new <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle⑧">FileSystemDirectoryHandle</a></code> whose <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②⓪">entry</a> is <var>child</var> and abort.</p>
+          </ol>
+        </ol>
+       <li data-md>
+        <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemgetfileoptions-create" id="ref-for-dom-filesystemgetfileoptions-create⑤">create</a></code> is <code>false</code>:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑤">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notfounderror" id="ref-for-notfounderror①">NotFoundError</a></code> and abort.</p>
+        </ol>
+       <li data-md>
+        <p>Let <var>child</var> be a new <a data-link-type="dfn" href="#directory" id="ref-for-directory⑥">directory entry</a>.</p>
+       <li data-md>
+        <p>Set <var>child</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name①①">name</a> to <var>name</var>.</p>
+       <li data-md>
+        <p>Set <var>child</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children⑦">children</a> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append②">Append</a> <var>child</var> to <var>entry</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children⑧">children</a>.</p>
+       <li data-md>
+        <p>If creating <var>child</var> in the underlying file system throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑥">reject</a> <var>result</var> with that exception and abort.</p>
+        <p class="issue" id="issue-721a33e4①"><a class="self-link" href="#issue-721a33e4①"></a> Better specify what possible exceptions this could throw. <a href="https://github.com/wicg/file-system-access/issues/68">[Issue #68]</a></p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑧">Resolve</a> <var>result</var> with a new <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle⑨">FileSystemDirectoryHandle</a></code> whose <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②①">entry</a> is <var>child</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <h4 class="heading settled" data-level="2.5.4" id="api-filesystemdirectoryhandle-removeentry"><span class="secno">2.5.4. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-removeentry" id="ref-for-dom-filesystemdirectoryhandle-removeentry①">removeEntry()</a></code> method</span><a class="self-link" href="#api-filesystemdirectoryhandle-removeentry"></a></h4>
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/removeEntry" title="The removeEntry() method of the FileSystemDirectoryHandle interface attempts to remove an entry if the directory handle contains a file or directory called the name specified.">FileSystemDirectoryHandle/removeEntry</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md>await <var>directoryHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-removeentry" id="ref-for-dom-filesystemdirectoryhandle-removeentry②">removeEntry</a></code>(<var>name</var>)
+     <dt data-md>await <var>directoryHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-removeentry" id="ref-for-dom-filesystemdirectoryhandle-removeentry③">removeEntry</a></code>(<var>name</var>, { <code class="idl"><a data-link-type="idl" href="#dom-filesystemremoveoptions-recursive" id="ref-for-dom-filesystemremoveoptions-recursive">recursive</a></code>: false })
+     <dd data-md>
+      <p>If the directory represented by <var>directoryHandle</var> contains a file named <var>name</var>, or an empty
+ directory named <var>name</var>, this will attempt to delete that file or directory.</p>
+      <p>Attempting to delete a file or directory that does not exist is considered success,
+ while attempting to delete a non-empty directory will result in a promise rejection.</p>
+     <dt data-md>await <var>directoryHandle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-removeentry" id="ref-for-dom-filesystemdirectoryhandle-removeentry④">removeEntry</a></code>(<var>name</var>, { <code class="idl"><a data-link-type="idl" href="#dom-filesystemremoveoptions-recursive" id="ref-for-dom-filesystemremoveoptions-recursive①">recursive</a></code>: true })
+     <dd data-md>
+      <p>Removes the entry named <var>name</var> in the directory represented by <var>directoryHandle</var>.
+ If that entry is a directory, its contents will also be deleted recursively.
+ recursively.</p>
+      <p>Attempting to delete a file or directory that does not exist is considered success.</p>
+    </dl>
+   </div>
+   <div class="algorithm" data-algorithm="removeEntry(name, options)" data-algorithm-for="FileSystemDirectoryHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemDirectoryHandle" data-dfn-type="method" data-export data-lt="removeEntry(name, options)|removeEntry(name)" id="dom-filesystemdirectoryhandle-removeentry"><code>removeEntry(<var>name</var>, <var>options</var>)</code></dfn> method, when invoked, must run
+these steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①①">a new promise</a>.</p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⓪">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>name</var> is not a <a data-link-type="dfn" href="#valid-file-name" id="ref-for-valid-file-name③">valid file name</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑦">reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror②">TypeError</a></code> and abort.</p>
+       <li data-md>
+        <p>Let <var>entry</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑧">this</a></b>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②②">entry</a>.</p>
+       <li data-md>
+        <p>Let <var>permissionStatus</var> be the result of <a data-link-type="dfn" href="#requesting-file-system-permission" id="ref-for-requesting-file-system-permission⑤">requesting file system permission</a> given <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑨">this</a></b> and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite⑨">"readwrite"</a></code>.
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑧">reject</a> <var>result</var> with that exception and abort.</p>
+       <li data-md>
+        <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted⑨">"granted"</a></code>,
+ reject <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑦">NotAllowedError</a></code> and abort.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate③">For each</a> <var>child</var> of <var>entry</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children⑨">children</a>:</p>
+        <ol>
+         <li data-md>
+          <p>If <var>child</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name①②">name</a> equals <var>name</var>:</p>
+          <ol>
+           <li data-md>
+            <p>If <var>child</var> is a <a data-link-type="dfn" href="#directory" id="ref-for-directory⑦">directory entry</a>:</p>
+            <ol>
+             <li data-md>
+              <p>If <var>child</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children①⓪">children</a> is not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">empty</a> and <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filesystemremoveoptions-recursive" id="ref-for-dom-filesystemremoveoptions-recursive②">recursive</a></code> is <code>false</code>:</p>
+              <ol>
+               <li data-md>
+                <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①⑨">Reject</a> <var>result</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidmodificationerror" id="ref-for-invalidmodificationerror">InvalidModificationError</a></code> and abort.</p>
+              </ol>
+            </ol>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove">Remove</a> <var>child</var> from <var>entry</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children①①">children</a>.</p>
+           <li data-md>
+            <p>If removing <var>child</var> in the underlying file system throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⓪">reject</a> <var>result</var> with that exception and abort.</p>
+            <p class="note" role="note"><span>Note:</span> If <code class="idl"><a data-link-type="idl" href="#dom-filesystemremoveoptions-recursive" id="ref-for-dom-filesystemremoveoptions-recursive③">recursive</a></code> is <code>true</code>, the removal can fail
+ non-atomically. Some files or directories might have been removed while other files
+ or directories still exist.</p>
+            <p class="issue" id="issue-721a33e4②"><a class="self-link" href="#issue-721a33e4②"></a> Better specify what possible exceptions this could throw. <a href="https://github.com/wicg/file-system-access/issues/68">[Issue #68]</a></p>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①⑨">Resolve</a> <var>result</var> with <code>undefined</code>.</p>
+          </ol>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②①">Reject</a> <var>result</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notfounderror" id="ref-for-notfounderror②">NotFoundError</a></code>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <h4 class="heading settled" data-level="2.5.5" id="api-filesystemdirectoryhandle-resolve"><span class="secno">2.5.5. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-resolve" id="ref-for-dom-filesystemdirectoryhandle-resolve①">resolve()</a></code> method</span><a class="self-link" href="#api-filesystemdirectoryhandle-resolve"></a></h4>
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/resolve" title="The resolve() method of the FileSystemDirectoryHandle interface returns an Array of directory names from the parent handle to the specified child entry, with the name of the child entry as the last array item.">FileSystemDirectoryHandle/resolve</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>86+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>14.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>path</var> = await <var>directory</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemdirectoryhandle-resolve" id="ref-for-dom-filesystemdirectoryhandle-resolve②">resolve</a></code>( <var>child</var> )
+     <dd data-md>
+      <p>If <var>child</var> is equal to <var>directory</var>, <var>path</var> will be an empty array.</p>
+     <dd data-md>
+      <p>If <var>child</var> is a direct child of <var>directory</var>, <var>path</var> will be an array containing <var>child</var>’s name.</p>
+     <dd data-md>
+      <p>If <var>child</var> is a descendant of <var>directory</var>, <var>path</var> will be an array containing the names of
+ all the intermediate directories and <var>child</var>’s name as last element.
+ For example if <var>directory</var> represents <code>/home/user/project</code> and <var>child</var> represents <code>/home/user/project/foo/bar</code>, this will return <code>['foo', 'bar']</code>.</p>
+     <dd data-md>
+      <p>Otherwise (<var>directory</var> and <var>child</var> are not related), <var>path</var> will be null.</p>
+      <p>This functionality can be useful if a web application shows a directory
+ listing to highlight a file opened through a file picker in that directory listing.</p>
+    </dl>
+   </div>
+   <p><strong class="advisement"> This method is first available in Chrome 82.</strong></p>
+   <div class="example" id="filesystemdirectoryhandle-resolve-example">
+    <a class="self-link" href="#filesystemdirectoryhandle-resolve-example"></a> 
+<pre class="highlight"><c- c1>// Assume we at some point got a valid directory handle.</c->
+<c- a>const</c-> dir_ref <c- o>=</c-> current_project_dir<c- p>;</c->
+<c- k>if</c-> <c- p>(</c-><c- o>!</c->dir_ref<c- p>)</c-> <c- k>return</c-><c- p>;</c->
+
+<c- c1>// Now get a file reference by showing a file picker:</c->
+<c- a>const</c-> file_ref <c- o>=</c-> <c- k>await</c-> self<c- p>.</c->showOpenFilePicker<c- p>();</c->
+<c- k>if</c-> <c- p>(</c-><c- o>!</c->file_ref<c- p>)</c-> <c- p>{</c->
+    <c- c1>// User cancelled, or otherwise failed to open a file.</c->
+    <c- k>return</c-><c- p>;</c->
+<c- p>}</c->
+
+<c- c1>// Check if file_ref exists inside dir_ref:</c->
+<c- a>const</c-> relative_path <c- o>=</c-> <c- k>await</c-> dir_ref<c- p>.</c->resolve<c- p>(</c->file_ref<c- p>);</c->
+<c- k>if</c-> <c- p>(</c->relative_path <c- o>===</c-> <c- kc>null</c-><c- p>)</c-> <c- p>{</c->
+    <c- c1>// Not inside dir_ref</c->
+<c- p>}</c-> <c- k>else</c-> <c- p>{</c->
+    <c- c1>// relative_path is an array of names, giving the relative path</c->
+    <c- c1>// from dir_ref to the file that is represented by file_ref:</c->
+    assert relative_path<c- p>.</c->pop<c- p>()</c-> <c- o>===</c-> file_ref<c- p>.</c->name<c- p>;</c->
+
+    <c- a>let</c-> entry <c- o>=</c-> dir_ref<c- p>;</c->
+    <c- k>for</c-> <c- p>(</c-><c- a>const</c-> name <c- k>of</c-> relative_path<c- p>)</c-> <c- p>{</c->
+        entry <c- o>=</c-> <c- k>await</c-> entry<c- p>.</c->getDirectory<c- p>(</c->name<c- p>);</c->
+    <c- p>}</c->
+    entry <c- o>=</c-> <c- k>await</c-> entry<c- p>.</c->getFile<c- p>(</c->file_ref<c- p>.</c->name<c- p>);</c->
+
+    <c- c1>// Now |entry| will represent the same file on disk as |file_ref|.</c->
+    assert <c- k>await</c-> entry<c- p>.</c->isSameEntry<c- p>(</c->file_ref<c- p>)</c-> <c- o>===</c-> <c- kc>true</c-><c- p>;</c->
+<c- p>}</c->
+</pre>
+   </div>
+   <div class="algorithm" data-algorithm="resolve(possibleDescendant)" data-algorithm-for="FileSystemDirectoryHandle"> The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemDirectoryHandle" data-dfn-type="method" data-export id="dom-filesystemdirectoryhandle-resolve"><code>resolve(<var>possibleDescendant</var>)</code></dfn> method,
+when invoked, must return the result of <a data-link-type="dfn" href="#entry-resolve" id="ref-for-entry-resolve①">resolving</a> <var>possibleDescendant</var>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②③">entry</a> relative to <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⓪">this</a>'s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②④">entry</a>. </div>
+   <h3 class="heading settled" data-level="2.6" id="api-filesystemwritablefilestream"><span class="secno">2.6. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream⑤">FileSystemWritableFileStream</a></code> interface</span><a class="self-link" href="#api-filesystemwritablefilestream"></a></h3>
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream" title="The FileSystemWritableFileStream interface of the File System Access API is a WritableStream object with additional convenience methods, which operates on a single file on disk. The interface is accessed through the FileSystemFileHandle.createWritable() method.">FileSystemWritableFileStream</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera no"><span>Opera</span><span>None</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>None</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>None</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+<pre class="idl highlight def"><c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-writecommandtype"><code><c- g>WriteCommandType</c-></code></dfn> {
+  <dfn class="dfn-paneled idl-code" data-dfn-for="WriteCommandType" data-dfn-type="enum-value" data-export id="dom-writecommandtype-write"><code><c- s>"write"</c-></code></dfn>,
+  <dfn class="dfn-paneled idl-code" data-dfn-for="WriteCommandType" data-dfn-type="enum-value" data-export id="dom-writecommandtype-seek"><code><c- s>"seek"</c-></code></dfn>,
+  <dfn class="dfn-paneled idl-code" data-dfn-for="WriteCommandType" data-dfn-type="enum-value" data-export id="dom-writecommandtype-truncate"><code><c- s>"truncate"</c-></code></dfn>,
+};
+
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-writeparams"><code><c- g>WriteParams</c-></code></dfn> {
+  <c- b>required</c-> <a data-link-type="idl-name" href="#enumdef-writecommandtype" id="ref-for-enumdef-writecommandtype"><c- n>WriteCommandType</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="WriteParams" data-dfn-type="dict-member" data-export data-type="WriteCommandType " id="dom-writeparams-type"><code><c- g>type</c-></code></dfn>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a>? <dfn class="dfn-paneled idl-code" data-dfn-for="WriteParams" data-dfn-type="dict-member" data-export data-type="unsigned long long? " id="dom-writeparams-size"><code><c- g>size</c-></code></dfn>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a>? <dfn class="dfn-paneled idl-code" data-dfn-for="WriteParams" data-dfn-type="dict-member" data-export data-type="unsigned long long? " id="dom-writeparams-position"><code><c- g>position</c-></code></dfn>;
+  (<a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#BufferSource" id="ref-for-BufferSource"><c- n>BufferSource</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-Blob" id="ref-for-dfn-Blob"><c- n>Blob</c-></a> <c- b>or</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString⑥"><c- b>USVString</c-></a>)? <dfn class="dfn-paneled idl-code" data-dfn-for="WriteParams" data-dfn-type="dict-member" data-export data-type="(BufferSource or Blob or USVString)? " id="dom-writeparams-data"><code><c- g>data</c-></code></dfn>;
+};
+
+<c- b>typedef</c-> (<a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#BufferSource" id="ref-for-BufferSource①"><c- n>BufferSource</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-Blob" id="ref-for-dfn-Blob①"><c- n>Blob</c-></a> <c- b>or</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString⑦"><c- b>USVString</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-writeparams" id="ref-for-dictdef-writeparams"><c- n>WriteParams</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-filesystemwritechunktype"><code><c- g>FileSystemWriteChunkType</c-></code></dfn>;
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed④"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->), <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext" id="ref-for-SecureContext③"><c- g>SecureContext</c-></a>]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="filesystemwritablefilestream"><code><c- g>FileSystemWritableFileStream</c-></code></dfn> : <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#writablestream" id="ref-for-writablestream"><c- n>WritableStream</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①⓪"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined①"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemwritablefilestream-write" id="ref-for-dom-filesystemwritablefilestream-write"><c- g>write</c-></a>(<a data-link-type="idl-name" href="#typedefdef-filesystemwritechunktype" id="ref-for-typedefdef-filesystemwritechunktype"><c- n>FileSystemWriteChunkType</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemWritableFileStream/write(data)" data-dfn-type="argument" data-export id="dom-filesystemwritablefilestream-write-data-data"><code><c- g>data</c-></code><a class="self-link" href="#dom-filesystemwritablefilestream-write-data-data"></a></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①①"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined②"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemwritablefilestream-seek" id="ref-for-dom-filesystemwritablefilestream-seek"><c- g>seek</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long②"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemWritableFileStream/seek(position)" data-dfn-type="argument" data-export id="dom-filesystemwritablefilestream-seek-position-position"><code><c- g>position</c-></code><a class="self-link" href="#dom-filesystemwritablefilestream-seek-position-position"></a></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①②"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined③"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemwritablefilestream-truncate" id="ref-for-dom-filesystemwritablefilestream-truncate"><c- g>truncate</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long③"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemWritableFileStream/truncate(size)" data-dfn-type="argument" data-export id="dom-filesystemwritablefilestream-truncate-size-size"><code><c- g>size</c-></code><a class="self-link" href="#dom-filesystemwritablefilestream-truncate-size-size"></a></dfn>);
+};
+</pre>
+   <p>A <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream⑥">FileSystemWritableFileStream</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="FileSystemWritableFileStream" data-dfn-type="dfn" data-noexport id="filesystemwritablefilestream-file">[[file]]</dfn> (a <a data-link-type="dfn" href="#file" id="ref-for-file⑦">file entry</a>).</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream⑦">FileSystemWritableFileStream</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="FileSystemWritableFileStream" data-dfn-type="dfn" data-noexport id="filesystemwritablefilestream-buffer">[[buffer]]</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence②">byte sequence</a>).
+It is initially empty.</p>
+   <p class="note" role="note"><span>Note:</span> This buffer can get arbitrarily large, so it is expected that implementations will not keep this in memory,
+but instead use a temporary file for this. All access to [[buffer]] is done in promise returning methods and
+algorithms, so even though operations on it seem sync, implementations can implement them async.</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream⑧">FileSystemWritableFileStream</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="FileSystemWritableFileStream" data-dfn-type="dfn" data-noexport id="filesystemwritablefilestream-seekoffset">[[seekOffset]]</dfn> (a number).
+It is initially 0.</p>
+   <div class="note domintro" role="note">
+     A <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream⑨">FileSystemWritableFileStream</a></code> object is a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#writablestream" id="ref-for-writablestream①">WritableStream</a></code> object with additional
+convenience methods, which operates on a single file on disk. 
+    <p>Upon creation, an underlying sink will have been created and the stream will be usable.
+All operations executed on the stream are queuable and producers will be able to respond to backpressure.</p>
+    <p>The underlying sink’s write method, and therefore <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#default-writer-write" id="ref-for-default-writer-write">WritableStreamDefaultWriter’s write()</a></code> method, will accept byte-like data or <code class="idl"><a data-link-type="idl" href="#dictdef-writeparams" id="ref-for-dictdef-writeparams①">WriteParams</a></code> as input.</p>
+    <p>The <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream①⓪">FileSystemWritableFileStream</a></code> has a file position cursor initialized at byte offset 0 from the top of the file.
+When using <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritablefilestream-write" id="ref-for-dom-filesystemwritablefilestream-write①">write()</a></code> or by using WritableStream capabilities through the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#default-writer-write" id="ref-for-default-writer-write①">WritableStreamDefaultWriter’s write()</a></code> method, this position will be advanced based on the number of bytes written through the stream object.</p>
+    <p>Similarly, when piping a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream">ReadableStream</a></code> into a <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream①①">FileSystemWritableFileStream</a></code> object, this position is updated with the number of bytes that passed through the stream.</p>
+    <p><code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-get-writer" id="ref-for-ws-get-writer">getWriter()</a></code> returns an instance of <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter" id="ref-for-writablestreamdefaultwriter">WritableStreamDefaultWriter</a></code>.</p>
+   </div>
+   <div class="algorithm" data-algorithm="create a new FileSystemWritableFileStream">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="create-a-new-filesystemwritablefilestream">create a new FileSystemWritableFileStream</dfn> given a <a data-link-type="dfn" href="#file" id="ref-for-file⑧">file entry</a> <var>file</var> in a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#realm" id="ref-for-realm">Realm</a> <var>realm</var>, perform the following steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>stream</var> be a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new">new</a> <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream①②">FileSystemWritableFileStream</a></code> in <var>realm</var>.</p>
+     <li data-md>
+      <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-file" id="ref-for-filesystemwritablefilestream-file">[[file]]</a> to <var>file</var>.</p>
+     <li data-md>
+      <p>Let <var>writeAlgorithm</var> be an algorithm which takes a <var>chunk</var> argument
+ and returns the result of running the <a data-link-type="dfn" href="#write-a-chunk" id="ref-for-write-a-chunk">write a chunk</a> algorithm with <var>stream</var> and <var>chunk</var>.</p>
+     <li data-md>
+      <p>Let <var>closeAlgorithm</var> be the following steps:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>closeResult</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①②">a new promise</a>.</p>
+       <li data-md>
+        <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①①">in parallel</a>:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>permissionStatus</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state⑦">permission state</a> for a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor⑤">FileSystemPermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑧">handle</a></code> representing <var>stream</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file">[[file]]</a>,
+ and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode⑥">mode</a></code> = <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite①⓪">"readwrite"</a></code>.</p>
+         <li data-md>
+          <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①⓪">"granted"</a></code>,
+ reject <var>closeResult</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑧">NotAllowedError</a></code> and abort.</p>
+         <li data-md>
+          <p>Perform user agent-specific <a data-link-type="dfn" href="#wellknowndirectory-malware-scans-and-safe-browsing-checks" id="ref-for-wellknowndirectory-malware-scans-and-safe-browsing-checks">malware scans and safe browsing checks</a>.
+ If these checks fail, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②②">reject</a> <var>closeResult</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror">AbortError</a></code> and abort.</p>
+         <li data-md>
+          <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file①">[[file]]</a>'s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data④">binary data</a> to <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①">[[buffer]]</a>.
+ If that throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②③">reject</a> <var>closeResult</var> with that exception and abort.</p>
+          <p class="note" role="note"><span>Note:</span> It is expected that this atomically updates the contents of the file on disk
+ being written to.</p>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⓪">Resolve</a> <var>closeResult</var> with <code>undefined</code>.</p>
+        </ol>
+       <li data-md>
+        <p>Return <var>closeResult</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Let <var>highWaterMark</var> be 1.</p>
+     <li data-md>
+      <p>Let <var>sizeAlgorithm</var> be an algorithm that returns <code>1</code>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up" id="ref-for-writablestream-set-up">Set up</a> <var>stream</var> with <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up-writealgorithm" id="ref-for-writablestream-set-up-writealgorithm"><var>writeAlgorithm</var></a> set to <var>writeAlgorithm</var>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up-closealgorithm" id="ref-for-writablestream-set-up-closealgorithm"><var>closeAlgorithm</var></a> set to <var>closeAlgorithm</var>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up-highwatermark" id="ref-for-writablestream-set-up-highwatermark"><var>highWaterMark</var></a> set to <var>highWaterMark</var>, and <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-set-up-sizealgorithm" id="ref-for-writablestream-set-up-sizealgorithm"><var>sizeAlgorithm</var></a> set to <var>sizeAlgorithm</var>.</p>
+     <li data-md>
+      <p>Return <var>stream</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="write a chunk">
+     The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="write-a-chunk">write a chunk</dfn> algorithm,
+given a <code class="idl"><a data-link-type="idl" href="#filesystemwritablefilestream" id="ref-for-filesystemwritablefilestream①③">FileSystemWritableFileStream</a></code> <var>stream</var> and <var>chunk</var>,
+runs these steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>input</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#javascript-string-convert" id="ref-for-javascript-string-convert">converting</a> <var>chunk</var> to a <code class="idl"><a data-link-type="idl" href="#typedefdef-filesystemwritechunktype" id="ref-for-typedefdef-filesystemwritechunktype①">FileSystemWriteChunkType</a></code>.
+ If this throws an exception, then return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with">a promise rejected with</a> that exception.</p>
+     <li data-md>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①③">a new promise</a>.</p>
+     <li data-md>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①②">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>permissionStatus</var> be the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state⑧">permission state</a> for a <code class="idl"><a data-link-type="idl" href="#dictdef-filesystempermissiondescriptor" id="ref-for-dictdef-filesystempermissiondescriptor⑥">FileSystemPermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle⑨">handle</a></code> representing <var>stream</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file②">[[file]]</a>,
+  and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode⑦">mode</a></code> = <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite①①">"readwrite"</a></code>.</p>
+       <li data-md>
+        <p>If <var>permissionStatus</var> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①①">"granted"</a></code>,
+  reject <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror⑨">NotAllowedError</a></code> and abort.</p>
+       <li data-md>
+        <p>Let <var>command</var> be <var>input</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-type" id="ref-for-dom-writeparams-type">type</a></code> if <var>input</var> is a <code class="idl"><a data-link-type="idl" href="#dictdef-writeparams" id="ref-for-dictdef-writeparams②">WriteParams</a></code>,
+  and <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-write" id="ref-for-dom-writecommandtype-write">"write"</a></code> otherwise.</p>
+       <li data-md>
+        <p>If <var>command</var> is <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-write" id="ref-for-dom-writecommandtype-write①">"write"</a></code>:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>data</var> be <var>input</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-data" id="ref-for-dom-writeparams-data">data</a></code> if <var>input</var> is a <code class="idl"><a data-link-type="idl" href="#dictdef-writeparams" id="ref-for-dictdef-writeparams③">WriteParams</a></code>,
+ and <var>input</var> otherwise.</p>
+         <li data-md>
+          <p>If <var>data</var> is <code>undefined</code>,
+ reject <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror③">TypeError</a></code> and abort.</p>
+         <li data-md>
+          <p>Let <var>writePosition</var> be <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-seekoffset" id="ref-for-filesystemwritablefilestream-seekoffset">[[seekOffset]]</a>.</p>
+         <li data-md>
+          <p>If <var>input</var> is a <code class="idl"><a data-link-type="idl" href="#dictdef-writeparams" id="ref-for-dictdef-writeparams④">WriteParams</a></code> and <var>input</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-position" id="ref-for-dom-writeparams-position">position</a></code> is not <code>undefined</code>,
+ set <var>writePosition</var> to <var>input</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-position" id="ref-for-dom-writeparams-position①">position</a></code>.</p>
+         <li data-md>
+          <p>Let <var>oldSize</var> be <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer②">[[buffer]]</a>'s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length">length</a>.</p>
+         <li data-md>
+          <p>If <var>data</var> is a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#BufferSource" id="ref-for-BufferSource②">BufferSource</a></code>,
+ let <var>dataBytes</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy" id="ref-for-dfn-get-buffer-source-copy">a copy of</a> <var>data</var>.</p>
+         <li data-md>
+          <p>Else if <var>data</var> is a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob" id="ref-for-dfn-Blob②">Blob</a></code>:</p>
+          <ol>
+           <li data-md>
+            <p>Let <var>dataBytes</var> be the result of performing the <a data-link-type="dfn" href="https://w3c.github.io/FileAPI/#readOperation" id="ref-for-readOperation">read operation</a> on <var>data</var>.
+  If this throws an exception, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②④">reject</a> <var>p</var> with that exception and abort.</p>
+          </ol>
+         <li data-md>
+          <p>Else:</p>
+          <ol>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">Assert</a>: <var>data</var> is a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString⑧">USVString</a></code>.</p>
+           <li data-md>
+            <p>Let <var>dataBytes</var> be the result of <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-encode" id="ref-for-utf-8-encode">UTF-8 encoding</a> <var>data</var>.</p>
+          </ol>
+         <li data-md>
+          <p>If <var>writePosition</var> is larger than <var>oldSize</var>,
+ append <var>writePosition</var> - <var>oldSize</var> <code>0x00</code> (NUL) bytes to the end of <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer③">[[buffer]]</a>.</p>
+          <p class="note" role="note"><span>Note:</span> Implementations are expected to behave as if the skipped over file contents
+ are indeed filled with NUL bytes. That doesn’t mean these bytes have to actually be
+ written to disk and take up disk space. Instead most file systems support so called
+ sparse files, where these NUL bytes don’t take up actual disk space.</p>
+         <li data-md>
+          <p>Let <var>head</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence③">byte sequence</a> containing the first <var>writePosition</var> bytes of <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer④">[[buffer]]</a>.</p>
+         <li data-md>
+          <p>Let <var>tail</var> be an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence④">byte sequence</a>.</p>
+         <li data-md>
+          <p>If <var>writePosition</var> + <var>data</var>.<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length①">length</a> is smaller than <var>oldSize</var>:</p>
+          <ol>
+           <li data-md>
+            <p>Let <var>tail</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑤">byte sequence</a> containing the last <var>oldSize</var> - (<var>writePosition</var> + <var>data</var>.<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length②">length</a>) bytes of <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer⑤">[[buffer]]</a>.</p>
+          </ol>
+         <li data-md>
+          <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer⑥">[[buffer]]</a> to the concatenation of <var>head</var>, <var>data</var> and <var>tail</var>.</p>
+         <li data-md>
+          <p>If the operations modifying <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer⑦">[[buffer]]</a> in the previous steps failed
+ due to exceeding the <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota">storage quota</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑤">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror">QuotaExceededError</a></code> and abort,
+ leaving <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer⑧">[[buffer]]</a> unmodified.</p>
+          <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota①">Storage quota</a> only applies to files stored in the <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system③">origin private file system</a>.
+ However this operation could still fail for other files, for example if the disk being written
+ to runs out of disk space.</p>
+         <li data-md>
+          <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-seekoffset" id="ref-for-filesystemwritablefilestream-seekoffset①">[[seekOffset]]</a> to <var>writePosition</var> + <var>data</var>.<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length③">length</a>.</p>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②①">Resolve</a> <var>p</var>.</p>
+        </ol>
+       <li data-md>
+        <p>Else if <var>command</var> is <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-seek" id="ref-for-dom-writecommandtype-seek">"seek"</a></code>:</p>
+        <ol>
+         <li data-md>
+          <p>If <var>chunk</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-position" id="ref-for-dom-writeparams-position②">position</a></code> is <code>undefined</code>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑥">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror④">TypeError</a></code> and abort.</p>
+         <li data-md>
+          <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-seekoffset" id="ref-for-filesystemwritablefilestream-seekoffset②">[[seekOffset]]</a> to <var>chunk</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-position" id="ref-for-dom-writeparams-position③">position</a></code>.</p>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②②">Resolve</a> <var>p</var>.</p>
+        </ol>
+       <li data-md>
+        <p>Else if <var>command</var> is <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-truncate" id="ref-for-dom-writecommandtype-truncate">"truncate"</a></code>:</p>
+        <ol>
+         <li data-md>
+          <p>If <var>chunk</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-size" id="ref-for-dom-writeparams-size">size</a></code> is <code>undefined</code>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑦">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror⑤">TypeError</a></code> and abort.</p>
+         <li data-md>
+          <p>Let <var>newSize</var> be <var>chunk</var>.<code class="idl"><a data-link-type="idl" href="#dom-writeparams-size" id="ref-for-dom-writeparams-size①">size</a></code>.</p>
+         <li data-md>
+          <p>Let <var>oldSize</var> be <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer⑨">[[buffer]]</a>'s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence-length" id="ref-for-byte-sequence-length④">length</a>.</p>
+         <li data-md>
+          <p>If <var>newSize</var> is larger than <var>oldSize</var>:</p>
+          <ol>
+           <li data-md>
+            <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①⓪">[[buffer]]</a> to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑥">byte sequence</a> formed by concating <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①①">[[buffer]]</a> with a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑦">byte sequence</a> containing <var>newSize</var>-<var>oldSize</var> <code>0x00</code> bytes.</p>
+           <li data-md>
+            <p>If the operation in the previous step failed due to exceeding the <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota②">storage quota</a>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑧">reject</a> <var>p</var> with a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#quotaexceedederror" id="ref-for-quotaexceedederror①">QuotaExceededError</a></code> and abort,
+  leaving <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①②">[[buffer]]</a> unmodified.</p>
+            <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota③">Storage quota</a> only applies to files stored in the <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system④">origin private file system</a>.
+  However this operation could still fail for other files, for example if the disk being written
+  to runs out of disk space.</p>
+          </ol>
+         <li data-md>
+          <p>Else if <var>newSize</var> is smaller than <var>oldSize</var>:</p>
+          <ol>
+           <li data-md>
+            <p>Set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①③">[[buffer]]</a> to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑧">byte sequence</a> containing the first <var>newSize</var> bytes
+  in <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-buffer" id="ref-for-filesystemwritablefilestream-buffer①④">[[buffer]]</a>.</p>
+          </ol>
+         <li data-md>
+          <p>If <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-seekoffset" id="ref-for-filesystemwritablefilestream-seekoffset③">[[seekOffset]]</a> is bigger than <var>newSize</var>,
+ set <var>stream</var>.<a data-link-type="dfn" href="#filesystemwritablefilestream-seekoffset" id="ref-for-filesystemwritablefilestream-seekoffset④">[[seekOffset]]</a> to <var>newSize</var>.</p>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②③">Resolve</a> <var>p</var>.</p>
+        </ol>
+      </ol>
+     <li data-md>
+      <p>Return <var>p</var>.</p>
+    </ol>
+   </div>
+   <h4 class="heading settled" data-level="2.6.1" id="api-filesystemwritablefilestream-write"><span class="secno">2.6.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritablefilestream-write" id="ref-for-dom-filesystemwritablefilestream-write②">write()</a></code> method</span><a class="self-link" href="#api-filesystemwritablefilestream-write"></a></h4>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md>await <var>stream</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritablefilestream-write" id="ref-for-dom-filesystemwritablefilestream-write③">write</a></code>(<var>data</var>)
+     <dt data-md>await <var>stream</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritablefilestream-write" id="ref-for-dom-filesystemwritablefilestream-write④">write</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-writeparams-type" id="ref-for-dom-writeparams-type①">type</a></code>: <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-write" id="ref-for-dom-writecommandtype-write②">"write"</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-writeparams-data" id="ref-for-dom-writeparams-data①">data</a></code>: <var>data</var> })
+     <dd data-md>
+      <p>Writes the content of <var>data</var> into the file associated with <var>stream</var> at the current file
+ cursor offset.</p>
+      <p>No changes are written to the actual file on disk until the stream has been closed.
+ Changes are typically written to a temporary file instead.</p>
+     <dt data-md>await <var>stream</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritablefilestream-write" id="ref-for-dom-filesystemwritablefilestream-write⑤">write</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-writeparams-type" id="ref-for-dom-writeparams-type②">type</a></code>: <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-write" id="ref-for-dom-writecommandtype-write③">"write"</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-writeparams-position" id="ref-for-dom-writeparams-position④">position</a></code>: <var>position</var>, <code class="idl"><a data-link-type="idl" href="#dom-writeparams-data" id="ref-for-dom-writeparams-data②">data</a></code>: <var>data</var> })
+     <dd data-md>
+      <p>Writes the content of <var>data</var> into the file associated with <var>stream</var> at <var>position</var> bytes from the top of the file. Also updates the current file cursor offset to the
+ end of the written data.</p>
+      <p>No changes are written to the actual file on disk until the stream has been closed.
+ Changes are typically written to a temporary file instead.</p>
+     <dt data-md>await <var>stream</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritablefilestream-write" id="ref-for-dom-filesystemwritablefilestream-write⑥">write</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-writeparams-type" id="ref-for-dom-writeparams-type③">type</a></code>: <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-seek" id="ref-for-dom-writecommandtype-seek①">"seek"</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-writeparams-position" id="ref-for-dom-writeparams-position⑤">position</a></code>: <var>position</var> })
+     <dd data-md>
+      <p>Updates the current file cursor offset the <var>position</var> bytes from the top of the file.</p>
+     <dt data-md>await <var>stream</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritablefilestream-write" id="ref-for-dom-filesystemwritablefilestream-write⑦">write</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-writeparams-type" id="ref-for-dom-writeparams-type④">type</a></code>: <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-truncate" id="ref-for-dom-writecommandtype-truncate①">"truncate"</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-writeparams-size" id="ref-for-dom-writeparams-size②">size</a></code>: <var>size</var> })
+     <dd data-md>
+      <p>Resizes the file associated with <var>stream</var> to be <var>size</var> bytes long. If <var>size</var> is larger than
+ the current file size this pads the file with null bytes, otherwise it truncates the file.</p>
+      <p>The file cursor is updated when <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-truncate" id="ref-for-dom-writecommandtype-truncate②">truncate</a></code> is called. If the offset is smaller than offset,
+ it remains unchanged. If the offset is larger than <var>size</var>, the offset is set to <var>size</var> to
+ ensure that subsequent writes do not error.</p>
+      <p>No changes are written to the actual file until on disk until the stream has been closed.
+ Changes are typically written to a temporary file instead.</p>
+    </dl>
+   </div>
+   <div class="mdn-anno wrapped">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/write" title="The write() method of the FileSystemWritableFileStream interface writes content into the file the method is called on, at the current file cursor offset.">FileSystemWritableFileStream/write</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera no"><span>Opera</span><span>None</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>None</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>None</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+   <div class="algorithm" data-algorithm="write(data)" data-algorithm-for="FileSystemWritableFileStream">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemWritableFileStream" data-dfn-type="method" data-export id="dom-filesystemwritablefilestream-write"><code>write(<var>data</var>)</code></dfn> method, when invoked, must run
+these steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>writer</var> be the result of <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-get-a-writer" id="ref-for-writablestream-get-a-writer">getting a writer</a> for <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②①">this</a>.</p>
+     <li data-md>
+      <p>Let <var>result</var> be the result of <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-write-a-chunk" id="ref-for-writablestreamdefaultwriter-write-a-chunk">writing a chunk</a> to <var>writer</var> given <var>data</var>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-release" id="ref-for-writablestreamdefaultwriter-release">Release</a> <var>writer</var>.</p>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <h4 class="heading settled" data-level="2.6.2" id="api-filesystemwritablefilestream-seek"><span class="secno">2.6.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritablefilestream-seek" id="ref-for-dom-filesystemwritablefilestream-seek①">seek()</a></code> method</span><a class="self-link" href="#api-filesystemwritablefilestream-seek"></a></h4>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md>await <var>stream</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritablefilestream-seek" id="ref-for-dom-filesystemwritablefilestream-seek②">seek</a></code>(<var>position</var>)
+     <dd data-md>
+      <p>Updates the current file cursor offset the <var>position</var> bytes from the top of the file.</p>
+    </dl>
+   </div>
+   <div class="mdn-anno wrapped">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/seek" title="The seek() method of the FileSystemWritableFileStream interface updates the current file cursor offset to the position (in bytes) specified when calling the method.">FileSystemWritableFileStream/seek</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera no"><span>Opera</span><span>None</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>None</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>None</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+   <div class="algorithm" data-algorithm="seek(position)" data-algorithm-for="FileSystemWritableFileStream">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemWritableFileStream" data-dfn-type="method" data-export id="dom-filesystemwritablefilestream-seek"><code>seek(<var>position</var>)</code></dfn> method, when invoked, must run these
+steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>writer</var> be the result of <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-get-a-writer" id="ref-for-writablestream-get-a-writer①">getting a writer</a> for <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②②">this</a>.</p>
+     <li data-md>
+      <p>Let <var>result</var> be the result of <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-write-a-chunk" id="ref-for-writablestreamdefaultwriter-write-a-chunk①">writing a chunk</a> to <var>writer</var> given
+  «[ "<code class="idl"><a data-link-type="idl" href="#dom-writeparams-type" id="ref-for-dom-writeparams-type⑤">type</a></code>" → <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-seek" id="ref-for-dom-writecommandtype-seek②">"seek"</a></code>, "<code class="idl"><a data-link-type="idl" href="#dom-writeparams-position" id="ref-for-dom-writeparams-position⑥">position</a></code>" → <var>position</var> ]».</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-release" id="ref-for-writablestreamdefaultwriter-release①">Release</a> <var>writer</var>.</p>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <h4 class="heading settled" data-level="2.6.3" id="api-filesystemwritablefilestream-truncate"><span class="secno">2.6.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritablefilestream-truncate" id="ref-for-dom-filesystemwritablefilestream-truncate①">truncate()</a></code> method</span><a class="self-link" href="#api-filesystemwritablefilestream-truncate"></a></h4>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md>await <var>stream</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritablefilestream-truncate" id="ref-for-dom-filesystemwritablefilestream-truncate②">truncate</a></code>(<var>size</var>)
+     <dd data-md>
+      <p>Resizes the file associated with <var>stream</var> to be <var>size</var> bytes long. If <var>size</var> is larger than
+ the current file size this pads the file with null bytes, otherwise it truncates the file.</p>
+      <p>The file cursor is updated when <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-truncate" id="ref-for-dom-writecommandtype-truncate③">truncate</a></code> is called. If the offset is smaller than offset,
+ it remains unchanged. If the offset is larger than <var>size</var>, the offset is set to <var>size</var> to
+ ensure that subsequent writes do not error.</p>
+      <p>No changes are written to the actual file until on disk until the stream has been closed.
+ Changes are typically written to a temporary file instead.</p>
+    </dl>
+   </div>
+   <div class="mdn-anno wrapped">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/truncate" title="The truncate() method of the FileSystemWritableFileStream interface resizes the file associated with the stream to be the specified size in bytes.">FileSystemWritableFileStream/truncate</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+      <hr>
+      <span class="opera no"><span>Opera</span><span>None</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>None</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>None</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+     </div>
+    </div>
+   </div>
+   <div class="algorithm" data-algorithm="truncate(size)" data-algorithm-for="FileSystemWritableFileStream">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemWritableFileStream" data-dfn-type="method" data-export id="dom-filesystemwritablefilestream-truncate"><code>truncate(<var>size</var>)</code></dfn> method, when invoked, must run these
+steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>writer</var> be the result of <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestream-get-a-writer" id="ref-for-writablestream-get-a-writer②">getting a writer</a> for <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②③">this</a>.</p>
+     <li data-md>
+      <p>Let <var>result</var> be the result of <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-write-a-chunk" id="ref-for-writablestreamdefaultwriter-write-a-chunk②">writing a chunk</a> to <var>writer</var> given
+  «[ "<code class="idl"><a data-link-type="idl" href="#dom-writeparams-type" id="ref-for-dom-writeparams-type⑥">type</a></code>" → <code class="idl"><a data-link-type="idl" href="#dom-writecommandtype-truncate" id="ref-for-dom-writecommandtype-truncate④">"truncate"</a></code>, "<code class="idl"><a data-link-type="idl" href="#dom-writeparams-size" id="ref-for-dom-writeparams-size③">size</a></code>" → <var>size</var> ]».</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-release" id="ref-for-writablestreamdefaultwriter-release②">Release</a> <var>writer</var>.</p>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="2.7" id="api-filesystemsyncaccesshandle"><span class="secno">2.7. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑦">FileSystemSyncAccessHandle</a></code> interface</span><a class="self-link" href="#api-filesystemsyncaccesshandle"></a></h3>
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filesystemreadwriteoptions"><code><c- g>FilesystemReadWriteOptions</c-></code></dfn> {
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange" id="ref-for-EnforceRange"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long④"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FilesystemReadWriteOptions" data-dfn-type="dict-member" data-export data-type="unsigned long long " id="dom-filesystemreadwriteoptions-at"><code><c- g>at</c-></code></dfn>;
+}
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed⑤"><c- g>Exposed</c-></a>=<c- n>DedicatedWorker</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext" id="ref-for-SecureContext④"><c- g>SecureContext</c-></a>]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="filesystemsyncaccesshandle"><code><c- g>FileSystemSyncAccessHandle</c-></code></dfn> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑤"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export data-lt="read(buffer, options)" id="dom-filesystemsyncaccesshandle-read"><code><c- g>read</c-></code></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#AllowShared" id="ref-for-AllowShared"><c- g>AllowShared</c-></a>] <a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#BufferSource" id="ref-for-BufferSource③"><c- n>BufferSource</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/read(buffer, options)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-read-buffer-options-buffer"><code><c- g>buffer</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-read-buffer-options-buffer"></a></dfn>,
+                             <a data-link-type="idl-name" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions"><c- n>FilesystemReadWriteOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/read(buffer, options)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-read-buffer-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-read-buffer-options-options"></a></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑥"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export data-lt="write(buffer, options)" id="dom-filesystemsyncaccesshandle-write"><code><c- g>write</c-></code></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#AllowShared" id="ref-for-AllowShared①"><c- g>AllowShared</c-></a>] <a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#BufferSource" id="ref-for-BufferSource④"><c- n>BufferSource</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/write(buffer, options)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-write-buffer-options-buffer"><code><c- g>buffer</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-write-buffer-options-buffer"></a></dfn>,
+                              <a data-link-type="idl-name" href="#dictdef-filesystemreadwriteoptions" id="ref-for-dictdef-filesystemreadwriteoptions①"><c- n>FilesystemReadWriteOptions</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/write(buffer, options)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-write-buffer-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-write-buffer-options-options"></a></dfn>);
+
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①③"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined④"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-truncate" id="ref-for-dom-filesystemsyncaccesshandle-truncate"><c- g>truncate</c-></a>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange" id="ref-for-EnforceRange①"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑦"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle/truncate(size)" data-dfn-type="argument" data-export id="dom-filesystemsyncaccesshandle-truncate-size-size"><code><c- g>size</c-></code><a class="self-link" href="#dom-filesystemsyncaccesshandle-truncate-size-size"></a></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①④"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑧"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-getsize" id="ref-for-dom-filesystemsyncaccesshandle-getsize"><c- g>getSize</c-></a>();
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①⑤"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined⑤"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-flush" id="ref-for-dom-filesystemsyncaccesshandle-flush"><c- g>flush</c-></a>();
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①⑥"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined⑥"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-close" id="ref-for-dom-filesystemsyncaccesshandle-close"><c- g>close</c-></a>();
+};
+
+</pre>
+   <p>A <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑧">FileSystemSyncAccessHandle</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="dfn" data-noexport id="filesystemsyncaccesshandle-file">[[file]]</dfn> (a <a data-link-type="dfn" href="#file" id="ref-for-file⑨">file entry</a>).</p>
+   <div class="note domintro" role="note">
+    <p>A <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle⑨">FileSystemSyncAccessHandle</a></code> is an object that is capable of reading/writing from/to,
+as well as obtaining and changing the size of, a single file.</p>
+    <p>The <code class="idl"><a data-link-type="idl">read()</a></code> and <code class="idl"><a data-link-type="idl">write()</a></code> methods are synchronous.
+This allows for higher performance for critical methods on contexts where asynchronous
+operations come with high overhead i.e., WebAssembly.</p>
+   </div>
+   <div class="algorithm" data-algorithm="create a new FileSystemSyncAccessHandle">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="create-a-new-filesystemsyncaccesshandle">create a new FileSystemSyncAccessHandle</dfn> given a <a data-link-type="dfn" href="#file" id="ref-for-file①⓪">file entry</a> <var>file</var> in a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#realm" id="ref-for-realm①">Realm</a> <var>realm</var>, perform the following steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>handle</var> be a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new①">new</a> <code class="idl"><a data-link-type="idl" href="#filesystemsyncaccesshandle" id="ref-for-filesystemsyncaccesshandle①⓪">FileSystemSyncAccessHandle</a></code> in <var>realm</var>.</p>
+     <li data-md>
+      <p>Set <var>handle</var>.<a data-link-type="dfn" href="#filesystemsyncaccesshandle-file" id="ref-for-filesystemsyncaccesshandle-file③">[[file]]</a> to <var>file</var>.</p>
+     <li data-md>
+      <p>Return <var>handle</var>.</p>
+    </ol>
+   </div>
+   <h4 class="heading settled" data-level="2.7.1" id="api-filesystemsyncaccesshandle-read"><span class="secno">2.7.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read">read()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-read"></a></h4>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read①">read</a></code>(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at">at</a></code>: <var>position</var>)
+     <dd data-md>
+      <p>Reads the contents of the file associated with <var>handle</var> into <var>buffer</var>, with <var>position</var> as the offset.</p>
+    </dl>
+   </div>
+   <div class="algorithm" data-algorithm="read(buffer, at: position)" data-algorithm-for="FileSystemSyncAccessHandle">
+     The <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-read-buffer-at-position"><code>read(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at①">at</a></code>: <var>position</var>)</code><a class="self-link" href="#dom-filesystemsyncaccesshandle-read-buffer-at-position"></a></dfn> method, when invoked, must run
+these steps: 
+    <p>// TODO(fivedots): fill in. Does this algorithm need to check that the access handle has not been closed?</p>
+   </div>
+   <h4 class="heading settled" data-level="2.7.2" id="api-filesystemsyncaccesshandle-write"><span class="secno">2.7.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write">write()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-write"></a></h4>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write①">write</a></code>(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at②">at</a></code>: <var>position</var>)
+     <dd data-md>
+      <p>Writes the content of <var>buffer</var> into the file associated with <var>handle</var> with <var>position</var> as the offset.</p>
+    </dl>
+   </div>
+   <div class="algorithm" data-algorithm="write(buffer, at: position)" data-algorithm-for="FileSystemSyncAccessHandle">
+     The <dfn class="idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-write-buffer-at-position"><code>write(<var>buffer</var>, <code class="idl"><a data-link-type="idl" href="#dom-filesystemreadwriteoptions-at" id="ref-for-dom-filesystemreadwriteoptions-at③">at</a></code>: <var>position</var>)</code><a class="self-link" href="#dom-filesystemsyncaccesshandle-write-buffer-at-position"></a></dfn> method, when invoked, must run
+these steps: 
+    <p>// TODO(fivedots): fill in. Does this algorithm need to explicitly interact with storage quota?</p>
+   </div>
+   <h4 class="heading settled" data-level="2.7.3" id="api-filesystemsyncaccesshandle-truncate"><span class="secno">2.7.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-truncate" id="ref-for-dom-filesystemsyncaccesshandle-truncate①">truncate()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-truncate"></a></h4>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-truncate" id="ref-for-dom-filesystemsyncaccesshandle-truncate②">truncate</a></code>(<var>size</var>)
+     <dd data-md>
+      <p>Resizes the file associated with stream to be size bytes long. If size is larger than the current file size this pads the file with null bytes, otherwise it truncates the file.</p>
+    </dl>
+   </div>
+   <div class="algorithm" data-algorithm="truncate(size)" data-algorithm-for="FileSystemSyncAccessHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-truncate"><code>truncate(<var>size</var>)</code></dfn> method, when invoked, must run
+these steps: 
+    <p>// TODO(fivedots): fill in.</p>
+   </div>
+   <h4 class="heading settled" data-level="2.7.4" id="api-filesystemsyncaccesshandle-getsize"><span class="secno">2.7.4. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-getsize" id="ref-for-dom-filesystemsyncaccesshandle-getsize①">getSize()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-getsize"></a></h4>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-getsize" id="ref-for-dom-filesystemsyncaccesshandle-getsize②">getSize()</a></code>
+     <dd data-md>
+      <p>Returns the size of the file associated with <var>handle</var> in bytes.</p>
+    </dl>
+   </div>
+   <div class="algorithm" data-algorithm="getSize()" data-algorithm-for="FileSystemSyncAccessHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-getsize"><code>getSize()</code></dfn> method, when invoked, must run
+these steps: 
+    <p>// TODO(fivedots): fill in.</p>
+   </div>
+   <h4 class="heading settled" data-level="2.7.5" id="api-filesystemsyncaccesshandle-flush"><span class="secno">2.7.5. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-flush" id="ref-for-dom-filesystemsyncaccesshandle-flush①">flush()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-flush"></a></h4>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-flush" id="ref-for-dom-filesystemsyncaccesshandle-flush②">flush()</a></code>
+     <dd data-md>
+      <p>Ensures that the contents of the file associated with <var>handle</var> contain all the modifications done through <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-read" id="ref-for-dom-filesystemsyncaccesshandle-read②">read()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-write" id="ref-for-dom-filesystemsyncaccesshandle-write②">write()</a></code>.</p>
+    </dl>
+   </div>
+   <div class="algorithm" data-algorithm="flush()" data-algorithm-for="FileSystemSyncAccessHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-flush"><code>flush()</code></dfn> method, when invoked, must run
+these steps: 
+    <p>// TODO(fivedots): fill in.</p>
+   </div>
+   <h4 class="heading settled" data-level="2.7.6" id="api-filesystemsyncaccesshandle-close"><span class="secno">2.7.6. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-close" id="ref-for-dom-filesystemsyncaccesshandle-close①">close()</a></code> method</span><a class="self-link" href="#api-filesystemsyncaccesshandle-close"></a></h4>
+   <div class="note domintro" role="note">
+    <dl>
+     <dt data-md><var>handle</var> . <code class="idl"><a data-link-type="idl" href="#dom-filesystemsyncaccesshandle-close" id="ref-for-dom-filesystemsyncaccesshandle-close②">close()</a></code>
+     <dd data-md>
+      <p>Flushes the access handle and then closes it. Closing an access handle disables any further operations on it and <a data-link-type="dfn" href="#file-entry-lock-release" id="ref-for-file-entry-lock-release">releases the lock</a> on the <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②⑤">entry</a> associated with <var>handle</var>.</p>
+    </dl>
+   </div>
+   <div class="algorithm" data-algorithm="close()" data-algorithm-for="FileSystemSyncAccessHandle">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="FileSystemSyncAccessHandle" data-dfn-type="method" data-export id="dom-filesystemsyncaccesshandle-close"><code>close()</code></dfn> method, when invoked, must run
+these steps: 
+    <p>// TODO(fivedots): fill in.</p>
+   </div>
+   <h2 class="heading settled" data-level="3" id="local-filesystem"><span class="secno">3. </span><span class="content">Accessing Local File System</span><a class="self-link" href="#local-filesystem"></a></h2>
+<pre class="idl highlight def"><c- b>enum</c-> <a class="idl-code" data-link-type="enum" href="#enumdef-wellknowndirectory" id="ref-for-enumdef-wellknowndirectory"><c- g>WellKnownDirectory</c-></a> {
+  <a class="idl-code" data-link-type="enum-value" href="#dom-wellknowndirectory-desktop" id="ref-for-dom-wellknowndirectory-desktop"><c- s>"desktop"</c-></a>,
+  <a class="idl-code" data-link-type="enum-value" href="#dom-wellknowndirectory-documents" id="ref-for-dom-wellknowndirectory-documents"><c- s>"documents"</c-></a>,
+  <a class="idl-code" data-link-type="enum-value" href="#dom-wellknowndirectory-downloads" id="ref-for-dom-wellknowndirectory-downloads"><c- s>"downloads"</c-></a>,
+  <a class="idl-code" data-link-type="enum-value" href="#dom-wellknowndirectory-music" id="ref-for-dom-wellknowndirectory-music"><c- s>"music"</c-></a>,
+  <a class="idl-code" data-link-type="enum-value" href="#dom-wellknowndirectory-pictures" id="ref-for-dom-wellknowndirectory-pictures"><c- s>"pictures"</c-></a>,
+  <a class="idl-code" data-link-type="enum-value" href="#dom-wellknowndirectory-videos" id="ref-for-dom-wellknowndirectory-videos"><c- s>"videos"</c-></a>,
+};
+
+<c- b>typedef</c-> (<a data-link-type="idl-name" href="#enumdef-wellknowndirectory" id="ref-for-enumdef-wellknowndirectory①"><c- n>WellKnownDirectory</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#filesystemhandle" id="ref-for-filesystemhandle①⑤"><c- n>FileSystemHandle</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-startindirectory"><code><c- g>StartInDirectory</c-></code></dfn>;
+
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filepickeraccepttype"><code><c- g>FilePickerAcceptType</c-></code></dfn> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString⑨"><c- b>USVString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FilePickerAcceptType" data-dfn-type="dict-member" data-export data-type="USVString " id="dom-filepickeraccepttype-description"><code><c- g>description</c-></code></dfn>;
+    <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-record" id="ref-for-idl-record"><c- b>record</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString①⓪"><c- b>USVString</c-></a>, (<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString①①"><c- b>USVString</c-></a> <c- b>or</c-> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence" id="ref-for-idl-sequence①"><c- b>sequence</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString①②"><c- b>USVString</c-></a>>)> <dfn class="dfn-paneled idl-code" data-dfn-for="FilePickerAcceptType" data-dfn-type="dict-member" data-export data-type="record<USVString, (USVString or sequence<USVString>)> " id="dom-filepickeraccepttype-accept"><code><c- g>accept</c-></code></dfn>;
+};
+
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-filepickeroptions"><code><c- g>FilePickerOptions</c-></code></dfn> {
+    <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence" id="ref-for-idl-sequence②"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#dictdef-filepickeraccepttype" id="ref-for-dictdef-filepickeraccepttype"><c- n>FilePickerAcceptType</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-for="FilePickerOptions" data-dfn-type="dict-member" data-export data-type="sequence<FilePickerAcceptType> " id="dom-filepickeroptions-types"><code><c- g>types</c-></code></dfn>;
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean⑤"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-default="false" data-dfn-for="FilePickerOptions" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-filepickeroptions-excludeacceptalloption"><code><c- g>excludeAcceptAllOption</c-></code></dfn> = <c- b>false</c->;
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FilePickerOptions" data-dfn-type="dict-member" data-export data-type="DOMString " id="dom-filepickeroptions-id"><code><c- g>id</c-></code></dfn>;
+    <a data-link-type="idl-name" href="#typedefdef-startindirectory" id="ref-for-typedefdef-startindirectory"><c- n>StartInDirectory</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FilePickerOptions" data-dfn-type="dict-member" data-export data-type="StartInDirectory " id="dom-filepickeroptions-startin"><code><c- g>startIn</c-></code></dfn>;
+};
+
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-openfilepickeroptions"><code><c- g>OpenFilePickerOptions</c-></code></dfn> : <a data-link-type="idl-name" href="#dictdef-filepickeroptions" id="ref-for-dictdef-filepickeroptions"><c- n>FilePickerOptions</c-></a> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean⑥"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-default="false" data-dfn-for="OpenFilePickerOptions" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-openfilepickeroptions-multiple"><code><c- g>multiple</c-></code></dfn> = <c- b>false</c->;
+};
+
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-savefilepickeroptions"><code><c- g>SaveFilePickerOptions</c-></code></dfn> : <a data-link-type="idl-name" href="#dictdef-filepickeroptions" id="ref-for-dictdef-filepickeroptions①"><c- n>FilePickerOptions</c-></a> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString①③"><c- b>USVString</c-></a>? <dfn class="dfn-paneled idl-code" data-dfn-for="SaveFilePickerOptions" data-dfn-type="dict-member" data-export data-type="USVString? " id="dom-savefilepickeroptions-suggestedname"><code><c- g>suggestedName</c-></code></dfn>;
+};
+
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-directorypickeroptions"><code><c- g>DirectoryPickerOptions</c-></code></dfn> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="DirectoryPickerOptions" data-dfn-type="dict-member" data-export data-type="DOMString " id="dom-directorypickeroptions-id"><code><c- g>id</c-></code></dfn>;
+    <a data-link-type="idl-name" href="#typedefdef-startindirectory" id="ref-for-typedefdef-startindirectory①"><c- n>StartInDirectory</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="DirectoryPickerOptions" data-dfn-type="dict-member" data-export data-type="StartInDirectory " id="dom-directorypickeroptions-startin"><code><c- g>startIn</c-></code></dfn>;
+};
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext" id="ref-for-SecureContext⑤"><c- g>SecureContext</c-></a>]
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window①"><c- g>Window</c-></a> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①⑦"><c- b>Promise</c-></a>&lt;<a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence" id="ref-for-idl-sequence③"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle⑧"><c- n>FileSystemFileHandle</c-></a>>> <a class="idl-code" data-link-type="method" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker"><c- g>showOpenFilePicker</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-openfilepickeroptions" id="ref-for-dictdef-openfilepickeroptions"><c- n>OpenFilePickerOptions</c-></a> <dfn class="idl-code" data-dfn-for="Window/showOpenFilePicker(options), Window/showOpenFilePicker()" data-dfn-type="argument" data-export id="dom-window-showopenfilepicker-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-window-showopenfilepicker-options-options"></a></dfn> = {});
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①⑧"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle⑨"><c- n>FileSystemFileHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker"><c- g>showSaveFilePicker</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-savefilepickeroptions" id="ref-for-dictdef-savefilepickeroptions"><c- n>SaveFilePickerOptions</c-></a> <dfn class="idl-code" data-dfn-for="Window/showSaveFilePicker(options), Window/showSaveFilePicker()" data-dfn-type="argument" data-export id="dom-window-showsavefilepicker-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-window-showsavefilepicker-options-options"></a></dfn> = {});
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①⑨"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①⓪"><c- n>FileSystemDirectoryHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-window-showdirectorypicker" id="ref-for-dom-window-showdirectorypicker"><c- g>showDirectoryPicker</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-directorypickeroptions" id="ref-for-dictdef-directorypickeroptions"><c- n>DirectoryPickerOptions</c-></a> <dfn class="idl-code" data-dfn-for="Window/showDirectoryPicker(options), Window/showDirectoryPicker()" data-dfn-type="argument" data-export id="dom-window-showdirectorypicker-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-window-showdirectorypicker-options-options"></a></dfn> = {});
+};
+</pre>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker①">showOpenFilePicker()</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker①">showSaveFilePicker()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-window-showdirectorypicker" id="ref-for-dom-window-showdirectorypicker①">showDirectoryPicker()</a></code> methods
+are together known as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="local-file-system-handle-factories">local file system handle factories</dfn>.</p>
+   <p class="note" role="note"><span>Note:</span> What is referred to as the "local file system" in this spec, does not have to
+strictly refer to the file system on the local device. What we call the local file system
+could just as well be backed by a cloud provider. For example on Chrome OS these
+file pickers will also let you pick files and directories on Google Drive.</p>
+   <p><strong class="advisement"> In Chrome versions earlier than 85, this was implemented as a generic <code>chooseFileSystemEntries</code> method.</strong></p>
+   <h3 class="heading settled" data-level="3.1" id="local-file-system-permissions"><span class="secno">3.1. </span><span class="content">Local File System Permissions</span><a class="self-link" href="#local-file-system-permissions"></a></h3>
+   <p>The fact that the user picked the specific files returned by the <a data-link-type="dfn" href="#local-file-system-handle-factories" id="ref-for-local-file-system-handle-factories②">local file system handle factories</a> in a prompt
+should be treated by the user agent as the user intending to grant read access to the website
+for the returned files. As such, at the time the promise returned by one of the <a data-link-type="dfn" href="#local-file-system-handle-factories" id="ref-for-local-file-system-handle-factories③">local file system handle factories</a> resolves, <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state⑨">permission state</a> for a descriptor with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle①⓪">handle</a></code> set to the returned handle,
+and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode⑧">mode</a></code> set to <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read" id="ref-for-dom-filesystempermissionmode-read⑨">"read"</a></code> should be <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①②">"granted"</a></code>.</p>
+   <p>Additionally for calls to <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker②">showSaveFilePicker</a></code> the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-permission-state" id="ref-for-dfn-permission-state①⓪">permission state</a> for a descriptor with <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-handle" id="ref-for-dom-filesystempermissiondescriptor-handle①①">handle</a></code> set to the returned handle,
+and <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissiondescriptor-mode" id="ref-for-dom-filesystempermissiondescriptor-mode⑨">mode</a></code> set to <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite" id="ref-for-dom-filesystempermissionmode-readwrite①②">readwrite</a></code> should be <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①③">"granted"</a></code>.</p>
+   <div class="algorithm" data-algorithm="is allowed to show a file picker">
+     To verify that an <var>environment</var> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="is-allowed-to-show-a-file-picker">is allowed to show a file picker</dfn>, run these steps: 
+    <ol>
+     <li data-md>
+      <p>If <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin③">origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque" id="ref-for-concept-origin-opaque">opaque origin</a>,
+ return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with①">a promise rejected with</a> a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#securityerror" id="ref-for-securityerror③">SecurityError</a></code>.</p>
+     <li data-md>
+      <p>If <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin④">origin</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin②">same origin</a> with <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin" id="ref-for-concept-environment-top-level-origin①">top-level origin</a>,
+ return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with②">a promise rejected with</a> a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#securityerror" id="ref-for-securityerror④">SecurityError</a></code>.</p>
+     <li data-md>
+      <p>Let <var>global</var> be <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global①">global object</a>.</p>
+     <li data-md>
+      <p>If <var>global</var> does not have <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation" id="ref-for-transient-activation①">transient activation</a>, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#securityerror" id="ref-for-securityerror⑤">SecurityError</a></code>.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="3.2" id="api-filepickeroptions"><span class="secno">3.2. </span><span class="content">File picker options</span><a class="self-link" href="#api-filepickeroptions"></a></h3>
+   <h4 class="heading settled" data-level="3.2.1" id="api-filepickeroptions-types"><span class="secno">3.2.1. </span><span class="content">Accepted file types</span><a class="self-link" href="#api-filepickeroptions-types"></a></h4>
+   <div class="note domintro" role="note">
+     The <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker②">showOpenFilePicker(options)</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker③">showSaveFilePicker(options)</a></code> methods accept a <code class="idl"><a data-link-type="idl" href="#dictdef-filepickeroptions" id="ref-for-dictdef-filepickeroptions②">FilePickerOptions</a></code> argument, which lets the website specify the types of files
+the file picker will let the user select. 
+    <p>Each entry in <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-types" id="ref-for-dom-filepickeroptions-types">types</a></code> specifies a single user selectable option
+for filtering the files displayed in the file picker.</p>
+    <p>Each option consists of an <span class="allow-2119">optional</span> <code class="idl"><a data-link-type="idl" href="#dom-filepickeraccepttype-description" id="ref-for-dom-filepickeraccepttype-description">description</a></code> and a number of MIME types and extensions (specified as a mapping of
+MIME type to a list of extensions). If no description is provided one will be generated.
+Extensions have to be strings that start with a "." and only contain <a data-link-type="dfn" href="#valid-suffix-code-point" id="ref-for-valid-suffix-code-point">valid suffix code points</a>.
+Additionally extensions are limited to a length of 16 code points.</p>
+    <p>In addition to complete MIME types, "*" can be used as the subtype of a MIME type to match
+for example all image formats with "image/*".</p>
+    <p>Websites <span class="allow-2119">should</span> always provide both MIME types and file
+extensions for each option. On platforms that only use file extensions to describe file types
+user agents can match on the extensions, while on platforms that don’t use extensions,
+user agents can match on MIME type.</p>
+    <p>By default the file picker will also include an option to not apply any filter,
+letting the user select any file. Set <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-excludeacceptalloption" id="ref-for-dom-filepickeroptions-excludeacceptalloption">excludeAcceptAllOption</a></code> to <code>true</code> to not
+include this option in the file picker.</p>
+    <p>For example , the following options will let the user pick one of three different filters.
+One for text files (either plain text or HTML), one for images, and a third one that doesn’t apply
+any filter and lets the user select any file.</p>
+<pre class="example highlight" id="filepickeroptions-types-example1"><a class="self-link" href="#filepickeroptions-types-example1"></a><c- a>const</c-> options <c- o>=</c-> <c- p>{</c->
+  <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-types" id="ref-for-dom-filepickeroptions-types①">types</a></code><c- o>:</c-> <c- p>[</c->
+    <c- p>{</c->
+      <code class="idl"><a data-link-type="idl" href="#dom-filepickeraccepttype-description" id="ref-for-dom-filepickeraccepttype-description①">description</a></code><c- o>:</c-> <c- t>'Text Files'</c-><c- p>,</c->
+      <code class="idl"><a data-link-type="idl" href="#dom-filepickeraccepttype-accept" id="ref-for-dom-filepickeraccepttype-accept">accept</a></code><c- o>:</c-> <c- p>{</c->
+        <c- t>'text/plain'</c-><c- o>:</c-> <c- p>[</c-><c- t>'.txt'</c-><c- p>,</c-> <c- t>'.text'</c-><c- p>],</c->
+        <c- t>'text/html'</c-><c- o>:</c-> <c- p>[</c-><c- t>'.html'</c-><c- p>,</c-> <c- t>'.htm'</c-><c- p>]</c->
+      <c- p>}</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <code class="idl"><a data-link-type="idl" href="#dom-filepickeraccepttype-description" id="ref-for-dom-filepickeraccepttype-description②">description</a></code><c- o>:</c-> <c- t>'Images'</c-><c- p>,</c->
+      <code class="idl"><a data-link-type="idl" href="#dom-filepickeraccepttype-accept" id="ref-for-dom-filepickeraccepttype-accept①">accept</a></code><c- o>:</c-> <c- p>{</c->
+        <c- t>'image/*'</c-><c- o>:</c-> <c- p>[</c-><c- t>'.png'</c-><c- p>,</c-> <c- t>'.gif'</c-><c- p>,</c-> <c- t>'.jpeg'</c-><c- p>,</c-> <c- t>'.jpg'</c-><c- p>]</c->
+      <c- p>}</c->
+    <c- p>}</c->
+  <c- p>],</c->
+<c- p>};</c->
+</pre>
+    <p>On the other hand, the following example will only let the user select SVG files. The dialog
+will not show an option to not apply any filters.</p>
+<pre class="example highlight" id="filepickeroptions-types-example2"><a class="self-link" href="#filepickeroptions-types-example2"></a><c- a>const</c-> options <c- o>=</c-> <c- p>{</c->
+  <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-types" id="ref-for-dom-filepickeroptions-types②">types</a></code><c- o>:</c-> <c- p>[</c->
+    <c- p>{</c->
+      <code class="idl"><a data-link-type="idl" href="#dom-filepickeraccepttype-accept" id="ref-for-dom-filepickeraccepttype-accept②">accept</a></code><c- o>:</c-> <c- p>{</c->
+        <c- t>'image/svg+xml'</c-><c- o>:</c-> <c- t>'.svg'</c->
+      <c- p>}</c->
+    <c- p>},</c->
+  <c- p>],</c->
+  <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-excludeacceptalloption" id="ref-for-dom-filepickeroptions-excludeacceptalloption①">excludeAcceptAllOption</a></code><c- o>:</c-> <c- kc>true</c->
+<c- p>};</c->
+</pre>
+   </div>
+   <div class="algorithm" data-algorithm="process accept types">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-accept-types">process accept types</dfn>, given <code class="idl"><a data-link-type="idl" href="#dictdef-filepickeroptions" id="ref-for-dictdef-filepickeroptions③">FilePickerOptions</a></code> <var>options</var>,
+run these steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>accepts options</var> be a empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of <a data-link-type="dfn">pairs</a>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate④">For each</a> <var>type</var> of <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-types" id="ref-for-dom-filepickeroptions-types③">types</a></code>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>description</var> be <var>type</var>.<code class="idl"><a data-link-type="idl" href="#dom-filepickeraccepttype-description" id="ref-for-dom-filepickeraccepttype-description③">description</a></code>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate">For each</a> <var>typeString</var> → <var>suffixes</var> of <var>type</var>.<code class="idl"><a data-link-type="idl" href="#dom-filepickeraccepttype-accept" id="ref-for-dom-filepickeraccepttype-accept③">accept</a></code>:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>parsedType</var> be the result of <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type" id="ref-for-parse-a-mime-type">parse a MIME type</a> with <var>typeString</var>.</p>
+         <li data-md>
+          <p>If <var>parsedType</var> is failure, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror⑥">TypeError</a></code>.</p>
+         <li data-md>
+          <p>If <var>parsedType</var>’s <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parameters" id="ref-for-parameters">parameters</a> are not empty, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror⑦">TypeError</a></code>.</p>
+         <li data-md>
+          <p>If <var>suffixes</var> is a string:</p>
+          <ol>
+           <li data-md>
+            <p><a data-link-type="dfn" href="#validate-a-suffix" id="ref-for-validate-a-suffix">Validate a suffix</a> given <var>suffixes</var>.</p>
+          </ol>
+         <li data-md>
+          <p>Otherwise, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate⑤">for each</a> <var>suffix</var> of <var>suffixes</var>:</p>
+          <ol>
+           <li data-md>
+            <p><a data-link-type="dfn" href="#validate-a-suffix" id="ref-for-validate-a-suffix①">Validate a suffix</a> given <var>suffix</var>.</p>
+          </ol>
+        </ol>
+       <li data-md>
+        <p>Let <var>filter</var> be the following steps, given a <var>filename</var> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">string</a>), and a <var>type</var> (a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#mime-type" id="ref-for-mime-type">MIME type</a>):</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate①">For each</a> <var>typeString</var> → <var>suffixes</var> of <var>type</var>.<code class="idl"><a data-link-type="idl" href="#dom-filepickeraccepttype-accept" id="ref-for-dom-filepickeraccepttype-accept④">accept</a></code>:</p>
+         <li data-md>
+          <p>Let <var>parsedType</var> be the result of <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type" id="ref-for-parse-a-mime-type①">parse a MIME type</a> with <var>typeString</var>.</p>
+          <ol>
+           <li data-md>
+            <p>If <var>parsedType</var>’s <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#subtype" id="ref-for-subtype">subtype</a> is "*":</p>
+            <ol>
+             <li data-md>
+              <p>If <var>parsedType</var>’s <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#type" id="ref-for-type">type</a> is "*", return <code>true</code>.</p>
+             <li data-md>
+              <p>If <var>parsedType</var>’s <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#type" id="ref-for-type①">type</a> is <var>type</var>’s <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#type" id="ref-for-type②">type</a>, return <code>true</code>.</p>
+            </ol>
+           <li data-md>
+            <p><var>parsedType</var>’s <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#mime-type-essence" id="ref-for-mime-type-essence">essence</a> is <var>type</var>’s <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#mime-type-essence" id="ref-for-mime-type-essence①">essence</a>, return <code>true</code>.</p>
+           <li data-md>
+            <p>If <var>suffixes</var> is a string, set <var>suffixes</var> to « <var>suffixes</var> ».</p>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate⑥">For each</a> <var>suffix</var> of <var>suffixes</var>:</p>
+            <ol>
+             <li data-md>
+              <p>If <var>filename</var> ends with <var>suffix</var>, return <code>true</code>.</p>
+            </ol>
+          </ol>
+         <li data-md>
+          <p>Return <code>false</code>.</p>
+        </ol>
+       <li data-md>
+        <p>If <var>description</var> is an empty string,
+set <var>description</var> to some user understandable string describing <var>filter</var>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append①">Append</a> <var>description</var>/<var>filter</var> to <var>accepts options</var>.</p>
+      </ol>
+     <li data-md>
+      <p>If either <var>accepts options</var> is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-empty" id="ref-for-list-empty">empty</a>,
+or <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-excludeacceptalloption" id="ref-for-dom-filepickeroptions-excludeacceptalloption②">excludeAcceptAllOption</a></code> is <code>false</code>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>description</var> be a user understandable string describing "all files".</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>filter</var> be an algorithm that returns <code>true</code>.</p>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append②">Append</a> <var>description</var>/<var>filter</var> to <var>accepts options</var>.</p>
+        </ol>
+      </ol>
+     <li data-md>
+      <p>If <var>accepts options</var> is empty, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror⑧">TypeError</a></code>.</p>
+     <li data-md>
+      <p>Return <var>accepts options</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="validate a suffix">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="validate-a-suffix">validate a suffix</dfn> <var>suffix</var>, run the following steps: 
+    <ol>
+     <li data-md>
+      <p>If <var>suffix</var> does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-starts-with" id="ref-for-string-starts-with">start with</a> ".", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror⑨">TypeError</a></code>.</p>
+     <li data-md>
+      <p>If <var>suffix</var> contains any <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-point" id="ref-for-code-point①">code points</a> that are not <a data-link-type="dfn" href="#valid-suffix-code-point" id="ref-for-valid-suffix-code-point①">valid suffix code points</a>,
+ throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①⓪">TypeError</a></code>.</p>
+     <li data-md>
+      <p>If <var>suffix</var> ends with ".", throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①①">TypeError</a></code>.</p>
+     <li data-md>
+      <p>If <var>suffix</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-length" id="ref-for-string-length">length</a> is more than 16, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①②">TypeError</a></code>.</p>
+    </ol>
+   </div>
+   <h4 class="heading settled" data-level="3.2.2" id="api-filepickeroptions-starting-directory"><span class="secno">3.2.2. </span><span class="content">Starting Directory</span><a class="self-link" href="#api-filepickeroptions-starting-directory"></a></h4>
+   <div class="note domintro" role="note">
+     The <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id">id</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-startin" id="ref-for-dom-filepickeroptions-startin">startIn</a></code> fields can be specified to suggest
+the directory in which the file picker opens. 
+    <p>If neither of these options are specified, the user agent remembers the last directory a file
+or directory was picked from, and new pickers will start out in that directory. By specifying an <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id①">id</a></code> the user agent can remember different directories for different IDs
+(user agents will only remember directories for a limited number of IDs).</p>
+<pre class="example highlight" id="filepickeroptions-starting-directory-example1"><a class="self-link" href="#filepickeroptions-starting-directory-example1"></a><c- c1>// If a mapping exists from this ID to a previousy picked directory, start in</c->
+<c- c1>// this directory. Otherwise, a mapping will be created from this ID to the</c->
+<c- c1>// directory of the resulting file picker invocation.</c->
+<c- a>const</c-> options <c- o>=</c-> <c- p>{</c->
+  <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id②">id</a></code><c- o>:</c-> <c- t>'foo'</c-><c- p>,</c->
+<c- p>};</c->
+</pre>
+    <p>Specifying <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-startin" id="ref-for-dom-filepickeroptions-startin①">startIn</a></code> as a <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①⓪">FileSystemFileHandle</a></code> will result in the dialog
+starting in the parent directory of that file, while passing in a <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①①">FileSystemDirectoryHandle</a></code> will result in the dialog to start in the passed in directory. These take precedence even if
+an explicit <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id③">id</a></code> is also passed in.</p>
+    <p>For example, given a <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①②">FileSystemDirectoryHandle</a></code> <var>project_dir</var>, the following will show
+a file picker that starts out in that directory:</p>
+<pre class="example highlight" id="filepickeroptions-starting-directory-example2"><a class="self-link" href="#filepickeroptions-starting-directory-example2"></a><c- c1>// The picker will open to the directory of |project_dir| regardless of whether</c->
+<c- c1>// 'foo' has a valid mapping.</c->
+<c- a>const</c-> options <c- o>=</c-> <c- p>{</c->
+  <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id④">id</a></code><c- o>:</c-> <c- t>'foo'</c-><c- p>,</c->
+  <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-startin" id="ref-for-dom-filepickeroptions-startin②">startIn</a></code><c- o>:</c-> <c- o>|</c->project_dir<c- o>|</c-><c- p>,</c->
+<c- p>};</c->
+</pre>
+    <p>The <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id⑤">id</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-startin" id="ref-for-dom-filepickeroptions-startin③">startIn</a></code> fields control only
+the directory the picker opens to. In the above example, it cannot be assumed that
+the <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id⑥">id</a></code> 'foo' will map to the same directory as <var>project_dir</var> once the file picker operation has completed.</p>
+    <p>Specifying <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-startin" id="ref-for-dom-filepickeroptions-startin④">startIn</a></code> as a <code class="idl"><a data-link-type="idl" href="#enumdef-wellknowndirectory" id="ref-for-enumdef-wellknowndirectory②">WellKnownDirectory</a></code> will result in the dialog
+starting in that directory, unless an explicit <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id⑦">id</a></code> was also passed
+in which has a mapping to a valid directory.</p>
+    <p>Below is an example of specifying both an <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id⑧">id</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-startin" id="ref-for-dom-filepickeroptions-startin⑤">startIn</a></code> as a <code class="idl"><a data-link-type="idl" href="#enumdef-wellknowndirectory" id="ref-for-enumdef-wellknowndirectory③">WellKnownDirectory</a></code>. If there is an existing
+mapping from the given ID to a path, this mapping is used. Otherwise, the path suggested
+via the <code class="idl"><a data-link-type="idl" href="#enumdef-wellknowndirectory" id="ref-for-enumdef-wellknowndirectory④">WellKnownDirectory</a></code> is used.</p>
+<pre class="example highlight" id="filepickeroptions-starting-directory-example3"><a class="self-link" href="#filepickeroptions-starting-directory-example3"></a><c- c1>// First time specifying the ID 'foo'. It is not mapped to a directory.</c->
+<c- c1>// The file picker will fall back to opening to the Downloads directory. TODO: link this.</c->
+<c- a>const</c-> options <c- o>=</c-> <c- p>{</c->
+  <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id⑨">id</a></code><c- o>:</c-> <c- t>'foo'</c-><c- p>,</c->  <c- c1>// Unmapped.</c->
+  <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-startin" id="ref-for-dom-filepickeroptions-startin⑥">startIn</a></code><c- o>:</c-> <code class="idl"><a data-link-type="idl" href="#dom-wellknowndirectory-downloads" id="ref-for-dom-wellknowndirectory-downloads①"><c- u>"downloads"</c-></a></code><c- p>,</c->  <c- c1>// Start here.</c->
+<c- p>};</c->
+
+<c- c1>// Later...</c->
+
+<c- c1>// The ID 'foo' might or might not be mapped. For example, the mapping for this ID</c->
+<c- c1>// might have been evicted.</c->
+<c- a>const</c-> options <c- o>=</c-> <c- p>{</c->
+  <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id①⓪">id</a></code><c- o>:</c-> <c- t>'foo'</c-><c- p>,</c->  <c- c1>// Maybe mapped. If so, start here.</c->
+  <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-startin" id="ref-for-dom-filepickeroptions-startin⑦">startIn</a></code><c- o>:</c-> <code class="idl"><a data-link-type="idl" href="#dom-wellknowndirectory-downloads" id="ref-for-dom-wellknowndirectory-downloads②"><c- u>"downloads"</c-></a></code><c- p>,</c->  <c- c1>// Otherwise, start here.</c->
+<c- p>};</c->
+</pre>
+   </div>
+   <p><strong class="advisement"> The <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-startin" id="ref-for-dom-filepickeroptions-startin⑧">startIn</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id①①">id</a></code> options were first introduced in Chrome 91.</strong></p>
+   <p>A user agent holds a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="recently-picked-directory-map">recently picked directory map</dfn>, which is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a> of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origins</a> to <a data-link-type="dfn" href="#path-id-map" id="ref-for-path-id-map">path id maps</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="path-id-map">path id map</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map①">map</a> of <a data-link-type="dfn" href="#valid-path-id" id="ref-for-valid-path-id">valid path ids</a> to paths.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="valid-path-id">valid path id</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> where each character is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-alphanumeric" id="ref-for-ascii-alphanumeric①">ASCII alphanumeric</a> or "_" or "-".</p>
+   <p>To prevent a <a data-link-type="dfn" href="#path-id-map" id="ref-for-path-id-map①">path id map</a> from growing without a bound, user agents should implement
+some mechanism to limit how many recently picked directories will be remembered. This
+can for example be done by evicting least recently used entries.
+User agents should allow at least 16 entries to be stored in a <a data-link-type="dfn" href="#path-id-map" id="ref-for-path-id-map②">path id map</a>.</p>
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-wellknowndirectory"><code>WellKnownDirectory</code></dfn> enum lets a website pick one of several well-known
+directories. The exact paths the various values of this enum map to is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#implementation-defined" id="ref-for-implementation-defined">implementation-defined</a> (and in some cases these might not even represent actual paths on disk).
+The following list describes the meaning of each of the values, and gives possible example paths on different operating systems:</p>
+   <dl>
+    <dl>
+     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-desktop"><code>"desktop"</code></dfn>
+     <dd data-md>
+      <p>The user’s Desktop directory, if such a thing exists. For example this could be <code>C:\Documents and Settings\username\Desktop</code>, <code>/Users/username/Desktop</code>, or <code>/home/username/Desktop</code>.</p>
+     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-documents"><code>"documents"</code></dfn>
+     <dd data-md>
+      <p>Directory in which documents created by the user would typically be stored.
+ For example <code>C:\Documents and Settings\username\My Documents</code>, <code>/Users/username/Documents</code>, or <code>/home/username/Documents</code>.</p>
+     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-downloads"><code>"downloads"</code></dfn>
+     <dd data-md>
+      <p>Directory where downloaded files would typically be stored.
+ For example <code>C:\Documents and Settings\username\Downloads</code>, <code>/Users/username/Downloads</code>, or <code>/home/username/Downloads</code>.</p>
+     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-music"><code>"music"</code></dfn>
+     <dd data-md>
+      <p>Directory where audio files would typically be stored.
+ For example <code>C:\Documents and Settings\username\My Documents\My Music</code>, <code>/Users/username/Music</code>, or <code>/home/username/Music</code>.</p>
+     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-pictures"><code>"pictures"</code></dfn>
+     <dd data-md>
+      <p>Directory where photos and other still images would typically be stored.
+ For example <code>C:\Documents and Settings\username\My Documents\My Pictures</code>, <code>/Users/username/Pictures</code>, or <code>/home/username/Pictures</code>.</p>
+     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WellKnownDirectory" data-dfn-type="enum-value" data-export id="dom-wellknowndirectory-videos"><code>"videos"</code></dfn>
+     <dd data-md>
+      <p>Directory where videos/movies would typically be stored.
+ For example <code>C:\Documents and Settings\username\My Documents\My Videos</code>, <code>/Users/username/Movies</code>, or <code>/home/username/Videos</code>.</p>
+    </dl>
+    <div class="algorithm" data-algorithm="determine the directory the picker will start in">
+      To <dfn class="dfn-paneled" data-dfn-for="WellKnownDirectory" data-dfn-type="dfn" data-noexport id="wellknowndirectory-determine-the-directory-the-picker-will-start-in">determine the directory the picker will start in</dfn>, given an optional <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> <var>id</var>,
+an optional <code class="idl"><a data-link-type="idl" href="#typedefdef-startindirectory" id="ref-for-typedefdef-startindirectory②">StartInDirectory</a></code> <var>startIn</var> and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object">environment settings object</a> <var>environment</var>,
+run the following steps: 
+     <ol>
+      <li data-md>
+       <p>If <var>id</var> given, and is not a <a data-link-type="dfn" href="#valid-path-id" id="ref-for-valid-path-id①">valid path id</a>, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①③">TypeError</a></code>.</p>
+      <li data-md>
+       <p>If <var>id</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-length" id="ref-for-string-length①">length</a> is more than 32, throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①④">TypeError</a></code>.</p>
+      <li data-md>
+       <p>Let <var>origin</var> be <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin⑤">origin</a>.</p>
+      <li data-md>
+       <p>If <var>startIn</var> is a <code class="idl"><a data-link-type="idl" href="#filesystemhandle" id="ref-for-filesystemhandle①⑥">FileSystemHandle</a></code>:</p>
+       <ol>
+        <li data-md>
+         <p>Let <var>entry</var> be <var>startIn</var>’s <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②⑥">entry</a>.</p>
+        <li data-md>
+         <p>If <var>entry</var> does not represent an <a data-link-type="dfn" href="#entry" id="ref-for-entry①⑤">entry</a> in an <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system⑤">origin private file system</a>:</p>
+         <ol>
+          <li data-md>
+           <p>If <var>entry</var> is a <a data-link-type="dfn" href="#file" id="ref-for-file①①">file entry</a>, and a path on the local file system
+ corresponding to the parent directory if <var>entry</var> can be determined,
+ then return that path.</p>
+          <li data-md>
+           <p>If <var>entry</var> is a <a data-link-type="dfn" href="#directory" id="ref-for-directory⑧">directory entry</a>, and a path on the local file system
+ corresponding to <var>entry</var> can be determined,
+ then return that path.</p>
+         </ol>
+       </ol>
+      <li data-md>
+       <p>If <var>id</var> is non-empty:</p>
+       <ol>
+        <li data-md>
+         <p>If <a data-link-type="dfn" href="#recently-picked-directory-map" id="ref-for-recently-picked-directory-map">recently picked directory map</a>[<var>origin</var>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists">exists</a>:</p>
+         <ol>
+          <li data-md>
+           <p>Let <var>path map</var> be <a data-link-type="dfn" href="#recently-picked-directory-map" id="ref-for-recently-picked-directory-map①">recently picked directory map</a>[<var>origin</var>].</p>
+          <li data-md>
+           <p>If <var>path map</var>[<var>id</var>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists①">exists</a>, then return <var>path map</var>[<var>id</var>].</p>
+         </ol>
+       </ol>
+      <li data-md>
+       <p>If <var>startIn</var> is a <code class="idl"><a data-link-type="idl" href="#enumdef-wellknowndirectory" id="ref-for-enumdef-wellknowndirectory⑤">WellKnownDirectory</a></code>:</p>
+       <ol>
+        <li data-md>
+         <p>Return a user agent defined path corresponding to the <code class="idl"><a data-link-type="idl" href="#enumdef-wellknowndirectory" id="ref-for-enumdef-wellknowndirectory⑥">WellKnownDirectory</a></code> value of <var>startIn</var>.</p>
+       </ol>
+      <li data-md>
+       <p>If <var>id</var> is not specified, or is an empty string:</p>
+       <ol>
+        <li data-md>
+         <p>If <a data-link-type="dfn" href="#recently-picked-directory-map" id="ref-for-recently-picked-directory-map②">recently picked directory map</a>[<var>origin</var>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists②">exists</a>:</p>
+         <ol>
+          <li data-md>
+           <p>Let <var>path map</var> be <a data-link-type="dfn" href="#recently-picked-directory-map" id="ref-for-recently-picked-directory-map③">recently picked directory map</a>[<var>origin</var>].</p>
+          <li data-md>
+           <p>If <var>path map</var>[""] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists③">exists</a>, then return <var>path map</var>[""].</p>
+         </ol>
+       </ol>
+      <li data-md>
+       <p>Return a default path in a user agent specific manner.</p>
+     </ol>
+    </div>
+    <div class="algorithm" data-algorithm="remember a picked directory">
+      To <dfn class="dfn-paneled" data-dfn-for="WellKnownDirectory" data-dfn-type="dfn" data-noexport id="wellknowndirectory-remember-a-picked-directory">remember a picked directory</dfn>, given an optional <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string⑤">string</a> <var>id</var>,
+an <a data-link-type="dfn" href="#entry" id="ref-for-entry①⑥">entry</a> <var>entry</var>, and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object①">environment settings object</a> <var>environment</var>,
+run the following steps: 
+     <ol>
+      <li data-md>
+       <p>Let <var>origin</var> be <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin⑥">origin</a>.</p>
+      <li data-md>
+       <p>If <a data-link-type="dfn" href="#recently-picked-directory-map" id="ref-for-recently-picked-directory-map④">recently picked directory map</a>[<var>origin</var>] does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists④">exist</a>,
+ then set <a data-link-type="dfn" href="#recently-picked-directory-map" id="ref-for-recently-picked-directory-map⑤">recently picked directory map</a>[<var>origin</var>] to an empty <a data-link-type="dfn" href="#path-id-map" id="ref-for-path-id-map③">path id map</a>.</p>
+      <li data-md>
+       <p>If <var>id</var> is not specified, let <var>id</var> be an empty string.</p>
+      <li data-md>
+       <p>Set <a data-link-type="dfn" href="#recently-picked-directory-map" id="ref-for-recently-picked-directory-map⑥">recently picked directory map</a>[<var>origin</var>][<var>id</var>] to the path on the local file system corresponding to <var>entry</var>,
+ if such a path can be determined.</p>
+     </ol>
+    </div>
+    <h3 class="heading settled" data-level="3.3" id="api-showopenfilepicker"><span class="secno">3.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker③">showOpenFilePicker()</a></code> method</span><a class="self-link" href="#api-showopenfilepicker"></a></h3>
+    <div class="mdn-anno wrapped after">
+     <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+     <div class="feature">
+      <p><a href="https://developer.mozilla.org/en-US/docs/Web/api/window/showopenfilepicker" title="The showOpenFilePicker() method of the Window interface shows a file picker that allows a user to select a file or multiple files and returns a handle for the file(s).">window/showopenfilepicker</a></p>
+      <p class="less-than-two-engines-text">In only one current engine.</p>
+      <div class="support">
+       <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+       <hr>
+       <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+       <hr>
+       <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+       <hr>
+       <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>None</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>None</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+      </div>
+     </div>
+    </div>
+    <div class="note domintro" role="note">
+     <dl>
+      <dt data-md>[ <var>handle</var> ] = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker④">showOpenFilePicker()</a></code>
+      <dt data-md>[ <var>handle</var> ] = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker⑤">showOpenFilePicker</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-openfilepickeroptions-multiple" id="ref-for-dom-openfilepickeroptions-multiple">multiple</a></code>: false })
+      <dd data-md>
+       <p>Shows a file picker that lets a user select a single existing file, returning a handle for
+the selected file.</p>
+      <dt data-md>handles = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker⑥">showOpenFilePicker</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-openfilepickeroptions-multiple" id="ref-for-dom-openfilepickeroptions-multiple①">multiple</a></code>: true })
+      <dd data-md>
+       <p>Shows a file picker that lets a user select multiple existing files, returning handles for
+the selected files.</p>
+       <p>Additional options can be passed to <code class="idl"><a data-link-type="idl" href="#dom-window-showopenfilepicker" id="ref-for-dom-window-showopenfilepicker⑦">showOpenFilePicker()</a></code> to indicate the types of files
+the website wants the user to select and the directory in which the
+file picker will open. See <a href="#api-filepickeroptions">§ 3.2 File picker options</a> for details.</p>
+     </dl>
+    </div>
+    <div class="algorithm" data-algorithm="showOpenFilePicker(options)" data-algorithm-for="Window">
+      The <dfn class="dfn-paneled idl-code" data-dfn-for="Window" data-dfn-type="method" data-export data-lt="showOpenFilePicker(options)|showOpenFilePicker()" id="dom-window-showopenfilepicker"><code>showOpenFilePicker(<var>options</var>)</code></dfn> method, when invoked, must run
+these steps: 
+     <ol>
+      <li data-md>
+       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②④">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object③">relevant settings object</a>.</p>
+      <li data-md>
+       <p>Let <var>accepts options</var> be the result of <a data-link-type="dfn" href="#process-accept-types" id="ref-for-process-accept-types">processing accept types</a> given <var>options</var>.</p>
+      <li data-md>
+       <p>Let <var>starting directory</var> be the result of <a data-link-type="dfn" href="#wellknowndirectory-determine-the-directory-the-picker-will-start-in" id="ref-for-wellknowndirectory-determine-the-directory-the-picker-will-start-in">determining the directory the picker will start in</a> given <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id①②">id</a></code>, <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-startin" id="ref-for-dom-filepickeroptions-startin⑨">startIn</a></code> and <var>environment</var>.</p>
+      <li data-md>
+       <p>Let <var>global</var> be <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global②">global object</a>.</p>
+      <li data-md>
+       <p>Verify that <var>environment</var> <a data-link-type="dfn" href="#is-allowed-to-show-a-file-picker" id="ref-for-is-allowed-to-show-a-file-picker">is allowed to show a file picker</a>.</p>
+      <li data-md>
+       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①④">a new promise</a>.</p>
+      <li data-md>
+       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①③">in parallel</a>:</p>
+       <ol>
+        <li data-md>
+         <p>Optionally, wait until any prior execution of this algorithm has terminated.</p>
+        <li data-md>
+         <p>Display a prompt to the user requesting that the user pick some files.
+ If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-openfilepickeroptions-multiple" id="ref-for-dom-openfilepickeroptions-multiple②">multiple</a></code> is false, there must be no more than one file selected;
+ otherwise any number may be selected.</p>
+         <p>The displayed prompt should let the user pick one of the <var>accepts options</var> to filter the list of displayed files.
+ Exactly how this is implemented, and what this prompt looks like is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#implementation-defined" id="ref-for-implementation-defined①">implementation-defined</a>.</p>
+         <p>When possible, this prompt should start out showing <var>starting directory</var>.</p>
+        <li data-md>
+         <p>Wait for the user to have made their selection.</p>
+        <li data-md>
+         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②⑨">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror①">AbortError</a></code> and abort.</p>
+        <li data-md>
+         <p>Let <var>entries</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> of <a data-link-type="dfn" href="#file" id="ref-for-file①②">file entries</a> representing the selected files or directories.</p>
+        <li data-md>
+         <p>Let <var>result</var> be a empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a>.</p>
+        <li data-md>
+         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate⑦">For each</a> <var>entry</var> of <var>entries</var>:</p>
+         <ol>
+          <li data-md>
+           <p>If <var>entry</var> is deemed <a data-link-type="dfn" href="#wellknowndirectory-too-sensitive-or-dangerous" id="ref-for-wellknowndirectory-too-sensitive-or-dangerous">too sensitive or dangerous</a> to be exposed to this website by the user agent:</p>
+           <ol>
+            <li data-md>
+             <p>Inform the user that the selected files or directories can’t be exposed to this website.</p>
+            <li data-md>
+             <p>At the discretion of the user agent,
+ either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①④">in parallel</a> steps,
+ or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③⓪">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror②">AbortError</a></code> and abort.</p>
+           </ol>
+          <li data-md>
+           <p>Add a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①①">FileSystemFileHandle</a></code> associated with <var>entry</var> to <var>result</var>.</p>
+         </ol>
+        <li data-md>
+         <p><a data-link-type="dfn" href="#wellknowndirectory-remember-a-picked-directory" id="ref-for-wellknowndirectory-remember-a-picked-directory">Remember a picked directory</a> given <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id①③">id</a></code>, <var>entries</var>[0] and <var>environment</var>.</p>
+        <li data-md>
+         <p>Perform the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#activation-notification" id="ref-for-activation-notification">activation notification</a> steps in <var>global</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#window-bc" id="ref-for-window-bc">browsing context</a>.</p>
+         <p class="note" role="note"><span>Note:</span> This lets a website immediately perform operations on the returned handles that
+ might require user activation, such as requesting more permissions.</p>
+        <li data-md>
+         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②④">Resolve</a> <var>p</var> with <var>result</var>.</p>
+       </ol>
+      <li data-md>
+       <p>Return <var>p</var>.</p>
+     </ol>
+    </div>
+    <h3 class="heading settled" data-level="3.4" id="api-showsavefilepicker"><span class="secno">3.4. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker④">showSaveFilePicker()</a></code> method</span><a class="self-link" href="#api-showsavefilepicker"></a></h3>
+    <div class="mdn-anno wrapped after">
+     <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+     <div class="feature">
+      <p><a href="https://developer.mozilla.org/en-US/docs/Web/api/window/showsavefilepicker" title="The showSaveFilePicker() method of the Window interface shows a file picker that allows a user to save a file. Either by selecting an existing file, or entering a name for a new file.">window/showsavefilepicker</a></p>
+      <p class="less-than-two-engines-text">In only one current engine.</p>
+      <div class="support">
+       <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+       <hr>
+       <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+       <hr>
+       <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+       <hr>
+       <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>None</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>None</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+      </div>
+     </div>
+    </div>
+    <div class="note domintro" role="note">
+     <dl>
+      <dt data-md><var>handle</var> = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker⑤">showSaveFilePicker</a></code>( <var>options</var> )
+      <dd data-md>
+       <p>Shows a file picker that lets a user select a single file, returning a handle for
+the selected file. The selected file does not have to exist already. If the selected
+file does not exist a new empty file is created before this method returns, otherwise
+the existing file is cleared before this method returned.</p>
+      <dt data-md><var>handle</var> = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker⑥">showSaveFilePicker</a></code>({ <code class="idl"><a data-link-type="idl" href="#dom-savefilepickeroptions-suggestedname" id="ref-for-dom-savefilepickeroptions-suggestedname">suggestedName</a></code>: "README.md" })
+      <dd data-md>
+       <p>Shows a file picker with the suggested "README.md" file name pre-filled as the default file name to save as.</p>
+       <p>Additional <var>options</var> can be passed to <code class="idl"><a data-link-type="idl" href="#dom-window-showsavefilepicker" id="ref-for-dom-window-showsavefilepicker⑦">showSaveFilePicker()</a></code> to indicate the types of files
+the website wants the user to select and the directory in which the
+file picker will open. See <a href="#api-filepickeroptions">§ 3.2 File picker options</a> for details.</p>
+     </dl>
+    </div>
+    <p><strong class="advisement"> The <code class="idl"><a data-link-type="idl" href="#dom-savefilepickeroptions-suggestedname" id="ref-for-dom-savefilepickeroptions-suggestedname①">suggestedName</a></code> option was first introduced in Chrome 91.</strong></p>
+    <div class="algorithm" data-algorithm="showSaveFilePicker(options)" data-algorithm-for="Window">
+      The <dfn class="dfn-paneled idl-code" data-dfn-for="Window" data-dfn-type="method" data-export data-lt="showSaveFilePicker(options)|showSaveFilePicker()" id="dom-window-showsavefilepicker"><code>showSaveFilePicker(<var>options</var>)</code></dfn> method, when invoked, must run
+these steps: 
+     <ol>
+      <li data-md>
+       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑤">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object④">relevant settings object</a>.</p>
+      <li data-md>
+       <p>Let <var>accepts options</var> be the result of <a data-link-type="dfn" href="#process-accept-types" id="ref-for-process-accept-types①">processing accept types</a> given <var>options</var>.</p>
+      <li data-md>
+       <p>Let <var>starting directory</var> be the result of <a data-link-type="dfn" href="#wellknowndirectory-determine-the-directory-the-picker-will-start-in" id="ref-for-wellknowndirectory-determine-the-directory-the-picker-will-start-in①">determining the directory the picker will start in</a> given <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id①④">id</a></code>, <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-startin" id="ref-for-dom-filepickeroptions-startin①⓪">startIn</a></code> and <var>environment</var>.</p>
+      <li data-md>
+       <p>Let <var>global</var> be <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global③">global object</a>.</p>
+      <li data-md>
+       <p>Verify that <var>environment</var> <a data-link-type="dfn" href="#is-allowed-to-show-a-file-picker" id="ref-for-is-allowed-to-show-a-file-picker①">is allowed to show a file picker</a>.</p>
+      <li data-md>
+       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑤">a new promise</a>.</p>
+      <li data-md>
+       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑤">in parallel</a>:</p>
+       <ol>
+        <li data-md>
+         <p>Optionally, wait until any prior execution of this algorithm has terminated.</p>
+        <li data-md>
+         <p>Display a prompt to the user requesting that the user pick exactly one file.
+ The displayed prompt should let the user pick one of the <var>accepts options</var> to filter the list of displayed files.
+ Exactly how this is implemented, and what this prompt looks like is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#implementation-defined" id="ref-for-implementation-defined②">implementation-defined</a>.
+ If <var>accepts options</var> are displayed in the UI, the selected option should also be used to suggest an extension
+ to append to a user provided file name, but this is not required. In particular user agents are free to ignore
+ potentially dangerous suffixes such as those ending in <code>".lnk"</code> or <code>".local"</code>.</p>
+         <p>When possible, this prompt should start out showing <var>starting directory</var>.</p>
+         <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-savefilepickeroptions-suggestedname" id="ref-for-dom-savefilepickeroptions-suggestedname②">suggestedName</a></code> is specified and not null,
+ the file picker prompt will be pre-filled with the <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-savefilepickeroptions-suggestedname" id="ref-for-dom-savefilepickeroptions-suggestedname③">suggestedName</a></code> as the default name to save as. The interaction between the <code class="idl"><a data-link-type="idl" href="#dom-savefilepickeroptions-suggestedname" id="ref-for-dom-savefilepickeroptions-suggestedname④">suggestedName</a></code> and <var>accepts options</var> is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#implementation-defined" id="ref-for-implementation-defined③">implementation-defined</a>.
+ If the <code class="idl"><a data-link-type="idl" href="#dom-savefilepickeroptions-suggestedname" id="ref-for-dom-savefilepickeroptions-suggestedname⑤">suggestedName</a></code> is deemed too dangerous, user agents should ignore or sanitize the
+ suggested file name, similar to the sanitization done when fetching something <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/links.html#as-a-download" id="ref-for-as-a-download">as a download</a>.</p>
+         <p class="note" role="note"><span>Note:</span> A user agent could for example pick whichever option in <var>accepts options</var> that matches <code class="idl"><a data-link-type="idl" href="#dom-savefilepickeroptions-suggestedname" id="ref-for-dom-savefilepickeroptions-suggestedname⑥">suggestedName</a></code> as the default filter.</p>
+        <li data-md>
+         <p>Wait for the user to have made their selection.</p>
+        <li data-md>
+         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③①">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror③">AbortError</a></code> and abort.</p>
+        <li data-md>
+         <p>Let <var>entry</var> be a <a data-link-type="dfn" href="#file" id="ref-for-file①③">file entry</a> representing the selected file.</p>
+        <li data-md>
+         <p>If <var>entry</var> is deemed <a data-link-type="dfn" href="#wellknowndirectory-too-sensitive-or-dangerous" id="ref-for-wellknowndirectory-too-sensitive-or-dangerous①">too sensitive or dangerous</a> to be exposed to this website by the user agent:</p>
+         <ol>
+          <li data-md>
+           <p>Inform the user that the selected files or directories can’t be exposed to this website.</p>
+          <li data-md>
+           <p>At the discretion of the user agent,
+ either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑥">in parallel</a> steps,
+ or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③②">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror④">AbortError</a></code> and abort.</p>
+         </ol>
+        <li data-md>
+         <p>Set <var>entry</var>’s <a data-link-type="dfn" href="#file-entry-binary-data" id="ref-for-file-entry-binary-data⑤">binary data</a> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte-sequence" id="ref-for-byte-sequence⑨">byte sequence</a>.</p>
+        <li data-md>
+         <p>Set <var>result</var> to a new <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①②">FileSystemFileHandle</a></code> associated with <var>entry</var>.</p>
+        <li data-md>
+         <p><a data-link-type="dfn" href="#wellknowndirectory-remember-a-picked-directory" id="ref-for-wellknowndirectory-remember-a-picked-directory①">Remember a picked directory</a> given <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id①⑤">id</a></code>, <var>entry</var> and <var>environment</var>.</p>
+        <li data-md>
+         <p>Perform the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#activation-notification" id="ref-for-activation-notification①">activation notification</a> steps in <var>global</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#window-bc" id="ref-for-window-bc①">browsing context</a>.</p>
+         <p class="note" role="note"><span>Note:</span> This lets a website immediately perform operations on the returned handles that
+ might require user activation, such as requesting more permissions.</p>
+        <li data-md>
+         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑤">Resolve</a> <var>p</var> with <var>result</var>.</p>
+       </ol>
+      <li data-md>
+       <p>Return <var>p</var>.</p>
+     </ol>
+    </div>
+    <h3 class="heading settled" data-level="3.5" id="api-showdirectorypicker"><span class="secno">3.5. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#dom-window-showdirectorypicker" id="ref-for-dom-window-showdirectorypicker②">showDirectoryPicker()</a></code> method</span><a class="self-link" href="#api-showdirectorypicker"></a></h3>
+    <div class="mdn-anno wrapped after">
+     <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+     <div class="feature">
+      <p><a href="https://developer.mozilla.org/en-US/docs/Web/api/window/showdirectorypicker" title="The showDirectoryPicker() method of the Window interface displays a directory picker which allows the user to select a directory.">window/showdirectorypicker</a></p>
+      <p class="less-than-two-engines-text">In only one current engine.</p>
+      <div class="support">
+       <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+       <hr>
+       <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+       <hr>
+       <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+       <hr>
+       <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>None</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>None</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+      </div>
+     </div>
+    </div>
+    <div class="note domintro" role="note">
+     <dl>
+      <dt data-md><var>handle</var> = await window . <code class="idl"><a data-link-type="idl" href="#dom-window-showdirectorypicker" id="ref-for-dom-window-showdirectorypicker③">showDirectoryPicker()</a></code>
+      <dd data-md>
+       <p>Shows a directory picker that lets the user select a single directory, returning a handle for
+the selected directory.</p>
+     </dl>
+     <p>The <code class="idl"><a data-link-type="idl" href="#dom-directorypickeroptions-id" id="ref-for-dom-directorypickeroptions-id">id</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-directorypickeroptions-startin" id="ref-for-dom-directorypickeroptions-startin">startIn</a></code> fields behave
+  identically to the <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-id" id="ref-for-dom-filepickeroptions-id①⑥">id</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-filepickeroptions-startin" id="ref-for-dom-filepickeroptions-startin①①">startIn</a></code> fields, respectively.
+  See <a href="#api-filepickeroptions-starting-directory">§ 3.2.2 Starting Directory</a> for details on how to use these fields.</p>
+    </div>
+    <div class="algorithm" data-algorithm="showDirectoryPicker(options)" data-algorithm-for="Window">
+      The <dfn class="dfn-paneled idl-code" data-dfn-for="Window" data-dfn-type="method" data-export data-lt="showDirectoryPicker(options)|showDirectoryPicker()" id="dom-window-showdirectorypicker"><code>showDirectoryPicker(<var>options</var>)</code></dfn> method, when invoked, must run
+these steps: 
+     <ol>
+      <li data-md>
+       <p>Let <var>environment</var> be <b><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑥">this</a></b>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object⑤">relevant settings object</a>.</p>
+      <li data-md>
+       <p>Let <var>starting directory</var> be the result of <a data-link-type="dfn" href="#wellknowndirectory-determine-the-directory-the-picker-will-start-in" id="ref-for-wellknowndirectory-determine-the-directory-the-picker-will-start-in②">determining the directory the picker will start in</a> given <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-directorypickeroptions-id" id="ref-for-dom-directorypickeroptions-id①">id</a></code>, <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-directorypickeroptions-startin" id="ref-for-dom-directorypickeroptions-startin①">startIn</a></code> and <var>environment</var>.</p>
+      <li data-md>
+       <p>Let <var>global</var> be <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global④">global object</a>.</p>
+      <li data-md>
+       <p>Verify that <var>environment</var> <a data-link-type="dfn" href="#is-allowed-to-show-a-file-picker" id="ref-for-is-allowed-to-show-a-file-picker②">is allowed to show a file picker</a>.</p>
+      <li data-md>
+       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑥">a new promise</a>.</p>
+      <li data-md>
+       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑦">in parallel</a>:</p>
+       <ol>
+        <li data-md>
+         <p>Optionally, wait until any prior execution of this algorithm has terminated.</p>
+        <li data-md>
+         <p>Display a prompt to the user requesting that the user pick a directory.</p>
+         <p>When possible, this prompt should start out showing <var>starting directory</var>.</p>
+        <li data-md>
+         <p>Wait for the user to have made their selection.</p>
+        <li data-md>
+         <p>If the user dismissed the prompt without making a selection, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③③">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror⑤">AbortError</a></code> and abort.</p>
+        <li data-md>
+         <p>Let <var>entry</var> be a <a data-link-type="dfn" href="#directory" id="ref-for-directory⑨">directory entry</a> representing the selected directory.</p>
+        <li data-md>
+         <p>If <var>entry</var> is deemed <a data-link-type="dfn" href="#wellknowndirectory-too-sensitive-or-dangerous" id="ref-for-wellknowndirectory-too-sensitive-or-dangerous②">too sensitive or dangerous</a> to be exposed to this website by the user agent:</p>
+         <ol>
+          <li data-md>
+           <p>Inform the user that the selected files or directories can’t be exposed to this website.</p>
+          <li data-md>
+           <p>At the discretion of the user agent,
+ either go back to the beginning of these <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑧">in parallel</a> steps,
+ or <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject③④">reject</a> <var>p</var> with an <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror⑥">AbortError</a></code> and abort.</p>
+         </ol>
+        <li data-md>
+         <p>Set <var>result</var> to a new <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①③">FileSystemDirectoryHandle</a></code> associated with <var>entry</var>.</p>
+        <li data-md>
+         <p><a data-link-type="dfn" href="#wellknowndirectory-remember-a-picked-directory" id="ref-for-wellknowndirectory-remember-a-picked-directory②">Remember a picked directory</a> given <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-directorypickeroptions-id" id="ref-for-dom-directorypickeroptions-id②">id</a></code>, <var>entry</var> and <var>environment</var>.</p>
+        <li data-md>
+         <p>Perform the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#activation-notification" id="ref-for-activation-notification②">activation notification</a> steps in <var>global</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#window-bc" id="ref-for-window-bc②">browsing context</a>.</p>
+         <p class="note" role="note"><span>Note:</span> This lets a website immediately perform operations on the returned handles that
+ might require user activation, such as requesting more permissions.</p>
+         <p class="issue" id="issue-923f3009"><a class="self-link" href="#issue-923f3009"></a> Rather than requiring the website to prompt separately for a writable directory,
+ we should provide some kind of API to request a writable directory in one step. <a href="https://github.com/wicg/file-system-access/issues/89">[Issue #89]</a></p>
+        <li data-md>
+         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑥">Resolve</a> <var>p</var> with <var>result</var>.</p>
+       </ol>
+      <li data-md>
+       <p>Return <var>p</var>.</p>
+     </ol>
+    </div>
+    <h3 class="heading settled" data-level="3.6" id="drag-and-drop"><span class="secno">3.6. </span><span class="content">Drag and Drop</span><a class="self-link" href="#drag-and-drop"></a></h3>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem" id="ref-for-datatransferitem"><c- g>DataTransferItem</c-></a> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise②⓪"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemhandle" id="ref-for-filesystemhandle①⑦"><c- n>FileSystemHandle</c-></a>?> <a class="idl-code" data-link-type="method" href="#dom-datatransferitem-getasfilesystemhandle" id="ref-for-dom-datatransferitem-getasfilesystemhandle"><c- g>getAsFileSystemHandle</c-></a>();
+};
+</pre>
+    <p>During a <em>drag-and-drop operation</em>, dragged file and
+directory items are associated with <a data-link-type="dfn" href="#file" id="ref-for-file①④">file entries</a> and <a data-link-type="dfn" href="#directory" id="ref-for-directory①⓪">directory entries</a> respectively.</p>
+    <div class="note domintro" role="note">
+     <dl>
+      <dt data-md><var>handle</var> = await item . <code class="idl"><a data-link-type="idl" href="#dom-datatransferitem-getasfilesystemhandle" id="ref-for-dom-datatransferitem-getasfilesystemhandle①">getAsFileSystemHandle()</a></code>
+      <dd data-md>
+       <p>Returns a <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①③">FileSystemFileHandle</a></code> object if the dragged item is a file and a <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①④">FileSystemDirectoryHandle</a></code> object if the dragged item is a directory.</p>
+     </dl>
+    </div>
+    <div class="algorithm" data-algorithm="getAsFileSystemHandle()" data-algorithm-for="DataTransferItem">
+     <div class="mdn-anno wrapped">
+      <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+      <div class="feature">
+       <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/getAsFileSystemHandle" title="The getAsFileSystemHandle() method of the DataTransferItem interface returns a FileSystemFileHandle if the dragged item is a file, or a FileSystemDirectoryHandle if the dragged item is a directory.">DataTransferItem/getAsFileSystemHandle</a></p>
+       <p class="less-than-two-engines-text">In only one current engine.</p>
+       <div class="support">
+        <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>86+</span></span>
+        <hr>
+        <span class="opera yes"><span>Opera</span><span>72+</span></span><span class="edge_blink yes"><span>Edge</span><span>86+</span></span>
+        <hr>
+        <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+        <hr>
+        <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>None</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>None</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+       </div>
+      </div>
+     </div>
+     <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="DataTransferItem" data-dfn-type="method" data-export id="dom-datatransferitem-getasfilesystemhandle"><code>getAsFileSystemHandle()</code></dfn> method steps are:</p>
+     <ol>
+      <li data-md>
+       <p>If the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem" id="ref-for-datatransferitem①">DataTransferItem</a></code> object is not in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-rw" id="ref-for-concept-dnd-rw">read/write
+  mode</a> or the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-ro" id="ref-for-concept-dnd-ro">read-only mode</a>, return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-resolved-with" id="ref-for-a-promise-resolved-with">a promise resolved with</a> <code>null</code>.</p>
+      <li data-md>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-item-kind" id="ref-for-the-drag-data-item-kind">the drag data item kind</a> is not <em>File</em>,
+  then return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-resolved-with" id="ref-for-a-promise-resolved-with①">a promise resolved with</a> <code>null</code>.</p>
+      <li data-md>
+       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①⑦">a new promise</a>.</p>
+      <li data-md>
+       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①⑨">in parallel</a>:</p>
+       <ol>
+        <li data-md>
+         <p>Let <var>entry</var> be the <a data-link-type="dfn" href="#entry" id="ref-for-entry①⑦">entry</a> representing the dragged file or directory.</p>
+        <li data-md>
+         <p>If <var>entry</var> is a <a data-link-type="dfn" href="#file" id="ref-for-file①⑤">file entry</a>:</p>
+         <ol>
+          <li data-md>
+           <p>Let <var>handle</var> be a <code class="idl"><a data-link-type="idl" href="#filesystemfilehandle" id="ref-for-filesystemfilehandle①④">FileSystemFileHandle</a></code> associated with <var>entry</var>.</p>
+         </ol>
+        <li data-md>
+         <p>Else if <var>entry</var> is a <a data-link-type="dfn" href="#directory" id="ref-for-directory①①">directory entry</a>:</p>
+         <ol>
+          <li data-md>
+           <p>Let <var>handle</var> be a <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①⑤">FileSystemDirectoryHandle</a></code> associated with <var>entry</var>.</p>
+         </ol>
+        <li data-md>
+         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②⑦">Resolve</a> <var>p</var> with <var>entry</var>.</p>
+       </ol>
+      <li data-md>
+       <p>Return <var>p</var>.</p>
+     </ol>
+    </div>
+    <div class="example" id="draganddrop-example">
+     <a class="self-link" href="#draganddrop-example"></a> Handling drag and drop of files and directories: 
+<pre class="highlight">elem<c- p>.</c->addEventListener<c- p>(</c-><c- t>'dragover'</c-><c- p>,</c-> <c- p>(</c->e<c- p>)</c-> <c- p>=></c-> <c- p>{</c->
+  <c- c1>// Prevent navigation.</c->
+  e<c- p>.</c->preventDefault<c- p>();</c->
+<c- p>});</c->
+elem<c- p>.</c->addEventListener<c- p>(</c-><c- t>'drop'</c-><c- p>,</c-> <c- k>async</c-> <c- p>(</c->e<c- p>)</c-> <c- p>=></c-> <c- p>{</c->
+  <c- c1>// Prevent navigation.</c->
+  e<c- p>.</c->preventDefault<c- p>();</c->
+
+  <c- c1>// Process all of the items.</c->
+  <c- k>for</c-> <c- p>(</c-><c- a>const</c-> item <c- k>of</c-> e<c- p>.</c->dataTransfer<c- p>.</c->items<c- p>)</c-> <c- p>{</c->
+    <c- c1>// kind will be 'file' for file/directory entries.</c->
+    <c- k>if</c-> <c- p>(</c->item<c- p>.</c->kind <c- o>===</c-> <c- t>'file'</c-><c- p>)</c-> <c- p>{</c->
+      <c- a>const</c-> entry <c- o>=</c-> <c- k>await</c-> item<c- p>.</c->getAsFileSystemHandle<c- p>();</c->
+      <c- k>if</c-> <c- p>(</c->entry<c- p>.</c->kind <c- o>===</c-> <c- t>'file'</c-><c- p>)</c-> <c- p>{</c->
+        handleFileEntry<c- p>(</c->entry<c- p>);</c->
+      <c- p>}</c-> <c- k>else</c-> <c- k>if</c-> <c- p>(</c->entry<c- p>.</c->kind <c- o>===</c-> <c- t>'directory'</c-><c- p>)</c-> <c- p>{</c->
+        handleDirectoryEntry<c- p>(</c->entry<c- p>);</c->
+      <c- p>}</c->
+    <c- p>}</c->
+  <c- p>}</c->
+<c- p>});</c->
+</pre>
+    </div>
+    <p class="issue" id="issue-8306b646"><a class="self-link" href="#issue-8306b646"></a> This currently does not block access to <a data-link-type="dfn" href="#wellknowndirectory-too-sensitive-or-dangerous" id="ref-for-wellknowndirectory-too-sensitive-or-dangerous③">too sensitive or dangerous</a> directories, to
+be consistent with other APIs that give access to dropped files and directories. This is inconsistent
+with the <a data-link-type="dfn" href="#local-file-system-handle-factories" id="ref-for-local-file-system-handle-factories④">local file system handle factories</a> though, so we might want to reconsider this.</p>
+    <h2 class="heading settled" data-level="4" id="sandboxed-filesystem"><span class="secno">4. </span><span class="content">Accessing the Origin Private File System</span><a class="self-link" href="#sandboxed-filesystem"></a></h2>
+    <p>The <dfn class="dfn-paneled" data-dfn-for="WellKnownDirectory" data-dfn-type="dfn" data-noexport id="wellknowndirectory-origin-private-file-system">origin private file system</dfn> is a <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-endpoint" id="ref-for-storage-endpoint">storage endpoint</a> whose <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-endpoint-identifier" id="ref-for-storage-endpoint-identifier">identifier</a> is <code>"fileSystem"</code>, <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-endpoint-types" id="ref-for-storage-endpoint-types">types</a> are <code>« "local" »</code>,
+and <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-endpoint-quota" id="ref-for-storage-endpoint-quota">quota</a> is null.</p>
+    <p class="issue" id="issue-9c98e739"><a class="self-link" href="#issue-9c98e739"></a> Storage endpoints should be defined in <a data-link-type="biblio" href="#biblio-storage">[storage]</a> itself, rather
+than being defined here. So merge this into the table there.</p>
+    <p class="note" role="note"><span>Note:</span> While user agents will typically implement this by persisting the contents of this <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system⑥">origin private file system</a> to disk, it is not intended that the contents are easily
+user accessible. Similarly there is no expectation that files or directories with names
+matching the names of children of the <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system⑦">origin private file system</a> exist.</p>
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext" id="ref-for-SecureContext⑥"><c- g>SecureContext</c-></a>]
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://storage.spec.whatwg.org/#storagemanager" id="ref-for-storagemanager"><c- g>StorageManager</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise②①"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①⑥"><c- n>FileSystemDirectoryHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-storagemanager-getdirectory" id="ref-for-dom-storagemanager-getdirectory②"><c- g>getDirectory</c-></a>();
+};
+</pre>
+    <p><strong class="advisement"> In Chrome this functionality was previously exposed as <code>FileSystemDirectoryHandle.getSystemDirectory({type: "sandbox"})</code>.
+This new method is available as of Chrome 85.</strong></p>
+    <div class="note domintro" role="note">
+     <dl>
+      <dt data-md><var>directoryHandle</var> = await navigator . storage . <code class="idl"><a data-link-type="idl" href="#dom-storagemanager-getdirectory" id="ref-for-dom-storagemanager-getdirectory③">getDirectory()</a></code>
+      <dd data-md>
+       <p>Returns the root directory of the origin private file system.</p>
+     </dl>
+    </div>
+    <div class="algorithm" data-algorithm="getDirectory()" data-algorithm-for="StorageManager">
+      The <dfn class="dfn-paneled idl-code" data-dfn-for="StorageManager" data-dfn-type="method" data-export id="dom-storagemanager-getdirectory"><code>getDirectory()</code></dfn> method, when
+invoked, must run these steps: 
+     <ol>
+      <li data-md>
+       <p>Let <var>environment</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object">current settings object</a>.</p>
+      <li data-md>
+       <p>Let <var>map</var> be the result of running <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#obtain-a-local-storage-bottle-map" id="ref-for-obtain-a-local-storage-bottle-map">obtain a local storage bottle map</a> with <var>environment</var> and <code>"fileSystem"</code>. If this returns failure,
+ return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with③">a promise rejected with</a> a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#securityerror" id="ref-for-securityerror⑥">SecurityError</a></code>.</p>
+      <li data-md>
+       <p>If <var>map</var>["root"] does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑤">exist</a>:</p>
+       <ol>
+        <li data-md>
+         <p>Let <var>dir</var> be a new <a data-link-type="dfn" href="#directory" id="ref-for-directory①②">directory entry</a>.</p>
+        <li data-md>
+         <p>Set <var>dir</var>’s <a data-link-type="dfn" href="#entry-name" id="ref-for-entry-name①③">name</a> to <code>""</code>.</p>
+        <li data-md>
+         <p>Set <var>dir</var>’s <a data-link-type="dfn" href="#directory-entry-children" id="ref-for-directory-entry-children①②">children</a> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">set</a>.</p>
+        <li data-md>
+         <p>Set <var>map</var>["root"] to <var>dir</var>.</p>
+       </ol>
+      <li data-md>
+       <p>Return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-promise-resolved-with" id="ref-for-a-promise-resolved-with②">a promise resolved with</a> a new <code class="idl"><a data-link-type="idl" href="#filesystemdirectoryhandle" id="ref-for-filesystemdirectoryhandle①⑦">FileSystemDirectoryHandle</a></code>,
+ whose associated <a data-link-type="dfn" href="#filesystemhandle-entry" id="ref-for-filesystemhandle-entry②⑦">entry</a> is <var>map</var>["root"].</p>
+     </ol>
+    </div>
+    <p class="note" role="note"><span>Note:</span> In Chrome the directory entry returned by the above algorithm refers to the same storage as the <a href="https://dev.w3.org/2009/dap/file-system/file-dir-sys.html#dfn-temporary">temporary
+file system</a> as used to be defined in <a data-link-type="biblio" href="#biblio-file-system-api">File API: Directories and System</a>.</p>
+    <h2 class="heading settled" data-level="5" id="accessibility-considerations"><span class="secno">5. </span><span class="content">Accessibility Considerations</span><a class="self-link" href="#accessibility-considerations"></a></h2>
+    <p><em>This section is non-normative.</em></p>
+    <p>When this specification is used to present information in the user interface,
+implementors will want to follow the OS level accessibility guidelines for the platform.</p>
+    <h2 class="heading settled" data-level="6" id="privacy-considerations"><span class="secno">6. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy-considerations"></a></h2>
+    <p><em>This section is non-normative.</em></p>
+    <p>This API does not give websites any more read access to data than the existing <code>&lt;input type=file></code> and <code>&lt;input type=file webkitdirectory></code> APIs already do. Furthermore similarly to those APIs, all
+access to files and directories is explicitly gated behind a file or directory picker.</p>
+    <p>There are however several major privacy risks with this new API:</p>
+    <h3 class="heading settled" data-level="6.1" id="privacy-wide-access"><span class="secno">6.1. </span><span class="content">Users giving access to more, or more sensitive files than they intended.</span><a class="self-link" href="#privacy-wide-access"></a></h3>
+    <p>This isn’t a new risk with this API, but user agents should try to make sure that users are aware
+of what exactly they’re giving websites access to. This is particularly important when giving
+access to a directory, where it might not be immediately clear to a user just how many files
+actually exist in that directory.</p>
+    <p>A related risk is having a user give access to particularly sensitive data. This
+could include some of a user agent’s configuration data, network cache or cookie store,
+or operating system configuration data such as password files. To protect against this, user agents
+are encouraged to restrict which directories a user is allowed to select in a directory picker,
+and potentially even restrict which files the user is allowed to select. This will make it much
+harder to accidentally give access to a directory that contains particularly sensitive data. Care
+must be taken to strike the right balance between restricting what the API can access while still
+having the API be useful. After all, this API intentionally lets the user use websites to interact
+with some of their most private personal data.</p>
+    <p>Examples of directories that user agents might want to restrict as being <dfn class="dfn-paneled" data-dfn-for="WellKnownDirectory" data-dfn-type="dfn" data-noexport id="wellknowndirectory-too-sensitive-or-dangerous">too sensitive or dangerous</dfn> include:</p>
+    <ul>
+     <li data-md>
+      <p>The directory or directories containing the user agent itself.</p>
+     <li data-md>
+      <p>Directories where the user agent stores <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#site-storage" id="ref-for-site-storage">website storage</a>.</p>
+     <li data-md>
+      <p>Directories containing system files (such as <code>C:\Windows</code> on Windows).</p>
+     <li data-md>
+      <p>Directories such as <code>/dev/</code>, <code>/sys</code>, and <code>/proc</code> on Linux that would give access to low-level devices.</p>
+     <li data-md>
+      <p>A user’s entire "home" directory.
+Individual files and directories inside the home directory should still be allowed,
+but user agents should not generally let users give blanket access to the entire directory.</p>
+     <li data-md>
+      <p>The default directory for downloads, if the user agent has such a thing.
+Individual files inside the directory again should be allowed, but the whole directory would risk leaking more data than a user realizes.</p>
+     <li data-md>
+      <p>Files with names that end in <code>.lnk</code>, when selecting a file to write to. Writing to
+these files on Windows is similar to creating symlinks on other operating systems,
+and as such can be used to attempt to trick users into giving access to files they didn’t intend to expose.</p>
+     <li data-md>
+      <p>Files with names that end in <code>.local</code>, when selecting a file to write to.
+Windows uses these files to decide what DLLs to load, and as such writing to
+these files could be used to cause code to be executed.</p>
+    </ul>
+    <h3 class="heading settled" data-level="6.2" id="privacy-tracking"><span class="secno">6.2. </span><span class="content">Websites trying to use this API for tracking.</span><a class="self-link" href="#privacy-tracking"></a></h3>
+    <p>This API could be used by websites to track the user across clearing browsing
+data. This is because, in contrast with existing file access APIs, user agents are
+able to grant persistent access to files or directories and can re-prompt. In
+combination with the ability to write to files, websites will be able to persist an
+identifier on the users' disk. Clearing browsing data will not affect those files
+in any way, making these identifiers persist through those actions.</p>
+    <p>This risk is somewhat mitigated by the fact that clearing browsing data will clear all handles
+that a website had persisted (for example in IndexedDB),
+so websites won’t have any handles to re-prompt for permission after browsing data was cleared.
+Furthermore user agents are encouraged to make it clear what files and directories a website has
+access to, and to automatically expire permission grants except for particularly well trusted
+origins (for example persistent permissions could be limited to "installed" web applications).</p>
+    <p>User agents also are encouraged to provide a way for users to revoke permissions granted.
+Clearing browsing data is expected to revoke all permissions as well.</p>
+    <h3 class="heading settled" data-level="6.3" id="privacy-third-party"><span class="secno">6.3. </span><span class="content">First-party vs third-party contexts.</span><a class="self-link" href="#privacy-third-party"></a></h3>
+    <p>In third-party contexts (e.g. an iframe whose origin does not match that of the top-level frame)
+websites can’t gain access to data they don’t already have access to. This includes both getting
+access to new files or directories via the <a data-link-type="dfn" href="#local-file-system-handle-factories" id="ref-for-local-file-system-handle-factories⑤">local file system handle factories</a>, as well as requesting
+more permissions to existing handles via the <code class="idl"><a data-link-type="idl" href="#dom-filesystemhandle-requestpermission" id="ref-for-dom-filesystemhandle-requestpermission⑦">requestPermission</a></code> API.</p>
+    <p>Handles can also only be post-messaged to same-origin destinations. Attempts to send a handle to
+a cross-origin destination will result in a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/indices.html#event-messageerror" id="ref-for-event-messageerror">messageerror</a></code> event.</p>
+    <h2 class="heading settled" data-level="7" id="security-considerations"><span class="secno">7. </span><span class="content">Security Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
+    <p><em>This section is non-normative.</em></p>
+    <p>This API gives websites the ability to modify existing files on disk, as well as write to new
+files. This has a couple of important security considerations:</p>
+    <h3 class="heading settled" data-level="7.1" id="security-malware"><span class="secno">7.1. </span><span class="content">Malware</span><a class="self-link" href="#security-malware"></a></h3>
+    <p>This API could be used by websites to try to store and/or execute malware on the users system.
+To mitigate this risk, this API does not provide any way to mark files as executable (on the other
+hand files that are already executable likely remain that way, even after the files are modified
+through this API). Furthermore user agents are encouraged to apply things like Mark-of-the-Web to
+files created or modified by this API.</p>
+    <p>Finally, user agents are encouraged to verify the contents of files modified by this API via <dfn class="dfn-paneled" data-dfn-for="WellKnownDirectory" data-dfn-type="dfn" data-lt="malware scans and safe browsing checks" data-noexport id="wellknowndirectory-malware-scans-and-safe-browsing-checks">malware
+scans and safe browsing checks</dfn>, unless some kind of external strong trust relation already exists.
+This of course has effects on the performance characteristics of this API.</p>
+    <h3 class="heading settled" data-level="7.2" id="security-ransomware"><span class="secno">7.2. </span><span class="content">Ransomware attacks</span><a class="self-link" href="#security-ransomware"></a></h3>
+    <p>Another risk factor is that of ransomware attacks. The limitations described above regarding
+blocking access to certain sensitive directories helps limit the damage such an attack can do.
+Additionally user agents can grant write access to files at whatever granularity they deem
+appropriate.</p>
+    <h3 class="heading settled" data-level="7.3" id="filling-up-disk"><span class="secno">7.3. </span><span class="content">Filling up a users disk</span><a class="self-link" href="#filling-up-disk"></a></h3>
+    <p>Other than files in the <a data-link-type="dfn" href="#wellknowndirectory-origin-private-file-system" id="ref-for-wellknowndirectory-origin-private-file-system⑧">origin private file system</a>, files written by this API are not subject
+to <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota④">storage quota</a>. As such websites can fill up a users disk without being limited by
+quota, which could leave a users device in a bad state (do note that even with storage that is
+subject to <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota⑤">storage quota</a> it is still possible to fill up, or come close to filling up, a users
+disk, since <a data-link-type="dfn" href="https://storage.spec.whatwg.org/#storage-quota" id="ref-for-storage-quota⑥">storage quota</a> in general is not dependent on the amount of available disk
+space).</p>
+    <p>Without this API websites can write data to disk not subject to quota limitations already
+by triggering downloads of large files (potentially created client side, to not incur any network
+overhead). While the presence of <code class="idl"><a data-link-type="idl" href="#dom-filesystemwritablefilestream-truncate" id="ref-for-dom-filesystemwritablefilestream-truncate③">truncate()</a></code> and writing at a
+potentially really large offset past the end of a file makes it much easier and lower cost to
+create large files, on most file systems such files should not actually take up as much disk space as
+most commonly used file systems support sparse files (and thus wouldn’t actually store the NUL
+bytes generated by resizing a file or seeking past the end of it).</p>
+    <p>Whatever mitigations user agents use to guard against websites filling up a disk via either
+quota managed storage or the existing downloads mechanism should also be employed when websites
+use this API to write to disk.</p>
+   </dl>
+  </main>
+  <div data-fill-with="conformance">
+   <h2 class="no-ref no-num heading settled" id="w3c-conformance"><span class="content">Conformance</span><a class="self-link" href="#w3c-conformance"></a></h2>
+   <h3 class="no-ref no-num heading settled" id="w3c-conventions"><span class="content">Document conventions</span><a class="self-link" href="#w3c-conventions"></a></h3>
+   <p>Conformance requirements are expressed
+    with a combination of descriptive assertions
+    and RFC 2119 terminology.
+    The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL”
+    in the normative parts of this document
+    are to be interpreted as described in RFC 2119.
+    However, for readability,
+    these words do not appear in all uppercase letters in this specification. </p>
+   <p>All of the text of this specification is normative
+    except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a> </p>
+   <p>Examples in this specification are introduced with the words “for example”
+    or are set apart from the normative text
+    with <code>class="example"</code>,
+    like this: </p>
+   <div class="example" id="w3c-example">
+    <a class="self-link" href="#w3c-example"></a> 
+    <p>This is an example of an informative example. </p>
+   </div>
+   <p>Informative notes begin with the word “Note”
+    and are set apart from the normative text
+    with <code>class="note"</code>,
+    like this: </p>
+   <p class="note" role="note">Note, this is an informative note. </p>
+   <h3 class="no-ref no-num heading settled" id="w3c-conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#w3c-conformant-algorithms"></a></h3>
+   <p>Requirements phrased in the imperative as part of algorithms
+    (such as "strip any leading space characters"
+    or "return false and abort these steps")
+    are to be interpreted with the meaning of the key word
+    ("must", "should", "may", etc)
+    used in introducing the algorithm. </p>
+   <p>Conformance requirements phrased as algorithms or specific steps
+    can be implemented in any manner,
+    so long as the end result is equivalent.
+    In particular, the algorithms defined in this specification
+    are intended to be easy to understand
+    and are not intended to be performant.
+    Implementers are encouraged to optimize. </p>
+  </div>
+<script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+  <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="index">
+   <li><a href="#dom-filepickeraccepttype-accept">accept</a><span>, in § 3</span>
+   <li><a href="#enumdef-accesshandlemode">AccessHandleMode</a><span>, in § 2.4</span>
+   <li><a href="#dom-filesystemreadwriteoptions-at">at</a><span>, in § 2.7</span>
+   <li><a href="#file-entry-binary-data">binary data</a><span>, in § 2.1</span>
+   <li><a href="#filesystemwritablefilestream-buffer">[[buffer]]</a><span>, in § 2.6</span>
+   <li><a href="#directory-entry-children">children</a><span>, in § 2.1</span>
+   <li><a href="#dom-filesystemsyncaccesshandle-close">close()</a><span>, in § 2.7.6</span>
+   <li>
+    create
+    <ul>
+     <li><a href="#dom-filesystemgetdirectoryoptions-create">dict-member for FileSystemGetDirectoryOptions</a><span>, in § 2.5</span>
+     <li><a href="#dom-filesystemgetfileoptions-create">dict-member for FileSystemGetFileOptions</a><span>, in § 2.5</span>
+    </ul>
+   <li><a href="#create-a-new-filesystemsyncaccesshandle">create a new FileSystemSyncAccessHandle</a><span>, in § 2.7</span>
+   <li><a href="#create-a-new-filesystemwritablefilestream">create a new FileSystemWritableFileStream</a><span>, in § 2.6</span>
+   <li><a href="#dom-filesystemfilehandle-createsyncaccesshandle">createSyncAccessHandle()</a><span>, in § 2.4.3</span>
+   <li><a href="#dom-filesystemfilehandle-createsyncaccesshandle">createSyncAccessHandle(options)</a><span>, in § 2.4.3</span>
+   <li><a href="#dom-filesystemfilehandle-createwritable">createWritable()</a><span>, in § 2.4.2</span>
+   <li><a href="#dom-filesystemfilehandle-createwritable">createWritable(options)</a><span>, in § 2.4.2</span>
+   <li><a href="#dom-writeparams-data">data</a><span>, in § 2.6</span>
+   <li><a href="#dom-filepickeraccepttype-description">description</a><span>, in § 3</span>
+   <li><a href="#dom-wellknowndirectory-desktop">"desktop"</a><span>, in § 3.2.2</span>
+   <li><a href="#wellknowndirectory-determine-the-directory-the-picker-will-start-in">determine the directory the picker will start in</a><span>, in § 3.2.2</span>
+   <li><a href="#dom-filesystemhandlekind-directory">"directory"</a><span>, in § 2.3</span>
+   <li><a href="#directory">directory</a><span>, in § 2.1</span>
+   <li><a href="#directory">directory entry</a><span>, in § 2.1</span>
+   <li><a href="#dictdef-directorypickeroptions">DirectoryPickerOptions</a><span>, in § 3</span>
+   <li><a href="#dom-wellknowndirectory-documents">"documents"</a><span>, in § 3.2.2</span>
+   <li><a href="#dom-wellknowndirectory-downloads">"downloads"</a><span>, in § 3.2.2</span>
+   <li>
+    entry
+    <ul>
+     <li><a href="#entry">definition of</a><span>, in § 2.1</span>
+     <li><a href="#filesystemhandle-entry">dfn for FileSystemHandle</a><span>, in § 2.3</span>
+    </ul>
+   <li><a href="#dom-filepickeroptions-excludeacceptalloption">excludeAcceptAllOption</a><span>, in § 3</span>
+   <li><a href="#dom-filesystemhandlekind-file">"file"</a><span>, in § 2.3</span>
+   <li>
+    [[file]]
+    <ul>
+     <li><a href="#filesystemsyncaccesshandle-file">dfn for FileSystemSyncAccessHandle</a><span>, in § 2.7</span>
+     <li><a href="#filesystemwritablefilestream-file">dfn for FileSystemWritableFileStream</a><span>, in § 2.6</span>
+    </ul>
+   <li><a href="#file">file</a><span>, in § 2.1</span>
+   <li><a href="#file">file entry</a><span>, in § 2.1</span>
+   <li><a href="#dictdef-filepickeraccepttype">FilePickerAcceptType</a><span>, in § 3</span>
+   <li><a href="#dictdef-filepickeroptions">FilePickerOptions</a><span>, in § 3</span>
+   <li><a href="#dom-permissionname-file-system">"file-system"</a><span>, in § 2.2</span>
+   <li><a href="#dictdef-filesystemcreatewritableoptions">FileSystemCreateWritableOptions</a><span>, in § 2.4</span>
+   <li><a href="#filesystemdirectoryhandle">FileSystemDirectoryHandle</a><span>, in § 2.5</span>
+   <li><a href="#filesystemfilehandle">FileSystemFileHandle</a><span>, in § 2.4</span>
+   <li><a href="#dictdef-filesystemfilehandlecreateaccesshandleoptions">FileSystemFileHandleCreateAccessHandleOptions</a><span>, in § 2.4</span>
+   <li><a href="#dictdef-filesystemgetdirectoryoptions">FileSystemGetDirectoryOptions</a><span>, in § 2.5</span>
+   <li><a href="#dictdef-filesystemgetfileoptions">FileSystemGetFileOptions</a><span>, in § 2.5</span>
+   <li><a href="#filesystemhandle">FileSystemHandle</a><span>, in § 2.3</span>
+   <li><a href="#enumdef-filesystemhandlekind">FileSystemHandleKind</a><span>, in § 2.3</span>
+   <li><a href="#dictdef-filesystemhandlepermissiondescriptor">FileSystemHandlePermissionDescriptor</a><span>, in § 2.3</span>
+   <li><a href="#dictdef-filesystempermissiondescriptor">FileSystemPermissionDescriptor</a><span>, in § 2.2</span>
+   <li><a href="#enumdef-filesystempermissionmode">FileSystemPermissionMode</a><span>, in § 2.2</span>
+   <li><a href="#dictdef-filesystemreadwriteoptions">FilesystemReadWriteOptions</a><span>, in § 2.7</span>
+   <li><a href="#dictdef-filesystemremoveoptions">FileSystemRemoveOptions</a><span>, in § 2.5</span>
+   <li><a href="#filesystemsyncaccesshandle">FileSystemSyncAccessHandle</a><span>, in § 2.7</span>
+   <li><a href="#filesystemwritablefilestream">FileSystemWritableFileStream</a><span>, in § 2.6</span>
+   <li><a href="#typedefdef-filesystemwritechunktype">FileSystemWriteChunkType</a><span>, in § 2.6</span>
+   <li><a href="#dom-filesystemsyncaccesshandle-flush">flush()</a><span>, in § 2.7.5</span>
+   <li><a href="#dom-datatransferitem-getasfilesystemhandle">getAsFileSystemHandle()</a><span>, in § 3.6</span>
+   <li><a href="#dom-storagemanager-getdirectory">getDirectory()</a><span>, in § 4</span>
+   <li><a href="#dom-filesystemdirectoryhandle-getdirectoryhandle">getDirectoryHandle(name)</a><span>, in § 2.5.3</span>
+   <li><a href="#dom-filesystemdirectoryhandle-getdirectoryhandle">getDirectoryHandle(name, options)</a><span>, in § 2.5.3</span>
+   <li><a href="#dom-filesystemfilehandle-getfile">getFile()</a><span>, in § 2.4.1</span>
+   <li><a href="#dom-filesystemdirectoryhandle-getfilehandle">getFileHandle(name)</a><span>, in § 2.5.2</span>
+   <li><a href="#dom-filesystemdirectoryhandle-getfilehandle">getFileHandle(name, options)</a><span>, in § 2.5.2</span>
+   <li><a href="#dom-filesystemsyncaccesshandle-getsize">getSize()</a><span>, in § 2.7.4</span>
+   <li><a href="#dom-filesystempermissiondescriptor-handle">handle</a><span>, in § 2.2</span>
+   <li>
+    id
+    <ul>
+     <li><a href="#dom-directorypickeroptions-id">dict-member for DirectoryPickerOptions</a><span>, in § 3</span>
+     <li><a href="#dom-filepickeroptions-id">dict-member for FilePickerOptions</a><span>, in § 3</span>
+    </ul>
+   <li><a href="#dom-accesshandlemode-in-place">"in-place"</a><span>, in § 2.4</span>
+   <li><a href="#is-allowed-to-show-a-file-picker">is allowed to show a file picker</a><span>, in § 3.1</span>
+   <li><a href="#dom-filesystemhandle-issameentry">isSameEntry(other)</a><span>, in § 2.3.1</span>
+   <li><a href="#dom-filesystemcreatewritableoptions-keepexistingdata">keepExistingData</a><span>, in § 2.4</span>
+   <li><a href="#dom-filesystemhandle-kind">kind</a><span>, in § 2.3</span>
+   <li><a href="#local-file-system-handle-factories">local file system handle factories</a><span>, in § 3</span>
+   <li><a href="#file-entry-lock">lock</a><span>, in § 2.1</span>
+   <li><a href="#wellknowndirectory-malware-scans-and-safe-browsing-checks">malware scans and safe browsing checks</a><span>, in § 7.1</span>
+   <li>
+    mode
+    <ul>
+     <li><a href="#dom-filesystemfilehandlecreateaccesshandleoptions-mode">dict-member for FileSystemFileHandleCreateAccessHandleOptions</a><span>, in § 2.4</span>
+     <li><a href="#dom-filesystemhandlepermissiondescriptor-mode">dict-member for FileSystemHandlePermissionDescriptor</a><span>, in § 2.3</span>
+     <li><a href="#dom-filesystempermissiondescriptor-mode">dict-member for FileSystemPermissionDescriptor</a><span>, in § 2.2</span>
+    </ul>
+   <li><a href="#file-entry-modification-timestamp">modification timestamp</a><span>, in § 2.1</span>
+   <li><a href="#dom-openfilepickeroptions-multiple">multiple</a><span>, in § 3</span>
+   <li><a href="#dom-wellknowndirectory-music">"music"</a><span>, in § 3.2.2</span>
+   <li>
+    name
+    <ul>
+     <li><a href="#dom-filesystemhandle-name">attribute for FileSystemHandle</a><span>, in § 2.3</span>
+     <li><a href="#entry-name">dfn for entry</a><span>, in § 2.1</span>
+    </ul>
+   <li><a href="#dictdef-openfilepickeroptions">OpenFilePickerOptions</a><span>, in § 3</span>
+   <li><a href="#wellknowndirectory-origin-private-file-system">origin private file system</a><span>, in § 4</span>
+   <li><a href="#entry-parent">parent</a><span>, in § 2.1</span>
+   <li><a href="#filesystemdirectoryhandle-iterator-past-results">past results</a><span>, in § 2.5.1</span>
+   <li><a href="#path-id-map">path id map</a><span>, in § 3.2.2</span>
+   <li><a href="#dom-wellknowndirectory-pictures">"pictures"</a><span>, in § 3.2.2</span>
+   <li><a href="#dom-writeparams-position">position</a><span>, in § 2.6</span>
+   <li><a href="#process-accept-types">process accept types</a><span>, in § 3.2.1</span>
+   <li><a href="#querying-file-system-permission">query file system permission</a><span>, in § 2.2</span>
+   <li><a href="#querying-file-system-permission">querying file system permission</a><span>, in § 2.2</span>
+   <li><a href="#dom-filesystemhandle-querypermission">queryPermission()</a><span>, in § 2.3.2</span>
+   <li><a href="#dom-filesystemhandle-querypermission">queryPermission(descriptor)</a><span>, in § 2.3.2</span>
+   <li><a href="#dom-filesystempermissionmode-read">"read"</a><span>, in § 2.2</span>
+   <li><a href="#dom-filesystemsyncaccesshandle-read-buffer-at-position">read(buffer, at: position)</a><span>, in § 2.7.1</span>
+   <li><a href="#dom-filesystemsyncaccesshandle-read">read(buffer, options)</a><span>, in § 2.7</span>
+   <li><a href="#dom-filesystempermissionmode-readwrite">"readwrite"</a><span>, in § 2.2</span>
+   <li><a href="#recently-picked-directory-map">recently picked directory map</a><span>, in § 3.2.2</span>
+   <li><a href="#dom-filesystemremoveoptions-recursive">recursive</a><span>, in § 2.5</span>
+   <li><a href="#file-entry-lock-release">release</a><span>, in § 2.1</span>
+   <li><a href="#wellknowndirectory-remember-a-picked-directory">remember a picked directory</a><span>, in § 3.2.2</span>
+   <li><a href="#dom-filesystemdirectoryhandle-removeentry">removeEntry(name)</a><span>, in § 2.5.4</span>
+   <li><a href="#dom-filesystemdirectoryhandle-removeentry">removeEntry(name, options)</a><span>, in § 2.5.4</span>
+   <li><a href="#requesting-file-system-permission">request file system permission</a><span>, in § 2.2</span>
+   <li><a href="#requesting-file-system-permission">requesting file system permission</a><span>, in § 2.2</span>
+   <li><a href="#dom-filesystemhandle-requestpermission">requestPermission()</a><span>, in § 2.3.3</span>
+   <li><a href="#dom-filesystemhandle-requestpermission">requestPermission(descriptor)</a><span>, in § 2.3.3</span>
+   <li><a href="#entry-resolve">resolve</a><span>, in § 2.1</span>
+   <li><a href="#dom-filesystemdirectoryhandle-resolve">resolve(possibleDescendant)</a><span>, in § 2.5.5</span>
+   <li><a href="#dictdef-savefilepickeroptions">SaveFilePickerOptions</a><span>, in § 3</span>
+   <li><a href="#dom-writecommandtype-seek">"seek"</a><span>, in § 2.6</span>
+   <li><a href="#filesystemwritablefilestream-seekoffset">[[seekOffset]]</a><span>, in § 2.6</span>
+   <li><a href="#dom-filesystemwritablefilestream-seek">seek(position)</a><span>, in § 2.6.2</span>
+   <li><a href="#dom-window-showdirectorypicker">showDirectoryPicker()</a><span>, in § 3.5</span>
+   <li><a href="#dom-window-showdirectorypicker">showDirectoryPicker(options)</a><span>, in § 3.5</span>
+   <li><a href="#dom-window-showopenfilepicker">showOpenFilePicker()</a><span>, in § 3.3</span>
+   <li><a href="#dom-window-showopenfilepicker">showOpenFilePicker(options)</a><span>, in § 3.3</span>
+   <li><a href="#dom-window-showsavefilepicker">showSaveFilePicker()</a><span>, in § 3.4</span>
+   <li><a href="#dom-window-showsavefilepicker">showSaveFilePicker(options)</a><span>, in § 3.4</span>
+   <li><a href="#dom-writeparams-size">size</a><span>, in § 2.6</span>
+   <li>
+    startIn
+    <ul>
+     <li><a href="#dom-directorypickeroptions-startin">dict-member for DirectoryPickerOptions</a><span>, in § 3</span>
+     <li><a href="#dom-filepickeroptions-startin">dict-member for FilePickerOptions</a><span>, in § 3</span>
+    </ul>
+   <li><a href="#typedefdef-startindirectory">StartInDirectory</a><span>, in § 3</span>
+   <li><a href="#dom-savefilepickeroptions-suggestedname">suggestedName</a><span>, in § 3</span>
+   <li><a href="#file-entry-lock-take">take</a><span>, in § 2.1</span>
+   <li><a href="#entry-the-same-as">the same as</a><span>, in § 2.1</span>
+   <li><a href="#wellknowndirectory-too-sensitive-or-dangerous">too sensitive or dangerous</a><span>, in § 6.1</span>
+   <li><a href="#dom-writecommandtype-truncate">"truncate"</a><span>, in § 2.6</span>
+   <li>
+    truncate(size)
+    <ul>
+     <li><a href="#dom-filesystemsyncaccesshandle-truncate">method for FileSystemSyncAccessHandle</a><span>, in § 2.7.3</span>
+     <li><a href="#dom-filesystemwritablefilestream-truncate">method for FileSystemWritableFileStream</a><span>, in § 2.6.3</span>
+    </ul>
+   <li><a href="#dom-writeparams-type">type</a><span>, in § 2.6</span>
+   <li><a href="#dom-filepickeroptions-types">types</a><span>, in § 3</span>
+   <li><a href="#validate-a-suffix">validate a suffix</a><span>, in § 3.2.1</span>
+   <li><a href="#valid-file-name">valid file name</a><span>, in § 2.1</span>
+   <li><a href="#valid-path-id">valid path id</a><span>, in § 3.2.2</span>
+   <li><a href="#valid-suffix-code-point">valid suffix code point</a><span>, in § 2.1</span>
+   <li><a href="#dom-wellknowndirectory-videos">"videos"</a><span>, in § 3.2.2</span>
+   <li><a href="#enumdef-wellknowndirectory">WellKnownDirectory</a><span>, in § 3.2.2</span>
+   <li><a href="#dom-writecommandtype-write">"write"</a><span>, in § 2.6</span>
+   <li><a href="#write-a-chunk">write a chunk</a><span>, in § 2.6</span>
+   <li><a href="#dom-filesystemsyncaccesshandle-write-buffer-at-position">write(buffer, at: position)</a><span>, in § 2.7.2</span>
+   <li><a href="#dom-filesystemsyncaccesshandle-write">write(buffer, options)</a><span>, in § 2.7</span>
+   <li><a href="#enumdef-writecommandtype">WriteCommandType</a><span>, in § 2.6</span>
+   <li><a href="#dom-filesystemwritablefilestream-write">write(data)</a><span>, in § 2.6.1</span>
+   <li><a href="#dictdef-writeparams">WriteParams</a><span>, in § 2.6</span>
+  </ul>
+  <aside class="dfn-panel" data-for="term-for-realm">
+   <a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-realm">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-realm①">2.7. The FileSystemSyncAccessHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-utf-8-encode">
+   <a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-utf-8-encode">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-Blob">
+   <a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-Blob">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dfn-Blob①">(2)</a> <a href="#ref-for-dfn-Blob②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-file">
+   <a href="https://w3c.github.io/FileAPI/#dfn-file">https://w3c.github.io/FileAPI/#dfn-file</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-file">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-dfn-file①">2.4.1. The getFile() method</a> <a href="#ref-for-dfn-file②">(2)</a> <a href="#ref-for-dfn-file③">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-lastModified">
+   <a href="https://w3c.github.io/FileAPI/#dfn-lastModified">https://w3c.github.io/FileAPI/#dfn-lastModified</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-lastModified">2.4.1. The getFile() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-name">
+   <a href="https://w3c.github.io/FileAPI/#dfn-name">https://w3c.github.io/FileAPI/#dfn-name</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-name">2.4.1. The getFile() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-readOperation">
+   <a href="https://w3c.github.io/FileAPI/#readOperation">https://w3c.github.io/FileAPI/#readOperation</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-readOperation">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-snapshot-state">
+   <a href="https://w3c.github.io/FileAPI/#snapshot-state">https://w3c.github.io/FileAPI/#snapshot-state</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-snapshot-state">2.4.1. The getFile() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-type">
+   <a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-type">2.4.1. The getFile() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-UnixEpoch">
+   <a href="https://w3c.github.io/FileAPI/#UnixEpoch">https://w3c.github.io/FileAPI/#UnixEpoch</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-UnixEpoch">2.1. Concepts</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-datatransferitem">
+   <a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem">https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-datatransferitem">3.6. Drag and Drop</a> <a href="#ref-for-datatransferitem①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-serializable">
+   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable">https://html.spec.whatwg.org/multipage/structured-data.html#serializable</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-serializable">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-serializable①">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-serializable②">2.5. The FileSystemDirectoryHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-window">
+   <a href="https://html.spec.whatwg.org/multipage/window-object.html#window">https://html.spec.whatwg.org/multipage/window-object.html#window</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-window">2.2. Permissions</a>
+    <li><a href="#ref-for-window①">3. Accessing Local File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-activation-notification">
+   <a href="https://html.spec.whatwg.org/multipage/interaction.html#activation-notification">https://html.spec.whatwg.org/multipage/interaction.html#activation-notification</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-activation-notification">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-activation-notification①">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-activation-notification②">3.5. The showDirectoryPicker() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-as-a-download">
+   <a href="https://html.spec.whatwg.org/multipage/links.html#as-a-download">https://html.spec.whatwg.org/multipage/links.html#as-a-download</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-as-a-download">3.4. The showSaveFilePicker() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-window-bc">
+   <a href="https://html.spec.whatwg.org/multipage/window-object.html#window-bc">https://html.spec.whatwg.org/multipage/window-object.html#window-bc</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-window-bc">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-window-bc①">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-window-bc②">3.5. The showDirectoryPicker() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-current-settings-object">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-current-settings-object">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-deserialization-steps">
+   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-deserialization-steps">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-deserialization-steps①">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-deserialization-steps②">2.5. The FileSystemDirectoryHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-environment-settings-object">3.2.2. Starting Directory</a> <a href="#ref-for-environment-settings-object①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-settings-object-global">2.2. Permissions</a>
+    <li><a href="#ref-for-concept-settings-object-global①">3.1. Local File System Permissions</a>
+    <li><a href="#ref-for-concept-settings-object-global②">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-concept-settings-object-global③">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-concept-settings-object-global④">3.5. The showDirectoryPicker() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-in-parallel">
+   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-in-parallel">2.1. Concepts</a> <a href="#ref-for-in-parallel①">(2)</a>
+    <li><a href="#ref-for-in-parallel②">2.3.1. The isSameEntry() method</a>
+    <li><a href="#ref-for-in-parallel③">2.3.2. The queryPermission() method</a>
+    <li><a href="#ref-for-in-parallel④">2.3.3. The requestPermission() method</a>
+    <li><a href="#ref-for-in-parallel⑤">2.4.1. The getFile() method</a>
+    <li><a href="#ref-for-in-parallel⑥">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-in-parallel⑦">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-in-parallel⑧">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-in-parallel⑨">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-in-parallel①⓪">2.5.4. The removeEntry() method</a>
+    <li><a href="#ref-for-in-parallel①①">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-in-parallel①②">(2)</a>
+    <li><a href="#ref-for-in-parallel①③">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-in-parallel①④">(2)</a>
+    <li><a href="#ref-for-in-parallel①⑤">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-in-parallel①⑥">(2)</a>
+    <li><a href="#ref-for-in-parallel①⑦">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-in-parallel①⑧">(2)</a>
+    <li><a href="#ref-for-in-parallel①⑨">3.6. Drag and Drop</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-event-messageerror">
+   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-messageerror">https://html.spec.whatwg.org/multipage/indices.html#event-messageerror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-event-messageerror">6.3. First-party vs third-party contexts.</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
+   <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-origin-opaque">3.1. Local File System Permissions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-settings-object-origin">2.2. Permissions</a>
+    <li><a href="#ref-for-concept-settings-object-origin①">2.3. The FileSystemHandle interface</a> <a href="#ref-for-concept-settings-object-origin②">(2)</a>
+    <li><a href="#ref-for-concept-settings-object-origin③">3.1. Local File System Permissions</a> <a href="#ref-for-concept-settings-object-origin④">(2)</a>
+    <li><a href="#ref-for-concept-settings-object-origin⑤">3.2.2. Starting Directory</a> <a href="#ref-for-concept-settings-object-origin⑥">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-dnd-ro">
+   <a href="https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-ro">https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-ro</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-dnd-ro">3.6. Drag and Drop</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-dnd-rw">
+   <a href="https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-rw">https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-rw</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-dnd-rw">3.6. Drag and Drop</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-relevant-realm">2.3.1. The isSameEntry() method</a>
+    <li><a href="#ref-for-concept-relevant-realm①">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-concept-relevant-realm②">2.4.3. The createSyncAccessHandle() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-relevant-settings-object">2.2. Permissions</a>
+    <li><a href="#ref-for-relevant-settings-object①">2.3. The FileSystemHandle interface</a> <a href="#ref-for-relevant-settings-object②">(2)</a>
+    <li><a href="#ref-for-relevant-settings-object③">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-relevant-settings-object④">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-relevant-settings-object⑤">3.5. The showDirectoryPicker() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-same-origin">
+   <a href="https://html.spec.whatwg.org/multipage/origin.html#same-origin">https://html.spec.whatwg.org/multipage/origin.html#same-origin</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-same-origin">2.2. Permissions</a>
+    <li><a href="#ref-for-same-origin①">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-same-origin②">3.1. Local File System Permissions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-serializable-objects">
+   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects">https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-serializable-objects">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-serializable-objects①">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-serializable-objects②">2.5. The FileSystemDirectoryHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-serialization-steps">
+   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-serialization-steps">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-serialization-steps①">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-serialization-steps②">2.5. The FileSystemDirectoryHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-drag-data-item-kind">
+   <a href="https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-item-kind">https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-item-kind</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-drag-data-item-kind">3.6. Drag and Drop</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-environment-top-level-origin">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-environment-top-level-origin">2.2. Permissions</a>
+    <li><a href="#ref-for-concept-environment-top-level-origin①">3.1. Local File System Permissions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-transient-activation">
+   <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-transient-activation">2.2. Permissions</a>
+    <li><a href="#ref-for-transient-activation①">3.1. Local File System Permissions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-set-append">
+   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-set-append">2.5.1. Directory iteration</a>
+    <li><a href="#ref-for-set-append①">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-set-append②">2.5.3. The getDirectoryHandle() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-ascii-alphanumeric">
+   <a href="https://infra.spec.whatwg.org/#ascii-alphanumeric">https://infra.spec.whatwg.org/#ascii-alphanumeric</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-ascii-alphanumeric">2.1. Concepts</a>
+    <li><a href="#ref-for-ascii-alphanumeric①">3.2.2. Starting Directory</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-assert">
+   <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-assert">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-byte-sequence">
+   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-byte-sequence">2.1. Concepts</a>
+    <li><a href="#ref-for-byte-sequence①">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-byte-sequence②">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-byte-sequence③">(2)</a> <a href="#ref-for-byte-sequence④">(3)</a> <a href="#ref-for-byte-sequence⑤">(4)</a> <a href="#ref-for-byte-sequence⑥">(5)</a> <a href="#ref-for-byte-sequence⑦">(6)</a> <a href="#ref-for-byte-sequence⑧">(7)</a>
+    <li><a href="#ref-for-byte-sequence⑨">3.4. The showSaveFilePicker() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-code-point">
+   <a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-code-point">2.1. Concepts</a>
+    <li><a href="#ref-for-code-point①">3.2.1. Accepted file types</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list-contain">
+   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list-contain">2.1. Concepts</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-javascript-string-convert">
+   <a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-javascript-string-convert">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list-empty">
+   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list-empty">3.2.1. Accepted file types</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-map-exists">
+   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-map-exists">3.2.2. Starting Directory</a> <a href="#ref-for-map-exists①">(2)</a> <a href="#ref-for-map-exists②">(3)</a> <a href="#ref-for-map-exists③">(4)</a> <a href="#ref-for-map-exists④">(5)</a>
+    <li><a href="#ref-for-map-exists⑤">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-map-iterate">
+   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-map-iterate">3.2.1. Accepted file types</a> <a href="#ref-for-map-iterate①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-implementation-defined">
+   <a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-implementation-defined">3.2.2. Starting Directory</a>
+    <li><a href="#ref-for-implementation-defined①">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-implementation-defined②">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-implementation-defined③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list-is-empty">
+   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list-is-empty">2.5.4. The removeEntry() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-string-length">
+   <a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-string-length">3.2.1. Accepted file types</a>
+    <li><a href="#ref-for-string-length①">3.2.2. Starting Directory</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list">
+   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list">3.2.1. Accepted file types</a>
+    <li><a href="#ref-for-list①">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-list②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-ordered-map">
+   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-ordered-map">3.2.2. Starting Directory</a> <a href="#ref-for-ordered-map①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list-prepend">
+   <a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list-prepend">2.1. Concepts</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list-remove">
+   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list-remove">2.5.4. The removeEntry() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-ordered-set">
+   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-ordered-set">2.1. Concepts</a>
+    <li><a href="#ref-for-ordered-set①">2.5.1. Directory iteration</a>
+    <li><a href="#ref-for-ordered-set②">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-ordered-set③">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-string-starts-with">
+   <a href="https://infra.spec.whatwg.org/#string-starts-with">https://infra.spec.whatwg.org/#string-starts-with</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-string-starts-with">3.2.1. Accepted file types</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-string">
+   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-string">2.1. Concepts</a> <a href="#ref-for-string①">(2)</a>
+    <li><a href="#ref-for-string②">3.2.1. Accepted file types</a>
+    <li><a href="#ref-for-string③">3.2.2. Starting Directory</a> <a href="#ref-for-string④">(2)</a> <a href="#ref-for-string⑤">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-mime-type-essence">
+   <a href="https://mimesniff.spec.whatwg.org/#mime-type-essence">https://mimesniff.spec.whatwg.org/#mime-type-essence</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mime-type-essence">3.2.1. Accepted file types</a> <a href="#ref-for-mime-type-essence①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-mime-type">
+   <a href="https://mimesniff.spec.whatwg.org/#mime-type">https://mimesniff.spec.whatwg.org/#mime-type</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mime-type">3.2.1. Accepted file types</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-parameters">
+   <a href="https://mimesniff.spec.whatwg.org/#parameters">https://mimesniff.spec.whatwg.org/#parameters</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-parameters">3.2.1. Accepted file types</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-parse-a-mime-type">
+   <a href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type">https://mimesniff.spec.whatwg.org/#parse-a-mime-type</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-parse-a-mime-type">3.2.1. Accepted file types</a> <a href="#ref-for-parse-a-mime-type①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-subtype">
+   <a href="https://mimesniff.spec.whatwg.org/#subtype">https://mimesniff.spec.whatwg.org/#subtype</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-subtype">3.2.1. Accepted file types</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-type">
+   <a href="https://mimesniff.spec.whatwg.org/#type">https://mimesniff.spec.whatwg.org/#type</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-type">3.2.1. Accepted file types</a> <a href="#ref-for-type①">(2)</a> <a href="#ref-for-type②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor">
+   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-permissiondescriptor">2.2. Permissions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-permissionstate">
+   <a href="https://w3c.github.io/permissions/#dom-permissionstate">https://w3c.github.io/permissions/#dom-permissionstate</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-permissionstate">2.3. The FileSystemHandle interface</a> <a href="#ref-for-dom-permissionstate①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-permissionstatus">
+   <a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-permissionstatus">2.2. Permissions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-create-a-permissionstatus">
+   <a href="https://w3c.github.io/permissions/#dfn-create-a-permissionstatus">https://w3c.github.io/permissions/#dfn-create-a-permissionstatus</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-create-a-permissionstatus">2.2. Permissions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-granted">
+   <a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-permissionstate-granted">2.2. Permissions</a> <a href="#ref-for-dom-permissionstate-granted①">(2)</a>
+    <li><a href="#ref-for-dom-permissionstate-granted②">2.4.1. The getFile() method</a>
+    <li><a href="#ref-for-dom-permissionstate-granted③">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-dom-permissionstate-granted④">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-dom-permissionstate-granted⑤">2.5.1. Directory iteration</a> <a href="#ref-for-dom-permissionstate-granted⑥">(2)</a>
+    <li><a href="#ref-for-dom-permissionstate-granted⑦">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-dom-permissionstate-granted⑧">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-dom-permissionstate-granted⑨">2.5.4. The removeEntry() method</a>
+    <li><a href="#ref-for-dom-permissionstate-granted①⓪">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dom-permissionstate-granted①①">(2)</a>
+    <li><a href="#ref-for-dom-permissionstate-granted①②">3.1. Local File System Permissions</a> <a href="#ref-for-dom-permissionstate-granted①③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor-name">
+   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-permissiondescriptor-name">2.2. Permissions</a> <a href="#ref-for-dom-permissiondescriptor-name①">(2)</a>
+    <li><a href="#ref-for-dom-permissiondescriptor-name②">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-permissiondescriptor-name③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type">
+   <a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-permission-descriptor-type">2.2. Permissions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-permission-state">
+   <a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-permission-state">2.2. Permissions</a> <a href="#ref-for-dfn-permission-state①">(2)</a> <a href="#ref-for-dfn-permission-state②">(3)</a> <a href="#ref-for-dfn-permission-state③">(4)</a> <a href="#ref-for-dfn-permission-state④">(5)</a> <a href="#ref-for-dfn-permission-state⑤">(6)</a> <a href="#ref-for-dfn-permission-state⑥">(7)</a>
+    <li><a href="#ref-for-dfn-permission-state⑦">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dfn-permission-state⑧">(2)</a>
+    <li><a href="#ref-for-dfn-permission-state⑨">3.1. Local File System Permissions</a> <a href="#ref-for-dfn-permission-state①⓪">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-permission-state-constraints">
+   <a href="https://w3c.github.io/permissions/#dfn-permission-state-constraints">https://w3c.github.io/permissions/#dfn-permission-state-constraints</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-permission-state-constraints">2.2. Permissions</a> <a href="#ref-for-dfn-permission-state-constraints①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-navigator-permissions">
+   <a href="https://w3c.github.io/permissions/#dom-navigator-permissions">https://w3c.github.io/permissions/#dom-navigator-permissions</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-navigator-permissions">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-navigator-permissions①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-powerful-feature">
+   <a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-powerful-feature">2.2. Permissions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-prompt">
+   <a href="https://w3c.github.io/permissions/#dom-permissionstate-prompt">https://w3c.github.io/permissions/#dom-permissionstate-prompt</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-permissionstate-prompt">2.2. Permissions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-permissions-query">
+   <a href="https://w3c.github.io/permissions/#dom-permissions-query">https://w3c.github.io/permissions/#dom-permissions-query</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-permissions-query">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-permissions-query①">(2)</a> <a href="#ref-for-dom-permissions-query②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-request-permission-to-use">
+   <a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-request-permission-to-use">2.2. Permissions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-permissionstatus-state">
+   <a href="https://w3c.github.io/permissions/#dom-permissionstatus-state">https://w3c.github.io/permissions/#dom-permissionstatus-state</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-permissionstatus-state">2.2. Permissions</a>
+    <li><a href="#ref-for-dom-permissionstatus-state①">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-permissionstatus-state②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-permission-request-algorithm">
+   <a href="https://wicg.github.io/permissions-request/#permission-request-algorithm">https://wicg.github.io/permissions-request/#permission-request-algorithm</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-permission-request-algorithm">2.2. Permissions</a> <a href="#ref-for-permission-request-algorithm①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-storagemanager">
+   <a href="https://storage.spec.whatwg.org/#storagemanager">https://storage.spec.whatwg.org/#storagemanager</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-storagemanager">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-storage-endpoint-identifier">
+   <a href="https://storage.spec.whatwg.org/#storage-endpoint-identifier">https://storage.spec.whatwg.org/#storage-endpoint-identifier</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-storage-endpoint-identifier">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-obtain-a-local-storage-bottle-map">
+   <a href="https://storage.spec.whatwg.org/#obtain-a-local-storage-bottle-map">https://storage.spec.whatwg.org/#obtain-a-local-storage-bottle-map</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-obtain-a-local-storage-bottle-map">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-storage-endpoint-quota">
+   <a href="https://storage.spec.whatwg.org/#storage-endpoint-quota">https://storage.spec.whatwg.org/#storage-endpoint-quota</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-storage-endpoint-quota">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-site-storage">
+   <a href="https://storage.spec.whatwg.org/#site-storage">https://storage.spec.whatwg.org/#site-storage</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-site-storage">6.1. Users giving access to more, or more sensitive files than they intended.</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-storage-endpoint">
+   <a href="https://storage.spec.whatwg.org/#storage-endpoint">https://storage.spec.whatwg.org/#storage-endpoint</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-storage-endpoint">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-storage-quota">
+   <a href="https://storage.spec.whatwg.org/#storage-quota">https://storage.spec.whatwg.org/#storage-quota</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-storage-quota">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-storage-quota①">(2)</a> <a href="#ref-for-storage-quota②">(3)</a> <a href="#ref-for-storage-quota③">(4)</a>
+    <li><a href="#ref-for-storage-quota④">7.3. Filling up a users disk</a> <a href="#ref-for-storage-quota⑤">(2)</a> <a href="#ref-for-storage-quota⑥">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-storage-endpoint-types">
+   <a href="https://storage.spec.whatwg.org/#storage-endpoint-types">https://storage.spec.whatwg.org/#storage-endpoint-types</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-storage-endpoint-types">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-readablestream">
+   <a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-readablestream">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-writablestream">
+   <a href="https://streams.spec.whatwg.org/#writablestream">https://streams.spec.whatwg.org/#writablestream</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-writablestream">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-writablestream①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-writablestreamdefaultwriter">
+   <a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter">https://streams.spec.whatwg.org/#writablestreamdefaultwriter</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-writablestreamdefaultwriter">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-writablestream-set-up-closealgorithm">
+   <a href="https://streams.spec.whatwg.org/#writablestream-set-up-closealgorithm">https://streams.spec.whatwg.org/#writablestream-set-up-closealgorithm</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-writablestream-set-up-closealgorithm">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-ws-get-writer">
+   <a href="https://streams.spec.whatwg.org/#ws-get-writer">https://streams.spec.whatwg.org/#ws-get-writer</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-ws-get-writer">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-writablestream-get-a-writer">
+   <a href="https://streams.spec.whatwg.org/#writablestream-get-a-writer">https://streams.spec.whatwg.org/#writablestream-get-a-writer</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-writablestream-get-a-writer">2.6.1. The write() method</a>
+    <li><a href="#ref-for-writablestream-get-a-writer①">2.6.2. The seek() method</a>
+    <li><a href="#ref-for-writablestream-get-a-writer②">2.6.3. The truncate() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-writablestream-set-up-highwatermark">
+   <a href="https://streams.spec.whatwg.org/#writablestream-set-up-highwatermark">https://streams.spec.whatwg.org/#writablestream-set-up-highwatermark</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-writablestream-set-up-highwatermark">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-writablestreamdefaultwriter-release">
+   <a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-release">https://streams.spec.whatwg.org/#writablestreamdefaultwriter-release</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-writablestreamdefaultwriter-release">2.6.1. The write() method</a>
+    <li><a href="#ref-for-writablestreamdefaultwriter-release①">2.6.2. The seek() method</a>
+    <li><a href="#ref-for-writablestreamdefaultwriter-release②">2.6.3. The truncate() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-writablestream-set-up">
+   <a href="https://streams.spec.whatwg.org/#writablestream-set-up">https://streams.spec.whatwg.org/#writablestream-set-up</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-writablestream-set-up">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-writablestream-set-up-sizealgorithm">
+   <a href="https://streams.spec.whatwg.org/#writablestream-set-up-sizealgorithm">https://streams.spec.whatwg.org/#writablestream-set-up-sizealgorithm</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-writablestream-set-up-sizealgorithm">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-default-writer-write">
+   <a href="https://streams.spec.whatwg.org/#default-writer-write">https://streams.spec.whatwg.org/#default-writer-write</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-default-writer-write">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-default-writer-write①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-writablestream-set-up-writealgorithm">
+   <a href="https://streams.spec.whatwg.org/#writablestream-set-up-writealgorithm">https://streams.spec.whatwg.org/#writablestream-set-up-writealgorithm</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-writablestream-set-up-writealgorithm">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-writablestreamdefaultwriter-write-a-chunk">
+   <a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-write-a-chunk">https://streams.spec.whatwg.org/#writablestreamdefaultwriter-write-a-chunk</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-writablestreamdefaultwriter-write-a-chunk">2.6.1. The write() method</a>
+    <li><a href="#ref-for-writablestreamdefaultwriter-write-a-chunk①">2.6.2. The seek() method</a>
+    <li><a href="#ref-for-writablestreamdefaultwriter-write-a-chunk②">2.6.3. The truncate() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-aborterror">
+   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-aborterror">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-aborterror①">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-aborterror②">(2)</a>
+    <li><a href="#ref-for-aborterror③">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-aborterror④">(2)</a>
+    <li><a href="#ref-for-aborterror⑤">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-aborterror⑥">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-AllowShared">
+   <a href="https://webidl.spec.whatwg.org/#AllowShared">https://webidl.spec.whatwg.org/#AllowShared</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-AllowShared">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-AllowShared①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-BufferSource">
+   <a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-BufferSource">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-BufferSource①">(2)</a> <a href="#ref-for-BufferSource②">(3)</a>
+    <li><a href="#ref-for-BufferSource③">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-BufferSource④">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
+   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-DOMString">3. Accessing Local File System</a> <a href="#ref-for-idl-DOMString①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-datacloneerror">
+   <a href="https://webidl.spec.whatwg.org/#datacloneerror">https://webidl.spec.whatwg.org/#datacloneerror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-datacloneerror">2.3. The FileSystemHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-EnforceRange">
+   <a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-EnforceRange">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-EnforceRange①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-Exposed">
+   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-Exposed">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-Exposed①">2.4. The FileSystemFileHandle interface</a> <a href="#ref-for-Exposed②">(2)</a>
+    <li><a href="#ref-for-Exposed③">2.5. The FileSystemDirectoryHandle interface</a>
+    <li><a href="#ref-for-Exposed④">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-Exposed⑤">2.7. The FileSystemSyncAccessHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-invalidmodificationerror">
+   <a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-invalidmodificationerror">2.5.4. The removeEntry() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
+   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-invalidstateerror">2.4.3. The createSyncAccessHandle() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-nomodificationallowederror">
+   <a href="https://webidl.spec.whatwg.org/#nomodificationallowederror">https://webidl.spec.whatwg.org/#nomodificationallowederror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-nomodificationallowederror">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-nomodificationallowederror①">2.4.3. The createSyncAccessHandle() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-notallowederror">
+   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-notallowederror">2.4.1. The getFile() method</a>
+    <li><a href="#ref-for-notallowederror①">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-notallowederror②">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-notallowederror③">2.5.1. Directory iteration</a> <a href="#ref-for-notallowederror④">(2)</a>
+    <li><a href="#ref-for-notallowederror⑤">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-notallowederror⑥">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-notallowederror⑦">2.5.4. The removeEntry() method</a>
+    <li><a href="#ref-for-notallowederror⑧">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-notallowederror⑨">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-notfounderror">
+   <a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-notfounderror">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-notfounderror①">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-notfounderror②">2.5.4. The removeEntry() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-promise">
+   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-promise">2.3. The FileSystemHandle interface</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a>
+    <li><a href="#ref-for-idl-promise③">2.4. The FileSystemFileHandle interface</a> <a href="#ref-for-idl-promise④">(2)</a> <a href="#ref-for-idl-promise⑤">(3)</a>
+    <li><a href="#ref-for-idl-promise⑥">2.5. The FileSystemDirectoryHandle interface</a> <a href="#ref-for-idl-promise⑦">(2)</a> <a href="#ref-for-idl-promise⑧">(3)</a> <a href="#ref-for-idl-promise⑨">(4)</a>
+    <li><a href="#ref-for-idl-promise①⓪">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-idl-promise①①">(2)</a> <a href="#ref-for-idl-promise①②">(3)</a>
+    <li><a href="#ref-for-idl-promise①③">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-idl-promise①④">(2)</a> <a href="#ref-for-idl-promise①⑤">(3)</a> <a href="#ref-for-idl-promise①⑥">(4)</a>
+    <li><a href="#ref-for-idl-promise①⑦">3. Accessing Local File System</a> <a href="#ref-for-idl-promise①⑧">(2)</a> <a href="#ref-for-idl-promise①⑨">(3)</a>
+    <li><a href="#ref-for-idl-promise②⓪">3.6. Drag and Drop</a>
+    <li><a href="#ref-for-idl-promise②①">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-quotaexceedederror">
+   <a href="https://webidl.spec.whatwg.org/#quotaexceedederror">https://webidl.spec.whatwg.org/#quotaexceedederror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-quotaexceedederror">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-quotaexceedederror①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-SecureContext">
+   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-SecureContext">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-SecureContext①">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-SecureContext②">2.5. The FileSystemDirectoryHandle interface</a>
+    <li><a href="#ref-for-SecureContext③">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-SecureContext④">2.7. The FileSystemSyncAccessHandle interface</a>
+    <li><a href="#ref-for-SecureContext⑤">3. Accessing Local File System</a>
+    <li><a href="#ref-for-SecureContext⑥">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-securityerror">
+   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-securityerror">2.2. Permissions</a> <a href="#ref-for-securityerror①">(2)</a> <a href="#ref-for-securityerror②">(3)</a>
+    <li><a href="#ref-for-securityerror③">3.1. Local File System Permissions</a> <a href="#ref-for-securityerror④">(2)</a> <a href="#ref-for-securityerror⑤">(3)</a>
+    <li><a href="#ref-for-securityerror⑥">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
+   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-exceptiondef-typeerror">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-exceptiondef-typeerror①">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-exceptiondef-typeerror②">2.5.4. The removeEntry() method</a>
+    <li><a href="#ref-for-exceptiondef-typeerror③">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-exceptiondef-typeerror④">(2)</a> <a href="#ref-for-exceptiondef-typeerror⑤">(3)</a>
+    <li><a href="#ref-for-exceptiondef-typeerror⑥">3.2.1. Accepted file types</a> <a href="#ref-for-exceptiondef-typeerror⑦">(2)</a> <a href="#ref-for-exceptiondef-typeerror⑧">(3)</a> <a href="#ref-for-exceptiondef-typeerror⑨">(4)</a> <a href="#ref-for-exceptiondef-typeerror①⓪">(5)</a> <a href="#ref-for-exceptiondef-typeerror①①">(6)</a> <a href="#ref-for-exceptiondef-typeerror①②">(7)</a>
+    <li><a href="#ref-for-exceptiondef-typeerror①③">3.2.2. Starting Directory</a> <a href="#ref-for-exceptiondef-typeerror①④">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-typemismatcherror">
+   <a href="https://webidl.spec.whatwg.org/#typemismatcherror">https://webidl.spec.whatwg.org/#typemismatcherror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-typemismatcherror">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-typemismatcherror①">2.5.3. The getDirectoryHandle() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-USVString">
+   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-USVString">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-idl-USVString①">2.5. The FileSystemDirectoryHandle interface</a> <a href="#ref-for-idl-USVString②">(2)</a> <a href="#ref-for-idl-USVString③">(3)</a> <a href="#ref-for-idl-USVString④">(4)</a> <a href="#ref-for-idl-USVString⑤">(5)</a>
+    <li><a href="#ref-for-idl-USVString⑥">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-idl-USVString⑦">(2)</a> <a href="#ref-for-idl-USVString⑧">(3)</a>
+    <li><a href="#ref-for-idl-USVString⑨">3. Accessing Local File System</a> <a href="#ref-for-idl-USVString①⓪">(2)</a> <a href="#ref-for-idl-USVString①①">(3)</a> <a href="#ref-for-idl-USVString①②">(4)</a> <a href="#ref-for-idl-USVString①③">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-a-new-promise">
+   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-a-new-promise">2.1. Concepts</a> <a href="#ref-for-a-new-promise①">(2)</a>
+    <li><a href="#ref-for-a-new-promise②">2.3.1. The isSameEntry() method</a>
+    <li><a href="#ref-for-a-new-promise③">2.3.2. The queryPermission() method</a>
+    <li><a href="#ref-for-a-new-promise④">2.3.3. The requestPermission() method</a>
+    <li><a href="#ref-for-a-new-promise⑤">2.4.1. The getFile() method</a>
+    <li><a href="#ref-for-a-new-promise⑥">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-a-new-promise⑦">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-a-new-promise⑧">2.5.1. Directory iteration</a>
+    <li><a href="#ref-for-a-new-promise⑨">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-a-new-promise①⓪">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-a-new-promise①①">2.5.4. The removeEntry() method</a>
+    <li><a href="#ref-for-a-new-promise①②">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-a-new-promise①③">(2)</a>
+    <li><a href="#ref-for-a-new-promise①④">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-a-new-promise①⑤">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-a-new-promise①⑥">3.5. The showDirectoryPicker() method</a>
+    <li><a href="#ref-for-a-new-promise①⑦">3.6. Drag and Drop</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
+   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-a-promise-rejected-with">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-a-promise-rejected-with①">3.1. Local File System Permissions</a> <a href="#ref-for-a-promise-rejected-with②">(2)</a>
+    <li><a href="#ref-for-a-promise-rejected-with③">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-a-promise-resolved-with">
+   <a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-a-promise-resolved-with">3.6. Drag and Drop</a> <a href="#ref-for-a-promise-resolved-with①">(2)</a>
+    <li><a href="#ref-for-a-promise-resolved-with②">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-asynchronous-iterator-initialization-steps">
+   <a href="https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps">https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-asynchronous-iterator-initialization-steps">2.5.1. Directory iteration</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-boolean">
+   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-boolean">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-idl-boolean①">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-idl-boolean②">2.5. The FileSystemDirectoryHandle interface</a> <a href="#ref-for-idl-boolean③">(2)</a> <a href="#ref-for-idl-boolean④">(3)</a>
+    <li><a href="#ref-for-idl-boolean⑤">3. Accessing Local File System</a> <a href="#ref-for-idl-boolean⑥">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy">
+   <a href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-get-buffer-source-copy">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-get-the-next-iteration-result">
+   <a href="https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result">https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-get-the-next-iteration-result">2.5.1. Directory iteration</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-new">
+   <a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-new">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-new①">2.7. The FileSystemSyncAccessHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-record">
+   <a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-record">3. Accessing Local File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-reject">
+   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-reject">2.1. Concepts</a> <a href="#ref-for-reject①">(2)</a>
+    <li><a href="#ref-for-reject②">2.3.3. The requestPermission() method</a>
+    <li><a href="#ref-for-reject③">2.4.2. The createWritable() method</a> <a href="#ref-for-reject④">(2)</a>
+    <li><a href="#ref-for-reject⑤">2.4.3. The createSyncAccessHandle() method</a> <a href="#ref-for-reject⑥">(2)</a>
+    <li><a href="#ref-for-reject⑦">2.5.2. The getFileHandle() method</a> <a href="#ref-for-reject⑧">(2)</a> <a href="#ref-for-reject⑨">(3)</a> <a href="#ref-for-reject①⓪">(4)</a> <a href="#ref-for-reject①①">(5)</a>
+    <li><a href="#ref-for-reject①②">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-reject①③">(2)</a> <a href="#ref-for-reject①④">(3)</a> <a href="#ref-for-reject①⑤">(4)</a> <a href="#ref-for-reject①⑥">(5)</a>
+    <li><a href="#ref-for-reject①⑦">2.5.4. The removeEntry() method</a> <a href="#ref-for-reject①⑧">(2)</a> <a href="#ref-for-reject①⑨">(3)</a> <a href="#ref-for-reject②⓪">(4)</a> <a href="#ref-for-reject②①">(5)</a>
+    <li><a href="#ref-for-reject②②">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-reject②③">(2)</a> <a href="#ref-for-reject②④">(3)</a> <a href="#ref-for-reject②⑤">(4)</a> <a href="#ref-for-reject②⑥">(5)</a> <a href="#ref-for-reject②⑦">(6)</a> <a href="#ref-for-reject②⑧">(7)</a>
+    <li><a href="#ref-for-reject②⑨">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-reject③⓪">(2)</a>
+    <li><a href="#ref-for-reject③①">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-reject③②">(2)</a>
+    <li><a href="#ref-for-reject③③">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-reject③④">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-resolve">
+   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-resolve">2.1. Concepts</a> <a href="#ref-for-resolve①">(2)</a> <a href="#ref-for-resolve②">(3)</a> <a href="#ref-for-resolve③">(4)</a> <a href="#ref-for-resolve④">(5)</a> <a href="#ref-for-resolve⑤">(6)</a>
+    <li><a href="#ref-for-resolve⑥">2.3.1. The isSameEntry() method</a> <a href="#ref-for-resolve⑦">(2)</a>
+    <li><a href="#ref-for-resolve⑧">2.3.2. The queryPermission() method</a>
+    <li><a href="#ref-for-resolve⑨">2.3.3. The requestPermission() method</a>
+    <li><a href="#ref-for-resolve①⓪">2.4.1. The getFile() method</a>
+    <li><a href="#ref-for-resolve①①">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-resolve①②">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-resolve①③">2.5.1. Directory iteration</a> <a href="#ref-for-resolve①④">(2)</a>
+    <li><a href="#ref-for-resolve①⑤">2.5.2. The getFileHandle() method</a> <a href="#ref-for-resolve①⑥">(2)</a>
+    <li><a href="#ref-for-resolve①⑦">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-resolve①⑧">(2)</a>
+    <li><a href="#ref-for-resolve①⑨">2.5.4. The removeEntry() method</a>
+    <li><a href="#ref-for-resolve②⓪">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-resolve②①">(2)</a> <a href="#ref-for-resolve②②">(3)</a> <a href="#ref-for-resolve②③">(4)</a>
+    <li><a href="#ref-for-resolve②④">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-resolve②⑤">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-resolve②⑥">3.5. The showDirectoryPicker() method</a>
+    <li><a href="#ref-for-resolve②⑦">3.6. Drag and Drop</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-sequence">
+   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-sequence">2.5. The FileSystemDirectoryHandle interface</a>
+    <li><a href="#ref-for-idl-sequence①">3. Accessing Local File System</a> <a href="#ref-for-idl-sequence②">(2)</a> <a href="#ref-for-idl-sequence③">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-this">
+   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-this">2.3.1. The isSameEntry() method</a> <a href="#ref-for-this①">(2)</a>
+    <li><a href="#ref-for-this②">2.3.2. The queryPermission() method</a>
+    <li><a href="#ref-for-this③">2.3.3. The requestPermission() method</a>
+    <li><a href="#ref-for-this④">2.4.1. The getFile() method</a> <a href="#ref-for-this⑤">(2)</a>
+    <li><a href="#ref-for-this⑥">2.4.2. The createWritable() method</a> <a href="#ref-for-this⑦">(2)</a> <a href="#ref-for-this⑧">(3)</a>
+    <li><a href="#ref-for-this⑨">2.4.3. The createSyncAccessHandle() method</a> <a href="#ref-for-this①⓪">(2)</a> <a href="#ref-for-this①①">(3)</a>
+    <li><a href="#ref-for-this①②">2.5.2. The getFileHandle() method</a> <a href="#ref-for-this①③">(2)</a> <a href="#ref-for-this①④">(3)</a>
+    <li><a href="#ref-for-this①⑤">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-this①⑥">(2)</a> <a href="#ref-for-this①⑦">(3)</a>
+    <li><a href="#ref-for-this①⑧">2.5.4. The removeEntry() method</a> <a href="#ref-for-this①⑨">(2)</a>
+    <li><a href="#ref-for-this②⓪">2.5.5. The resolve() method</a>
+    <li><a href="#ref-for-this②①">2.6.1. The write() method</a>
+    <li><a href="#ref-for-this②②">2.6.2. The seek() method</a>
+    <li><a href="#ref-for-this②③">2.6.3. The truncate() method</a>
+    <li><a href="#ref-for-this②④">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-this②⑤">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-this②⑥">3.5. The showDirectoryPicker() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-undefined">
+   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-undefined">2.5. The FileSystemDirectoryHandle interface</a>
+    <li><a href="#ref-for-idl-undefined①">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-idl-undefined②">(2)</a> <a href="#ref-for-idl-undefined③">(3)</a>
+    <li><a href="#ref-for-idl-undefined④">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-idl-undefined⑤">(2)</a> <a href="#ref-for-idl-undefined⑥">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
+   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-unsigned-long-long">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-idl-unsigned-long-long①">(2)</a> <a href="#ref-for-idl-unsigned-long-long②">(3)</a> <a href="#ref-for-idl-unsigned-long-long③">(4)</a>
+    <li><a href="#ref-for-idl-unsigned-long-long④">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-idl-unsigned-long-long⑤">(2)</a> <a href="#ref-for-idl-unsigned-long-long⑥">(3)</a> <a href="#ref-for-idl-unsigned-long-long⑦">(4)</a> <a href="#ref-for-idl-unsigned-long-long⑧">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
+   <a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-upon-fulfillment">2.1. Concepts</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-wait-for-all">
+   <a href="https://webidl.spec.whatwg.org/#wait-for-all">https://webidl.spec.whatwg.org/#wait-for-all</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-wait-for-all">2.1. Concepts</a>
+   </ul>
+  </aside>
+  <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
+  <ul class="index">
+   <li>
+    <a data-link-type="biblio">[ECMASCRIPT]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-realm">realm</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[ENCODING]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-utf-8-encode">utf-8 encode</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[FILE-API]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-dfn-Blob">Blob</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-file">File</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-lastModified">lastModified</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-name">name</span>
+     <li><span class="dfn-paneled" id="term-for-readOperation">read operation</span>
+     <li><span class="dfn-paneled" id="term-for-snapshot-state">snapshot state</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-type">type</span>
+     <li><span class="dfn-paneled" id="term-for-UnixEpoch">unix epoch</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[HTML]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-datatransferitem">DataTransferItem</span>
+     <li><span class="dfn-paneled" id="term-for-serializable">Serializable</span>
+     <li><span class="dfn-paneled" id="term-for-window">Window</span>
+     <li><span class="dfn-paneled" id="term-for-activation-notification">activation notification</span>
+     <li><span class="dfn-paneled" id="term-for-as-a-download">as a download</span>
+     <li><span class="dfn-paneled" id="term-for-window-bc">browsing context</span>
+     <li><span class="dfn-paneled" id="term-for-current-settings-object">current settings object</span>
+     <li><span class="dfn-paneled" id="term-for-deserialization-steps">deserialization steps</span>
+     <li><span class="dfn-paneled" id="term-for-environment-settings-object">environment settings object</span>
+     <li><span class="dfn-paneled" id="term-for-concept-settings-object-global">global object</span>
+     <li><span class="dfn-paneled" id="term-for-in-parallel">in parallel</span>
+     <li><span class="dfn-paneled" id="term-for-event-messageerror">messageerror</span>
+     <li><span class="dfn-paneled" id="term-for-concept-origin-opaque">opaque origin</span>
+     <li><span class="dfn-paneled" id="term-for-concept-settings-object-origin">origin <small>(for environment settings object)</small></span>
+     <li><span class="dfn-paneled" id="term-for-concept-dnd-ro">read-only mode</span>
+     <li><span class="dfn-paneled" id="term-for-concept-dnd-rw">read/write mode</span>
+     <li><span class="dfn-paneled" id="term-for-concept-relevant-realm">relevant realm</span>
+     <li><span class="dfn-paneled" id="term-for-relevant-settings-object">relevant settings object</span>
+     <li><span class="dfn-paneled" id="term-for-same-origin">same origin</span>
+     <li><span class="dfn-paneled" id="term-for-serializable-objects">serializable objects</span>
+     <li><span class="dfn-paneled" id="term-for-serialization-steps">serialization steps</span>
+     <li><span class="dfn-paneled" id="term-for-the-drag-data-item-kind">the drag data item kind</span>
+     <li><span class="dfn-paneled" id="term-for-concept-environment-top-level-origin">top-level origin</span>
+     <li><span class="dfn-paneled" id="term-for-transient-activation">transient activation</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[INFRA]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-set-append">append <small>(for set)</small></span>
+     <li><span class="dfn-paneled" id="term-for-ascii-alphanumeric">ascii alphanumeric</span>
+     <li><span class="dfn-paneled" id="term-for-assert">assert</span>
+     <li><span class="dfn-paneled" id="term-for-byte-sequence">byte sequence</span>
+     <li><span class="dfn-paneled" id="term-for-code-point">code point</span>
+     <li><span class="dfn-paneled" id="term-for-list-contain">contain</span>
+     <li><span class="dfn-paneled" id="term-for-javascript-string-convert">convert</span>
+     <li><span class="dfn-paneled" id="term-for-list-empty">empty</span>
+     <li><span class="dfn-paneled" id="term-for-map-exists">exist</span>
+     <li><span class="dfn-paneled" id="term-for-map-iterate">for each <small>(for map)</small></span>
+     <li><span class="dfn-paneled" id="term-for-implementation-defined">implementation-defined</span>
+     <li><span class="dfn-paneled" id="term-for-list-is-empty">is empty</span>
+     <li><span class="dfn-paneled" id="term-for-string-length">length <small>(for string)</small></span>
+     <li><span class="dfn-paneled" id="term-for-list">list</span>
+     <li><span class="dfn-paneled" id="term-for-ordered-map">map</span>
+     <li><span class="dfn-paneled" id="term-for-list-prepend">prepend</span>
+     <li><span class="dfn-paneled" id="term-for-list-remove">remove</span>
+     <li><span class="dfn-paneled" id="term-for-ordered-set">set</span>
+     <li><span class="dfn-paneled" id="term-for-string-starts-with">starts with</span>
+     <li><span class="dfn-paneled" id="term-for-string">string</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[MIMESNIFF]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-mime-type-essence">essence</span>
+     <li><span class="dfn-paneled" id="term-for-mime-type">mime type</span>
+     <li><span class="dfn-paneled" id="term-for-parameters">parameters</span>
+     <li><span class="dfn-paneled" id="term-for-parse-a-mime-type">parse a mime type</span>
+     <li><span class="dfn-paneled" id="term-for-subtype">subtype</span>
+     <li><span class="dfn-paneled" id="term-for-type">type</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[permissions]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-dom-permissiondescriptor">PermissionDescriptor</span>
+     <li><span class="dfn-paneled" id="term-for-dom-permissionstate">PermissionState</span>
+     <li><span class="dfn-paneled" id="term-for-dom-permissionstatus">PermissionStatus</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-create-a-permissionstatus">create a permissionstatus</span>
+     <li><span class="dfn-paneled" id="term-for-dom-permissionstate-granted">granted</span>
+     <li><span class="dfn-paneled" id="term-for-dom-permissiondescriptor-name">name</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-permission-descriptor-type">permission descriptor type</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-permission-state">permission state</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-permission-state-constraints">permission state constraints</span>
+     <li><span class="dfn-paneled" id="term-for-dom-navigator-permissions">permissions</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-powerful-feature">powerful feature</span>
+     <li><span class="dfn-paneled" id="term-for-dom-permissionstate-prompt">prompt</span>
+     <li><span class="dfn-paneled" id="term-for-dom-permissions-query">query()</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-request-permission-to-use">request permission to use</span>
+     <li><span class="dfn-paneled" id="term-for-dom-permissionstatus-state">state</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[PERMISSIONS-REQUEST]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-permission-request-algorithm">permission request algorithm</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[storage]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-storagemanager">StorageManager</span>
+     <li><span class="dfn-paneled" id="term-for-storage-endpoint-identifier">identifier</span>
+     <li><span class="dfn-paneled" id="term-for-obtain-a-local-storage-bottle-map">obtain a local storage bottle map</span>
+     <li><span class="dfn-paneled" id="term-for-storage-endpoint-quota">quota</span>
+     <li><span class="dfn-paneled" id="term-for-site-storage">storage</span>
+     <li><span class="dfn-paneled" id="term-for-storage-endpoint">storage endpoint</span>
+     <li><span class="dfn-paneled" id="term-for-storage-quota">storage quota</span>
+     <li><span class="dfn-paneled" id="term-for-storage-endpoint-types">types</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[STREAMS]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-readablestream">ReadableStream</span>
+     <li><span class="dfn-paneled" id="term-for-writablestream">WritableStream</span>
+     <li><span class="dfn-paneled" id="term-for-writablestreamdefaultwriter">WritableStreamDefaultWriter</span>
+     <li><span class="dfn-paneled" id="term-for-writablestream-set-up-closealgorithm">closealgorithm</span>
+     <li><span class="dfn-paneled" id="term-for-ws-get-writer">getWriter()</span>
+     <li><span class="dfn-paneled" id="term-for-writablestream-get-a-writer">getting a writer</span>
+     <li><span class="dfn-paneled" id="term-for-writablestream-set-up-highwatermark">highwatermark</span>
+     <li><span class="dfn-paneled" id="term-for-writablestreamdefaultwriter-release">release</span>
+     <li><span class="dfn-paneled" id="term-for-writablestream-set-up">set up</span>
+     <li><span class="dfn-paneled" id="term-for-writablestream-set-up-sizealgorithm">sizealgorithm</span>
+     <li><span class="dfn-paneled" id="term-for-default-writer-write">write()</span>
+     <li><span class="dfn-paneled" id="term-for-writablestream-set-up-writealgorithm">writealgorithm</span>
+     <li><span class="dfn-paneled" id="term-for-writablestreamdefaultwriter-write-a-chunk">writing a chunk</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-aborterror">AbortError</span>
+     <li><span class="dfn-paneled" id="term-for-AllowShared">AllowShared</span>
+     <li><span class="dfn-paneled" id="term-for-BufferSource">BufferSource</span>
+     <li><span class="dfn-paneled" id="term-for-idl-DOMString">DOMString</span>
+     <li><span class="dfn-paneled" id="term-for-datacloneerror">DataCloneError</span>
+     <li><span class="dfn-paneled" id="term-for-EnforceRange">EnforceRange</span>
+     <li><span class="dfn-paneled" id="term-for-Exposed">Exposed</span>
+     <li><span class="dfn-paneled" id="term-for-invalidmodificationerror">InvalidModificationError</span>
+     <li><span class="dfn-paneled" id="term-for-invalidstateerror">InvalidStateError</span>
+     <li><span class="dfn-paneled" id="term-for-nomodificationallowederror">NoModificationAllowedError</span>
+     <li><span class="dfn-paneled" id="term-for-notallowederror">NotAllowedError</span>
+     <li><span class="dfn-paneled" id="term-for-notfounderror">NotFoundError</span>
+     <li><span class="dfn-paneled" id="term-for-idl-promise">Promise</span>
+     <li><span class="dfn-paneled" id="term-for-quotaexceedederror">QuotaExceededError</span>
+     <li><span class="dfn-paneled" id="term-for-SecureContext">SecureContext</span>
+     <li><span class="dfn-paneled" id="term-for-securityerror">SecurityError</span>
+     <li><span class="dfn-paneled" id="term-for-exceptiondef-typeerror">TypeError</span>
+     <li><span class="dfn-paneled" id="term-for-typemismatcherror">TypeMismatchError</span>
+     <li><span class="dfn-paneled" id="term-for-idl-USVString">USVString</span>
+     <li><span class="dfn-paneled" id="term-for-a-new-promise">a new promise</span>
+     <li><span class="dfn-paneled" id="term-for-a-promise-rejected-with">a promise rejected with</span>
+     <li><span class="dfn-paneled" id="term-for-a-promise-resolved-with">a promise resolved with</span>
+     <li><span class="dfn-paneled" id="term-for-asynchronous-iterator-initialization-steps">asynchronous iterator initialization steps</span>
+     <li><span class="dfn-paneled" id="term-for-idl-boolean">boolean</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-get-buffer-source-copy">get a copy of the buffer source</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-get-the-next-iteration-result">get the next iteration result</span>
+     <li><span class="dfn-paneled" id="term-for-new">new</span>
+     <li><span class="dfn-paneled" id="term-for-idl-record">record</span>
+     <li><span class="dfn-paneled" id="term-for-reject">reject</span>
+     <li><span class="dfn-paneled" id="term-for-resolve">resolve</span>
+     <li><span class="dfn-paneled" id="term-for-idl-sequence">sequence</span>
+     <li><span class="dfn-paneled" id="term-for-this">this</span>
+     <li><span class="dfn-paneled" id="term-for-idl-undefined">undefined</span>
+     <li><span class="dfn-paneled" id="term-for-idl-unsigned-long-long">unsigned long long</span>
+     <li><span class="dfn-paneled" id="term-for-upon-fulfillment">upon fulfillment</span>
+     <li><span class="dfn-paneled" id="term-for-wait-for-all">wait for all</span>
+    </ul>
+  </ul>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
+  <dl>
+   <dt id="biblio-ecmascript">[ECMASCRIPT]
+   <dd><a href="https://tc39.es/ecma262/multipage/"><cite>ECMAScript Language Specification</cite></a>. URL: <a href="https://tc39.es/ecma262/multipage/">https://tc39.es/ecma262/multipage/</a>
+   <dt id="biblio-encoding">[ENCODING]
+   <dd>Anne van Kesteren. <a href="https://encoding.spec.whatwg.org/"><cite>Encoding Standard</cite></a>. Living Standard. URL: <a href="https://encoding.spec.whatwg.org/">https://encoding.spec.whatwg.org/</a>
+   <dt id="biblio-file-api">[FILE-API]
+   <dd>Marijn Kruisselbrink; Arun Ranganathan. <a href="https://www.w3.org/TR/FileAPI/"><cite>File API</cite></a>. 4 June 2021. WD. URL: <a href="https://www.w3.org/TR/FileAPI/">https://www.w3.org/TR/FileAPI/</a>
+   <dt id="biblio-html">[HTML]
+   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dt id="biblio-infra">[INFRA]
+   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+   <dt id="biblio-mimesniff">[MIMESNIFF]
+   <dd>Gordon P. Hemsley. <a href="https://mimesniff.spec.whatwg.org/"><cite>MIME Sniffing Standard</cite></a>. Living Standard. URL: <a href="https://mimesniff.spec.whatwg.org/">https://mimesniff.spec.whatwg.org/</a>
+   <dt id="biblio-permissions">[PERMISSIONS]
+   <dd>Marcos Caceres; Mike Taylor; Jeffrey Yasskin. <a href="https://www.w3.org/TR/permissions/"><cite>Permissions</cite></a>. 28 October 2021. WD. URL: <a href="https://www.w3.org/TR/permissions/">https://www.w3.org/TR/permissions/</a>
+   <dt id="biblio-permissions-request">[PERMISSIONS-REQUEST]
+   <dd><a href="https://wicg.github.io/permissions-request/"><cite>Requesting Permissions</cite></a>. cg-draft. URL: <a href="https://wicg.github.io/permissions-request/">https://wicg.github.io/permissions-request/</a>
+   <dt id="biblio-rfc2119">[RFC2119]
+   <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
+   <dt id="biblio-storage">[STORAGE]
+   <dd>Anne van Kesteren. <a href="https://storage.spec.whatwg.org/"><cite>Storage Standard</cite></a>. Living Standard. URL: <a href="https://storage.spec.whatwg.org/">https://storage.spec.whatwg.org/</a>
+   <dt id="biblio-streams">[STREAMS]
+   <dd>Adam Rice; et al. <a href="https://streams.spec.whatwg.org/"><cite>Streams Standard</cite></a>. Living Standard. URL: <a href="https://streams.spec.whatwg.org/">https://streams.spec.whatwg.org/</a>
+   <dt id="biblio-webidl">[WEBIDL]
+   <dd>Edgar Chen; Timothy Gu. <a href="https://webidl.spec.whatwg.org/"><cite>Web IDL Standard</cite></a>. Living Standard. URL: <a href="https://webidl.spec.whatwg.org/">https://webidl.spec.whatwg.org/</a>
+  </dl>
+  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <dl>
+   <dt id="biblio-entries-api">[ENTRIES-API]
+   <dd><a href="https://wicg.github.io/entries-api/"><cite>File and Directory Entries API</cite></a>. cg-draft. URL: <a href="https://wicg.github.io/entries-api/">https://wicg.github.io/entries-api/</a>
+   <dt id="biblio-file-system-api">[FILE-SYSTEM-API]
+   <dd>Eric Uhrhane. <a href="https://www.w3.org/TR/file-system-api/"><cite>File API: Directories and System</cite></a>. 24 April 2014. NOTE. URL: <a href="https://www.w3.org/TR/file-system-api/">https://www.w3.org/TR/file-system-api/</a>
+  </dl>
+  <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
+<pre class="idl highlight def"><c- b>enum</c-> <a href="#enumdef-filesystempermissionmode"><code><c- g>FileSystemPermissionMode</c-></code></a> {
+  <a href="#dom-filesystempermissionmode-read"><code><c- s>"read"</c-></code></a>,
+  <a href="#dom-filesystempermissionmode-readwrite"><code><c- s>"readwrite"</c-></code></a>
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-filesystempermissiondescriptor"><code><c- g>FileSystemPermissionDescriptor</c-></code></a> : <a data-link-type="idl-name" href="https://w3c.github.io/permissions/#dom-permissiondescriptor"><c- n>PermissionDescriptor</c-></a> {
+  <c- b>required</c-> <a data-link-type="idl-name" href="#filesystemhandle"><c- n>FileSystemHandle</c-></a> <a data-type="FileSystemHandle " href="#dom-filesystempermissiondescriptor-handle"><code><c- g>handle</c-></code></a>;
+  <a data-link-type="idl-name" href="#enumdef-filesystempermissionmode"><c- n>FileSystemPermissionMode</c-></a> <a data-default="&quot;read&quot;" data-type="FileSystemPermissionMode " href="#dom-filesystempermissiondescriptor-mode"><code><c- g>mode</c-></code></a> = "read";
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-filesystemhandlepermissiondescriptor"><code><c- g>FileSystemHandlePermissionDescriptor</c-></code></a> {
+  <a data-link-type="idl-name" href="#enumdef-filesystempermissionmode"><c- n>FileSystemPermissionMode</c-></a> <a data-default="&quot;read&quot;" data-type="FileSystemPermissionMode " href="#dom-filesystemhandlepermissiondescriptor-mode"><code><c- g>mode</c-></code></a> = "read";
+};
+
+<c- b>enum</c-> <a href="#enumdef-filesystemhandlekind"><code><c- g>FileSystemHandleKind</c-></code></a> {
+  <a href="#dom-filesystemhandlekind-file"><code><c- s>"file"</c-></code></a>,
+  <a href="#dom-filesystemhandlekind-directory"><code><c- s>"directory"</c-></code></a>,
+};
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->), <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable"><c- g>Serializable</c-></a>]
+<c- b>interface</c-> <a href="#filesystemhandle"><code><c- g>FileSystemHandle</c-></code></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#enumdef-filesystemhandlekind"><c- n>FileSystemHandleKind</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="FileSystemHandleKind" href="#dom-filesystemhandle-kind"><c- g>kind</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="USVString" href="#dom-filesystemhandle-name"><c- g>name</c-></a>;
+
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemhandle-issameentry"><c- g>isSameEntry</c-></a>(<a data-link-type="idl-name" href="#filesystemhandle"><c- n>FileSystemHandle</c-></a> <a href="#dom-filesystemhandle-issameentry-other-other"><code><c- g>other</c-></code></a>);
+
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="https://w3c.github.io/permissions/#dom-permissionstate"><c- n>PermissionState</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemhandle-querypermission"><c- g>queryPermission</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemhandlepermissiondescriptor"><c- n>FileSystemHandlePermissionDescriptor</c-></a> <a href="#dom-filesystemhandle-querypermission-descriptor-descriptor"><code><c- g>descriptor</c-></code></a> = {});
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="https://w3c.github.io/permissions/#dom-permissionstate"><c- n>PermissionState</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemhandle-requestpermission"><c- g>requestPermission</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemhandlepermissiondescriptor"><c- n>FileSystemHandlePermissionDescriptor</c-></a> <a href="#dom-filesystemhandle-requestpermission-descriptor-descriptor"><code><c- g>descriptor</c-></code></a> = {});
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-filesystemcreatewritableoptions"><code><c- g>FileSystemCreateWritableOptions</c-></code></a> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a data-default="false" data-type="boolean " href="#dom-filesystemcreatewritableoptions-keepexistingdata"><code><c- g>keepExistingData</c-></code></a> = <c- b>false</c->;
+};
+
+<c- b>enum</c-> <a href="#enumdef-accesshandlemode"><code><c- g>AccessHandleMode</c-></code></a> { <a href="#dom-accesshandlemode-in-place"><code><c- s>"in-place"</c-></code></a> };
+
+<c- b>dictionary</c-> <a href="#dictdef-filesystemfilehandlecreateaccesshandleoptions"><code><c- g>FileSystemFileHandleCreateAccessHandleOptions</c-></code></a> {
+  <c- b>required</c-> <a data-link-type="idl-name" href="#enumdef-accesshandlemode"><c- n>AccessHandleMode</c-></a> <a data-type="AccessHandleMode " href="#dom-filesystemfilehandlecreateaccesshandleoptions-mode"><code><c- g>mode</c-></code></a>;
+};
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->), <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable"><c- g>Serializable</c-></a>]
+<c- b>interface</c-> <a href="#filesystemfilehandle"><code><c- g>FileSystemFileHandle</c-></code></a> : <a data-link-type="idl-name" href="#filesystemhandle"><c- n>FileSystemHandle</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-file"><c- n>File</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-getfile"><c- g>getFile</c-></a>();
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemwritablefilestream"><c- n>FileSystemWritableFileStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createwritable"><c- g>createWritable</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemcreatewritableoptions"><c- n>FileSystemCreateWritableOptions</c-></a> <a href="#dom-filesystemfilehandle-createwritable-options-options"><code><c- g>options</c-></code></a> = {});
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=<c- n>DedicatedWorker</c->]
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemsyncaccesshandle"><c- n>FileSystemSyncAccessHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemfilehandle-createsyncaccesshandle"><c- g>createSyncAccessHandle</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemfilehandlecreateaccesshandleoptions"><c- n>FileSystemFileHandleCreateAccessHandleOptions</c-></a> <a href="#dom-filesystemfilehandle-createsyncaccesshandle-options-options"><code><c- g>options</c-></code></a> = {});
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-filesystemgetfileoptions"><code><c- g>FileSystemGetFileOptions</c-></code></a> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a data-default="false" data-type="boolean " href="#dom-filesystemgetfileoptions-create"><code><c- g>create</c-></code></a> = <c- b>false</c->;
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-filesystemgetdirectoryoptions"><code><c- g>FileSystemGetDirectoryOptions</c-></code></a> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a data-default="false" data-type="boolean " href="#dom-filesystemgetdirectoryoptions-create"><code><c- g>create</c-></code></a> = <c- b>false</c->;
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-filesystemremoveoptions"><code><c- g>FileSystemRemoveOptions</c-></code></a> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a data-default="false" data-type="boolean " href="#dom-filesystemremoveoptions-recursive"><code><c- g>recursive</c-></code></a> = <c- b>false</c->;
+};
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->), <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable"><c- g>Serializable</c-></a>]
+<c- b>interface</c-> <a href="#filesystemdirectoryhandle"><code><c- g>FileSystemDirectoryHandle</c-></code></a> : <a data-link-type="idl-name" href="#filesystemhandle"><c- n>FileSystemHandle</c-></a> {
+  <c- b>async</c-> <c- b>iterable</c->&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a>, <a data-link-type="idl-name" href="#filesystemhandle"><c- n>FileSystemHandle</c-></a>>;
+
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemfilehandle"><c- n>FileSystemFileHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemdirectoryhandle-getfilehandle"><c- g>getFileHandle</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a> <a href="#dom-filesystemdirectoryhandle-getfilehandle-name-options-name"><code><c- g>name</c-></code></a>, <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemgetfileoptions"><c- n>FileSystemGetFileOptions</c-></a> <a href="#dom-filesystemdirectoryhandle-getfilehandle-name-options-options"><code><c- g>options</c-></code></a> = {});
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemdirectoryhandle"><c- n>FileSystemDirectoryHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemdirectoryhandle-getdirectoryhandle"><c- g>getDirectoryHandle</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a> <a href="#dom-filesystemdirectoryhandle-getdirectoryhandle-name-options-name"><code><c- g>name</c-></code></a>, <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemgetdirectoryoptions"><c- n>FileSystemGetDirectoryOptions</c-></a> <a href="#dom-filesystemdirectoryhandle-getdirectoryhandle-name-options-options"><code><c- g>options</c-></code></a> = {});
+
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemdirectoryhandle-removeentry"><c- g>removeEntry</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a> <a href="#dom-filesystemdirectoryhandle-removeentry-name-options-name"><code><c- g>name</c-></code></a>, <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-filesystemremoveoptions"><c- n>FileSystemRemoveOptions</c-></a> <a href="#dom-filesystemdirectoryhandle-removeentry-name-options-options"><code><c- g>options</c-></code></a> = {});
+
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence"><c- b>sequence</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a>>?> <a class="idl-code" data-link-type="method" href="#dom-filesystemdirectoryhandle-resolve"><c- g>resolve</c-></a>(<a data-link-type="idl-name" href="#filesystemhandle"><c- n>FileSystemHandle</c-></a> <a href="#dom-filesystemdirectoryhandle-resolve-possibledescendant-possibledescendant"><code><c- g>possibleDescendant</c-></code></a>);
+};
+
+<c- b>enum</c-> <a href="#enumdef-writecommandtype"><code><c- g>WriteCommandType</c-></code></a> {
+  <a href="#dom-writecommandtype-write"><code><c- s>"write"</c-></code></a>,
+  <a href="#dom-writecommandtype-seek"><code><c- s>"seek"</c-></code></a>,
+  <a href="#dom-writecommandtype-truncate"><code><c- s>"truncate"</c-></code></a>,
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-writeparams"><code><c- g>WriteParams</c-></code></a> {
+  <c- b>required</c-> <a data-link-type="idl-name" href="#enumdef-writecommandtype"><c- n>WriteCommandType</c-></a> <a data-type="WriteCommandType " href="#dom-writeparams-type"><code><c- g>type</c-></code></a>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a>? <a data-type="unsigned long long? " href="#dom-writeparams-size"><code><c- g>size</c-></code></a>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a>? <a data-type="unsigned long long? " href="#dom-writeparams-position"><code><c- g>position</c-></code></a>;
+  (<a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#BufferSource"><c- n>BufferSource</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-Blob"><c- n>Blob</c-></a> <c- b>or</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a>)? <a data-type="(BufferSource or Blob or USVString)? " href="#dom-writeparams-data"><code><c- g>data</c-></code></a>;
+};
+
+<c- b>typedef</c-> (<a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#BufferSource"><c- n>BufferSource</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-Blob"><c- n>Blob</c-></a> <c- b>or</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-writeparams"><c- n>WriteParams</c-></a>) <a href="#typedefdef-filesystemwritechunktype"><code><c- g>FileSystemWriteChunkType</c-></code></a>;
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->), <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext"><c- g>SecureContext</c-></a>]
+<c- b>interface</c-> <a href="#filesystemwritablefilestream"><code><c- g>FileSystemWritableFileStream</c-></code></a> : <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#writablestream"><c- n>WritableStream</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemwritablefilestream-write"><c- g>write</c-></a>(<a data-link-type="idl-name" href="#typedefdef-filesystemwritechunktype"><c- n>FileSystemWriteChunkType</c-></a> <a href="#dom-filesystemwritablefilestream-write-data-data"><code><c- g>data</c-></code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemwritablefilestream-seek"><c- g>seek</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a href="#dom-filesystemwritablefilestream-seek-position-position"><code><c- g>position</c-></code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemwritablefilestream-truncate"><c- g>truncate</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a href="#dom-filesystemwritablefilestream-truncate-size-size"><code><c- g>size</c-></code></a>);
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-filesystemreadwriteoptions"><code><c- g>FilesystemReadWriteOptions</c-></code></a> {
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a data-type="unsigned long long " href="#dom-filesystemreadwriteoptions-at"><code><c- g>at</c-></code></a>;
+}
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=<c- n>DedicatedWorker</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext"><c- g>SecureContext</c-></a>]
+<c- b>interface</c-> <a href="#filesystemsyncaccesshandle"><code><c- g>FileSystemSyncAccessHandle</c-></code></a> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a href="#dom-filesystemsyncaccesshandle-read"><code><c- g>read</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#AllowShared"><c- g>AllowShared</c-></a>] <a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#BufferSource"><c- n>BufferSource</c-></a> <a href="#dom-filesystemsyncaccesshandle-read-buffer-options-buffer"><code><c- g>buffer</c-></code></a>,
+                             <a data-link-type="idl-name" href="#dictdef-filesystemreadwriteoptions"><c- n>FilesystemReadWriteOptions</c-></a> <a href="#dom-filesystemsyncaccesshandle-read-buffer-options-options"><code><c- g>options</c-></code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a href="#dom-filesystemsyncaccesshandle-write"><code><c- g>write</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#AllowShared"><c- g>AllowShared</c-></a>] <a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#BufferSource"><c- n>BufferSource</c-></a> <a href="#dom-filesystemsyncaccesshandle-write-buffer-options-buffer"><code><c- g>buffer</c-></code></a>,
+                              <a data-link-type="idl-name" href="#dictdef-filesystemreadwriteoptions"><c- n>FilesystemReadWriteOptions</c-></a> <a href="#dom-filesystemsyncaccesshandle-write-buffer-options-options"><code><c- g>options</c-></code></a>);
+
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-truncate"><c- g>truncate</c-></a>([<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#EnforceRange"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a href="#dom-filesystemsyncaccesshandle-truncate-size-size"><code><c- g>size</c-></code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-getsize"><c- g>getSize</c-></a>();
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-flush"><c- g>flush</c-></a>();
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-filesystemsyncaccesshandle-close"><c- g>close</c-></a>();
+};
+
+
+<c- b>enum</c-> <a class="idl-code" data-link-type="enum" href="#enumdef-wellknowndirectory"><c- g>WellKnownDirectory</c-></a> {
+  <a class="idl-code" data-link-type="enum-value" href="#dom-wellknowndirectory-desktop"><c- s>"desktop"</c-></a>,
+  <a class="idl-code" data-link-type="enum-value" href="#dom-wellknowndirectory-documents"><c- s>"documents"</c-></a>,
+  <a class="idl-code" data-link-type="enum-value" href="#dom-wellknowndirectory-downloads"><c- s>"downloads"</c-></a>,
+  <a class="idl-code" data-link-type="enum-value" href="#dom-wellknowndirectory-music"><c- s>"music"</c-></a>,
+  <a class="idl-code" data-link-type="enum-value" href="#dom-wellknowndirectory-pictures"><c- s>"pictures"</c-></a>,
+  <a class="idl-code" data-link-type="enum-value" href="#dom-wellknowndirectory-videos"><c- s>"videos"</c-></a>,
+};
+
+<c- b>typedef</c-> (<a data-link-type="idl-name" href="#enumdef-wellknowndirectory"><c- n>WellKnownDirectory</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#filesystemhandle"><c- n>FileSystemHandle</c-></a>) <a href="#typedefdef-startindirectory"><code><c- g>StartInDirectory</c-></code></a>;
+
+<c- b>dictionary</c-> <a href="#dictdef-filepickeraccepttype"><code><c- g>FilePickerAcceptType</c-></code></a> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a> <a data-type="USVString " href="#dom-filepickeraccepttype-description"><code><c- g>description</c-></code></a>;
+    <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-record"><c- b>record</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a>, (<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a> <c- b>or</c-> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence"><c- b>sequence</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a>>)> <a data-type="record<USVString, (USVString or sequence<USVString>)> " href="#dom-filepickeraccepttype-accept"><code><c- g>accept</c-></code></a>;
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-filepickeroptions"><code><c- g>FilePickerOptions</c-></code></a> {
+    <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#dictdef-filepickeraccepttype"><c- n>FilePickerAcceptType</c-></a>> <a data-type="sequence<FilePickerAcceptType> " href="#dom-filepickeroptions-types"><code><c- g>types</c-></code></a>;
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a data-default="false" data-type="boolean " href="#dom-filepickeroptions-excludeacceptalloption"><code><c- g>excludeAcceptAllOption</c-></code></a> = <c- b>false</c->;
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <a data-type="DOMString " href="#dom-filepickeroptions-id"><code><c- g>id</c-></code></a>;
+    <a data-link-type="idl-name" href="#typedefdef-startindirectory"><c- n>StartInDirectory</c-></a> <a data-type="StartInDirectory " href="#dom-filepickeroptions-startin"><code><c- g>startIn</c-></code></a>;
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-openfilepickeroptions"><code><c- g>OpenFilePickerOptions</c-></code></a> : <a data-link-type="idl-name" href="#dictdef-filepickeroptions"><c- n>FilePickerOptions</c-></a> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a data-default="false" data-type="boolean " href="#dom-openfilepickeroptions-multiple"><code><c- g>multiple</c-></code></a> = <c- b>false</c->;
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-savefilepickeroptions"><code><c- g>SaveFilePickerOptions</c-></code></a> : <a data-link-type="idl-name" href="#dictdef-filepickeroptions"><c- n>FilePickerOptions</c-></a> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a>? <a data-type="USVString? " href="#dom-savefilepickeroptions-suggestedname"><code><c- g>suggestedName</c-></code></a>;
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-directorypickeroptions"><code><c- g>DirectoryPickerOptions</c-></code></a> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <a data-type="DOMString " href="#dom-directorypickeroptions-id"><code><c- g>id</c-></code></a>;
+    <a data-link-type="idl-name" href="#typedefdef-startindirectory"><c- n>StartInDirectory</c-></a> <a data-type="StartInDirectory " href="#dom-directorypickeroptions-startin"><code><c- g>startIn</c-></code></a>;
+};
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext"><c- g>SecureContext</c-></a>]
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/window-object.html#window"><c- g>Window</c-></a> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemfilehandle"><c- n>FileSystemFileHandle</c-></a>>> <a class="idl-code" data-link-type="method" href="#dom-window-showopenfilepicker"><c- g>showOpenFilePicker</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-openfilepickeroptions"><c- n>OpenFilePickerOptions</c-></a> <a href="#dom-window-showopenfilepicker-options-options"><code><c- g>options</c-></code></a> = {});
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemfilehandle"><c- n>FileSystemFileHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-window-showsavefilepicker"><c- g>showSaveFilePicker</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-savefilepickeroptions"><c- n>SaveFilePickerOptions</c-></a> <a href="#dom-window-showsavefilepicker-options-options"><code><c- g>options</c-></code></a> = {});
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemdirectoryhandle"><c- n>FileSystemDirectoryHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-window-showdirectorypicker"><c- g>showDirectoryPicker</c-></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-directorypickeroptions"><c- n>DirectoryPickerOptions</c-></a> <a href="#dom-window-showdirectorypicker-options-options"><code><c- g>options</c-></code></a> = {});
+};
+
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem"><c- g>DataTransferItem</c-></a> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemhandle"><c- n>FileSystemHandle</c-></a>?> <a class="idl-code" data-link-type="method" href="#dom-datatransferitem-getasfilesystemhandle"><c- g>getAsFileSystemHandle</c-></a>();
+};
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext"><c- g>SecureContext</c-></a>]
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://storage.spec.whatwg.org/#storagemanager"><c- g>StorageManager</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#filesystemdirectoryhandle"><c- n>FileSystemDirectoryHandle</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-storagemanager-getdirectory"><c- g>getDirectory</c-></a>();
+};
+
+</pre>
+  <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
+  <div style="counter-reset:issue">
+   <div class="issue"> We should consider having further normative restrictions on file names that will
+never be allowed using this API, rather than leaving it entirely up to underlying file
+systems. <a class="issue-return" href="#issue-58d5d75b" title="Jump to section">↵</a></div>
+   <div class="issue"> TODO: Explain better how entries map to files on disk (multiple entries can map to the same file or
+directory on disk but an entry doesn’t have to map to any file on disk). <a class="issue-return" href="#issue-88e7ec9d" title="Jump to section">↵</a></div>
+   <div class="issue"> Ideally this user activation requirement would be defined upstream. <a href="https://github.com/WICG/permissions-request/issues/2">[Issue #WICG/permissions-request#2]</a> <a class="issue-return" href="#issue-88417955" title="Jump to section">↵</a></div>
+   <div class="issue"> Currently <code class="idl"><a data-link-type="idl" href="#enumdef-filesystempermissionmode">FileSystemPermissionMode</a></code> can only be <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-read">"read"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-filesystempermissionmode-readwrite">"readwrite"</a></code>. In
+the future we might want to add a "write" mode as well to support write-only handles. <a href="https://github.com/wicg/file-system-access/issues/119">[Issue #119]</a> <a class="issue-return" href="#issue-7fc2f5c7" title="Jump to section">↵</a></div>
+   <div class="issue"> The reading and snapshotting behavior needs to be better specified in the <a data-link-type="biblio" href="#biblio-file-api">[FILE-API]</a> spec,
+ for now this is kind of hand-wavy. <a class="issue-return" href="#issue-1fb8bcae" title="Jump to section">↵</a></div>
+   <div class="issue"> There has been some discussion around and desire for a "inPlace" mode for createWritable
+(where changes will be written to the actual underlying file as they are written to the writer, for
+example to support in-place modification of large files or things like databases). This is not
+currently implemented in Chrome. Implementing this is currently blocked on figuring out how to
+combine the desire to run malware checks with the desire to let websites make fast in-place
+modifications to existing large files. <a href="https://github.com/wicg/file-system-access/issues/67">[Issue #67]</a> <a class="issue-return" href="#issue-0693bc11" title="Jump to section">↵</a></div>
+   <div class="issue"> In the future we might want to add arguments to the async iterable declaration to
+support for example recursive iteration. <a href="https://github.com/wicg/file-system-access/issues/173">[Issue #173]</a> <a class="issue-return" href="#issue-cce0bb28" title="Jump to section">↵</a></div>
+   <div class="issue"> Better specify what possible exceptions this could throw. <a href="https://github.com/wicg/file-system-access/issues/68">[Issue #68]</a> <a class="issue-return" href="#issue-721a33e4" title="Jump to section">↵</a></div>
+   <div class="issue"> Better specify what possible exceptions this could throw. <a href="https://github.com/wicg/file-system-access/issues/68">[Issue #68]</a> <a class="issue-return" href="#issue-721a33e4①" title="Jump to section">↵</a></div>
+   <div class="issue"> Better specify what possible exceptions this could throw. <a href="https://github.com/wicg/file-system-access/issues/68">[Issue #68]</a> <a class="issue-return" href="#issue-721a33e4②" title="Jump to section">↵</a></div>
+   <div class="issue"> Rather than requiring the website to prompt separately for a writable directory,
+ we should provide some kind of API to request a writable directory in one step. <a href="https://github.com/wicg/file-system-access/issues/89">[Issue #89]</a> <a class="issue-return" href="#issue-923f3009" title="Jump to section">↵</a></div>
+   <div class="issue"> This currently does not block access to <a data-link-type="dfn" href="#wellknowndirectory-too-sensitive-or-dangerous">too sensitive or dangerous</a> directories, to
+be consistent with other APIs that give access to dropped files and directories. This is inconsistent
+with the <a data-link-type="dfn" href="#local-file-system-handle-factories">local file system handle factories</a> though, so we might want to reconsider this. <a class="issue-return" href="#issue-8306b646" title="Jump to section">↵</a></div>
+   <div class="issue"> Storage endpoints should be defined in <a data-link-type="biblio" href="#biblio-storage">[storage]</a> itself, rather
+than being defined here. So merge this into the table there. <a class="issue-return" href="#issue-9c98e739" title="Jump to section">↵</a></div>
+  </div>
+  <aside class="dfn-panel" data-for="entry">
+   <b><a href="#entry">#entry</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-entry">2.1. Concepts</a> <a href="#ref-for-entry①">(2)</a> <a href="#ref-for-entry②">(3)</a> <a href="#ref-for-entry③">(4)</a> <a href="#ref-for-entry④">(5)</a> <a href="#ref-for-entry⑤">(6)</a> <a href="#ref-for-entry⑥">(7)</a> <a href="#ref-for-entry⑦">(8)</a> <a href="#ref-for-entry⑧">(9)</a>
+    <li><a href="#ref-for-entry⑨">2.2. Permissions</a>
+    <li><a href="#ref-for-entry①⓪">2.3. The FileSystemHandle interface</a> <a href="#ref-for-entry①①">(2)</a> <a href="#ref-for-entry①②">(3)</a>
+    <li><a href="#ref-for-entry①③">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-entry①④">2.5.1. Directory iteration</a>
+    <li><a href="#ref-for-entry①⑤">3.2.2. Starting Directory</a> <a href="#ref-for-entry①⑥">(2)</a>
+    <li><a href="#ref-for-entry①⑦">3.6. Drag and Drop</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="entry-name">
+   <b><a href="#entry-name">#entry-name</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-entry-name">2.1. Concepts</a>
+    <li><a href="#ref-for-entry-name①">2.3. The FileSystemHandle interface</a> <a href="#ref-for-entry-name②">(2)</a>
+    <li><a href="#ref-for-entry-name③">2.4.1. The getFile() method</a> <a href="#ref-for-entry-name④">(2)</a>
+    <li><a href="#ref-for-entry-name⑤">2.5.1. Directory iteration</a> <a href="#ref-for-entry-name⑥">(2)</a> <a href="#ref-for-entry-name⑦">(3)</a>
+    <li><a href="#ref-for-entry-name⑧">2.5.2. The getFileHandle() method</a> <a href="#ref-for-entry-name⑨">(2)</a>
+    <li><a href="#ref-for-entry-name①⓪">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-entry-name①①">(2)</a>
+    <li><a href="#ref-for-entry-name①②">2.5.4. The removeEntry() method</a>
+    <li><a href="#ref-for-entry-name①③">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="valid-file-name">
+   <b><a href="#valid-file-name">#valid-file-name</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-valid-file-name">2.1. Concepts</a>
+    <li><a href="#ref-for-valid-file-name①">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-valid-file-name②">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-valid-file-name③">2.5.4. The removeEntry() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="valid-suffix-code-point">
+   <b><a href="#valid-suffix-code-point">#valid-suffix-code-point</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-valid-suffix-code-point">3.2.1. Accepted file types</a> <a href="#ref-for-valid-suffix-code-point①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="file">
+   <b><a href="#file">#file</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-file">2.1. Concepts</a> <a href="#ref-for-file①">(2)</a>
+    <li><a href="#ref-for-file②">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-file③">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-file④">2.5.1. Directory iteration</a>
+    <li><a href="#ref-for-file⑤">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-file⑥">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-file⑦">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-file⑧">(2)</a>
+    <li><a href="#ref-for-file⑨">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-file①⓪">(2)</a>
+    <li><a href="#ref-for-file①①">3.2.2. Starting Directory</a>
+    <li><a href="#ref-for-file①②">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-file①③">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-file①④">3.6. Drag and Drop</a> <a href="#ref-for-file①⑤">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="file-entry-binary-data">
+   <b><a href="#file-entry-binary-data">#file-entry-binary-data</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-file-entry-binary-data">2.1. Concepts</a>
+    <li><a href="#ref-for-file-entry-binary-data①">2.4.1. The getFile() method</a>
+    <li><a href="#ref-for-file-entry-binary-data②">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-file-entry-binary-data③">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-file-entry-binary-data④">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-file-entry-binary-data⑤">3.4. The showSaveFilePicker() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="file-entry-modification-timestamp">
+   <b><a href="#file-entry-modification-timestamp">#file-entry-modification-timestamp</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-file-entry-modification-timestamp">2.1. Concepts</a>
+    <li><a href="#ref-for-file-entry-modification-timestamp①">2.4.1. The getFile() method</a>
+    <li><a href="#ref-for-file-entry-modification-timestamp②">2.5.2. The getFileHandle() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="file-entry-lock">
+   <b><a href="#file-entry-lock">#file-entry-lock</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-file-entry-lock">2.1. Concepts</a> <a href="#ref-for-file-entry-lock①">(2)</a> <a href="#ref-for-file-entry-lock②">(3)</a> <a href="#ref-for-file-entry-lock③">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="file-entry-lock-take">
+   <b><a href="#file-entry-lock-take">#file-entry-lock-take</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-file-entry-lock-take">2.4.2. The createWritable() method</a> <a href="#ref-for-file-entry-lock-take①">(2)</a>
+    <li><a href="#ref-for-file-entry-lock-take②">2.4.3. The createSyncAccessHandle() method</a> <a href="#ref-for-file-entry-lock-take③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="file-entry-lock-release">
+   <b><a href="#file-entry-lock-release">#file-entry-lock-release</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-file-entry-lock-release">2.7.6. The close() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="directory">
+   <b><a href="#directory">#directory</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-directory">2.1. Concepts</a> <a href="#ref-for-directory①">(2)</a> <a href="#ref-for-directory②">(3)</a> <a href="#ref-for-directory③">(4)</a>
+    <li><a href="#ref-for-directory④">2.5. The FileSystemDirectoryHandle interface</a>
+    <li><a href="#ref-for-directory⑤">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-directory⑥">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-directory⑦">2.5.4. The removeEntry() method</a>
+    <li><a href="#ref-for-directory⑧">3.2.2. Starting Directory</a>
+    <li><a href="#ref-for-directory⑨">3.5. The showDirectoryPicker() method</a>
+    <li><a href="#ref-for-directory①⓪">3.6. Drag and Drop</a> <a href="#ref-for-directory①①">(2)</a>
+    <li><a href="#ref-for-directory①②">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="directory-entry-children">
+   <b><a href="#directory-entry-children">#directory-entry-children</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-directory-entry-children">2.1. Concepts</a> <a href="#ref-for-directory-entry-children①">(2)</a> <a href="#ref-for-directory-entry-children②">(3)</a>
+    <li><a href="#ref-for-directory-entry-children③">2.5.1. Directory iteration</a>
+    <li><a href="#ref-for-directory-entry-children④">2.5.2. The getFileHandle() method</a> <a href="#ref-for-directory-entry-children⑤">(2)</a>
+    <li><a href="#ref-for-directory-entry-children⑥">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-directory-entry-children⑦">(2)</a> <a href="#ref-for-directory-entry-children⑧">(3)</a>
+    <li><a href="#ref-for-directory-entry-children⑨">2.5.4. The removeEntry() method</a> <a href="#ref-for-directory-entry-children①⓪">(2)</a> <a href="#ref-for-directory-entry-children①①">(3)</a>
+    <li><a href="#ref-for-directory-entry-children①②">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="entry-parent">
+   <b><a href="#entry-parent">#entry-parent</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-entry-parent">2.1. Concepts</a>
+    <li><a href="#ref-for-entry-parent①">2.2. Permissions</a> <a href="#ref-for-entry-parent②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="entry-the-same-as">
+   <b><a href="#entry-the-same-as">#entry-the-same-as</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-entry-the-same-as">2.1. Concepts</a>
+    <li><a href="#ref-for-entry-the-same-as①">2.3.1. The isSameEntry() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="entry-resolve">
+   <b><a href="#entry-resolve">#entry-resolve</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-entry-resolve">2.1. Concepts</a>
+    <li><a href="#ref-for-entry-resolve①">2.5.5. The resolve() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-permissionname-file-system">
+   <b><a href="#dom-permissionname-file-system">#dom-permissionname-file-system</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-permissionname-file-system">2.2. Permissions</a> <a href="#ref-for-dom-permissionname-file-system①">(2)</a> <a href="#ref-for-dom-permissionname-file-system②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="enumdef-filesystempermissionmode">
+   <b><a href="#enumdef-filesystempermissionmode">#enumdef-filesystempermissionmode</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-filesystempermissionmode">2.2. Permissions</a> <a href="#ref-for-enumdef-filesystempermissionmode①">(2)</a> <a href="#ref-for-enumdef-filesystempermissionmode②">(3)</a> <a href="#ref-for-enumdef-filesystempermissionmode③">(4)</a>
+    <li><a href="#ref-for-enumdef-filesystempermissionmode④">2.3. The FileSystemHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystempermissionmode-read">
+   <b><a href="#dom-filesystempermissionmode-read">#dom-filesystempermissionmode-read</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystempermissionmode-read">2.2. Permissions</a> <a href="#ref-for-dom-filesystempermissionmode-read①">(2)</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-read②">2.3.2. The queryPermission() method</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-read③">2.3.3. The requestPermission() method</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-read④">2.4.1. The getFile() method</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-read⑤">2.5.1. Directory iteration</a> <a href="#ref-for-dom-filesystempermissionmode-read⑥">(2)</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-read⑦">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-read⑧">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-read⑨">3.1. Local File System Permissions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystempermissionmode-readwrite">
+   <b><a href="#dom-filesystempermissionmode-readwrite">#dom-filesystempermissionmode-readwrite</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystempermissionmode-readwrite">2.2. Permissions</a> <a href="#ref-for-dom-filesystempermissionmode-readwrite①">(2)</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-readwrite②">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-filesystempermissionmode-readwrite③">(2)</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-readwrite④">2.3.3. The requestPermission() method</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-readwrite⑤">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-readwrite⑥">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-readwrite⑦">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-readwrite⑧">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-readwrite⑨">2.5.4. The removeEntry() method</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-readwrite①⓪">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dom-filesystempermissionmode-readwrite①①">(2)</a>
+    <li><a href="#ref-for-dom-filesystempermissionmode-readwrite①②">3.1. Local File System Permissions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-filesystempermissiondescriptor">
+   <b><a href="#dictdef-filesystempermissiondescriptor">#dictdef-filesystempermissiondescriptor</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-filesystempermissiondescriptor">2.2. Permissions</a> <a href="#ref-for-dictdef-filesystempermissiondescriptor①">(2)</a> <a href="#ref-for-dictdef-filesystempermissiondescriptor②">(3)</a> <a href="#ref-for-dictdef-filesystempermissiondescriptor③">(4)</a> <a href="#ref-for-dictdef-filesystempermissiondescriptor④">(5)</a>
+    <li><a href="#ref-for-dictdef-filesystempermissiondescriptor⑤">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dictdef-filesystempermissiondescriptor⑥">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystempermissiondescriptor-handle">
+   <b><a href="#dom-filesystempermissiondescriptor-handle">#dom-filesystempermissiondescriptor-handle</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystempermissiondescriptor-handle">2.2. Permissions</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle①">(2)</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle②">(3)</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle③">(4)</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle④">(5)</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle⑤">(6)</a>
+    <li><a href="#ref-for-dom-filesystempermissiondescriptor-handle⑥">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle⑦">(2)</a>
+    <li><a href="#ref-for-dom-filesystempermissiondescriptor-handle⑧">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle⑨">(2)</a>
+    <li><a href="#ref-for-dom-filesystempermissiondescriptor-handle①⓪">3.1. Local File System Permissions</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle①①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystempermissiondescriptor-mode">
+   <b><a href="#dom-filesystempermissiondescriptor-mode">#dom-filesystempermissiondescriptor-mode</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystempermissiondescriptor-mode">2.2. Permissions</a> <a href="#ref-for-dom-filesystempermissiondescriptor-mode①">(2)</a> <a href="#ref-for-dom-filesystempermissiondescriptor-mode②">(3)</a> <a href="#ref-for-dom-filesystempermissiondescriptor-mode③">(4)</a> <a href="#ref-for-dom-filesystempermissiondescriptor-mode④">(5)</a>
+    <li><a href="#ref-for-dom-filesystempermissiondescriptor-mode⑤">2.3.2. The queryPermission() method</a>
+    <li><a href="#ref-for-dom-filesystempermissiondescriptor-mode⑥">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dom-filesystempermissiondescriptor-mode⑦">(2)</a>
+    <li><a href="#ref-for-dom-filesystempermissiondescriptor-mode⑧">3.1. Local File System Permissions</a> <a href="#ref-for-dom-filesystempermissiondescriptor-mode⑨">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="querying-file-system-permission">
+   <b><a href="#querying-file-system-permission">#querying-file-system-permission</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-querying-file-system-permission">2.3.2. The queryPermission() method</a>
+    <li><a href="#ref-for-querying-file-system-permission①">2.4.1. The getFile() method</a>
+    <li><a href="#ref-for-querying-file-system-permission②">2.5.1. Directory iteration</a> <a href="#ref-for-querying-file-system-permission③">(2)</a>
+    <li><a href="#ref-for-querying-file-system-permission④">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-querying-file-system-permission⑤">2.5.3. The getDirectoryHandle() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="requesting-file-system-permission">
+   <b><a href="#requesting-file-system-permission">#requesting-file-system-permission</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-requesting-file-system-permission">2.3.3. The requestPermission() method</a>
+    <li><a href="#ref-for-requesting-file-system-permission①">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-requesting-file-system-permission②">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-requesting-file-system-permission③">2.5.2. The getFileHandle() method</a>
+    <li><a href="#ref-for-requesting-file-system-permission④">2.5.3. The getDirectoryHandle() method</a>
+    <li><a href="#ref-for-requesting-file-system-permission⑤">2.5.4. The removeEntry() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-filesystemhandlepermissiondescriptor">
+   <b><a href="#dictdef-filesystemhandlepermissiondescriptor">#dictdef-filesystemhandlepermissiondescriptor</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-filesystemhandlepermissiondescriptor">2.3. The FileSystemHandle interface</a> <a href="#ref-for-dictdef-filesystemhandlepermissiondescriptor①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemhandlepermissiondescriptor-mode">
+   <b><a href="#dom-filesystemhandlepermissiondescriptor-mode">#dom-filesystemhandlepermissiondescriptor-mode</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemhandlepermissiondescriptor-mode">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-filesystemhandlepermissiondescriptor-mode①">(2)</a> <a href="#ref-for-dom-filesystemhandlepermissiondescriptor-mode②">(3)</a>
+    <li><a href="#ref-for-dom-filesystemhandlepermissiondescriptor-mode③">2.3.3. The requestPermission() method</a> <a href="#ref-for-dom-filesystemhandlepermissiondescriptor-mode④">(2)</a> <a href="#ref-for-dom-filesystemhandlepermissiondescriptor-mode⑤">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="enumdef-filesystemhandlekind">
+   <b><a href="#enumdef-filesystemhandlekind">#enumdef-filesystemhandlekind</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-filesystemhandlekind">2.3. The FileSystemHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemhandlekind-file">
+   <b><a href="#dom-filesystemhandlekind-file">#dom-filesystemhandlekind-file</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemhandlekind-file">2.3. The FileSystemHandle interface</a> <a href="#ref-for-dom-filesystemhandlekind-file①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemhandlekind-directory">
+   <b><a href="#dom-filesystemhandlekind-directory">#dom-filesystemhandlekind-directory</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemhandlekind-directory">2.3. The FileSystemHandle interface</a> <a href="#ref-for-dom-filesystemhandlekind-directory①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="filesystemhandle">
+   <b><a href="#filesystemhandle">#filesystemhandle</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-filesystemhandle">2.2. Permissions</a> <a href="#ref-for-filesystemhandle①">(2)</a> <a href="#ref-for-filesystemhandle②">(3)</a>
+    <li><a href="#ref-for-filesystemhandle③">2.3. The FileSystemHandle interface</a> <a href="#ref-for-filesystemhandle④">(2)</a> <a href="#ref-for-filesystemhandle⑤">(3)</a> <a href="#ref-for-filesystemhandle⑥">(4)</a> <a href="#ref-for-filesystemhandle⑦">(5)</a> <a href="#ref-for-filesystemhandle⑧">(6)</a>
+    <li><a href="#ref-for-filesystemhandle⑨">2.4. The FileSystemFileHandle interface</a> <a href="#ref-for-filesystemhandle①⓪">(2)</a>
+    <li><a href="#ref-for-filesystemhandle①①">2.5. The FileSystemDirectoryHandle interface</a> <a href="#ref-for-filesystemhandle①②">(2)</a> <a href="#ref-for-filesystemhandle①③">(3)</a> <a href="#ref-for-filesystemhandle①④">(4)</a>
+    <li><a href="#ref-for-filesystemhandle①⑤">3. Accessing Local File System</a>
+    <li><a href="#ref-for-filesystemhandle①⑥">3.2.2. Starting Directory</a>
+    <li><a href="#ref-for-filesystemhandle①⑦">3.6. Drag and Drop</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="filesystemhandle-entry">
+   <b><a href="#filesystemhandle-entry">#filesystemhandle-entry</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-filesystemhandle-entry">2.1. Concepts</a>
+    <li><a href="#ref-for-filesystemhandle-entry①">2.2. Permissions</a>
+    <li><a href="#ref-for-filesystemhandle-entry②">2.3. The FileSystemHandle interface</a> <a href="#ref-for-filesystemhandle-entry③">(2)</a> <a href="#ref-for-filesystemhandle-entry④">(3)</a> <a href="#ref-for-filesystemhandle-entry⑤">(4)</a>
+    <li><a href="#ref-for-filesystemhandle-entry⑥">2.3.1. The isSameEntry() method</a> <a href="#ref-for-filesystemhandle-entry⑦">(2)</a>
+    <li><a href="#ref-for-filesystemhandle-entry⑧">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-filesystemhandle-entry⑨">2.4.1. The getFile() method</a>
+    <li><a href="#ref-for-filesystemhandle-entry①⓪">2.4.2. The createWritable() method</a> <a href="#ref-for-filesystemhandle-entry①①">(2)</a>
+    <li><a href="#ref-for-filesystemhandle-entry①②">2.4.3. The createSyncAccessHandle() method</a> <a href="#ref-for-filesystemhandle-entry①③">(2)</a>
+    <li><a href="#ref-for-filesystemhandle-entry①④">2.5. The FileSystemDirectoryHandle interface</a>
+    <li><a href="#ref-for-filesystemhandle-entry①⑤">2.5.1. Directory iteration</a>
+    <li><a href="#ref-for-filesystemhandle-entry①⑥">2.5.2. The getFileHandle() method</a> <a href="#ref-for-filesystemhandle-entry①⑦">(2)</a> <a href="#ref-for-filesystemhandle-entry①⑧">(3)</a>
+    <li><a href="#ref-for-filesystemhandle-entry①⑨">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-filesystemhandle-entry②⓪">(2)</a> <a href="#ref-for-filesystemhandle-entry②①">(3)</a>
+    <li><a href="#ref-for-filesystemhandle-entry②②">2.5.4. The removeEntry() method</a>
+    <li><a href="#ref-for-filesystemhandle-entry②③">2.5.5. The resolve() method</a> <a href="#ref-for-filesystemhandle-entry②④">(2)</a>
+    <li><a href="#ref-for-filesystemhandle-entry②⑤">2.7.6. The close() method</a>
+    <li><a href="#ref-for-filesystemhandle-entry②⑥">3.2.2. Starting Directory</a>
+    <li><a href="#ref-for-filesystemhandle-entry②⑦">4. Accessing the Origin Private File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemhandle-kind">
+   <b><a href="#dom-filesystemhandle-kind">#dom-filesystemhandle-kind</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemhandle-kind">2.3. The FileSystemHandle interface</a> <a href="#ref-for-dom-filesystemhandle-kind①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemhandle-name">
+   <b><a href="#dom-filesystemhandle-name">#dom-filesystemhandle-name</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemhandle-name">2.3. The FileSystemHandle interface</a> <a href="#ref-for-dom-filesystemhandle-name①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemhandle-issameentry">
+   <b><a href="#dom-filesystemhandle-issameentry">#dom-filesystemhandle-issameentry</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemhandle-issameentry">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemhandle-issameentry①">2.3.1. The isSameEntry() method</a> <a href="#ref-for-dom-filesystemhandle-issameentry②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemhandle-querypermission">
+   <b><a href="#dom-filesystemhandle-querypermission">#dom-filesystemhandle-querypermission</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemhandle-querypermission">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemhandle-querypermission①">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-filesystemhandle-querypermission②">(2)</a> <a href="#ref-for-dom-filesystemhandle-querypermission③">(3)</a> <a href="#ref-for-dom-filesystemhandle-querypermission④">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemhandle-requestpermission">
+   <b><a href="#dom-filesystemhandle-requestpermission">#dom-filesystemhandle-requestpermission</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemhandle-requestpermission">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemhandle-requestpermission①">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-filesystemhandle-requestpermission②">(2)</a>
+    <li><a href="#ref-for-dom-filesystemhandle-requestpermission③">2.3.3. The requestPermission() method</a> <a href="#ref-for-dom-filesystemhandle-requestpermission④">(2)</a> <a href="#ref-for-dom-filesystemhandle-requestpermission⑤">(3)</a> <a href="#ref-for-dom-filesystemhandle-requestpermission⑥">(4)</a>
+    <li><a href="#ref-for-dom-filesystemhandle-requestpermission⑦">6.3. First-party vs third-party contexts.</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-filesystemcreatewritableoptions">
+   <b><a href="#dictdef-filesystemcreatewritableoptions">#dictdef-filesystemcreatewritableoptions</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-filesystemcreatewritableoptions">2.4. The FileSystemFileHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemcreatewritableoptions-keepexistingdata">
+   <b><a href="#dom-filesystemcreatewritableoptions-keepexistingdata">#dom-filesystemcreatewritableoptions-keepexistingdata</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemcreatewritableoptions-keepexistingdata">2.4.2. The createWritable() method</a> <a href="#ref-for-dom-filesystemcreatewritableoptions-keepexistingdata①">(2)</a> <a href="#ref-for-dom-filesystemcreatewritableoptions-keepexistingdata②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="enumdef-accesshandlemode">
+   <b><a href="#enumdef-accesshandlemode">#enumdef-accesshandlemode</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-accesshandlemode">2.4. The FileSystemFileHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-filesystemfilehandlecreateaccesshandleoptions">
+   <b><a href="#dictdef-filesystemfilehandlecreateaccesshandleoptions">#dictdef-filesystemfilehandlecreateaccesshandleoptions</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-filesystemfilehandlecreateaccesshandleoptions">2.4. The FileSystemFileHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemfilehandlecreateaccesshandleoptions-mode">
+   <b><a href="#dom-filesystemfilehandlecreateaccesshandleoptions-mode">#dom-filesystemfilehandlecreateaccesshandleoptions-mode</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemfilehandlecreateaccesshandleoptions-mode">2.4.3. The createSyncAccessHandle() method</a> <a href="#ref-for-dom-filesystemfilehandlecreateaccesshandleoptions-mode①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="filesystemfilehandle">
+   <b><a href="#filesystemfilehandle">#filesystemfilehandle</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-filesystemfilehandle">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-filesystemfilehandle①">2.4. The FileSystemFileHandle interface</a> <a href="#ref-for-filesystemfilehandle②">(2)</a> <a href="#ref-for-filesystemfilehandle③">(3)</a>
+    <li><a href="#ref-for-filesystemfilehandle④">2.5. The FileSystemDirectoryHandle interface</a>
+    <li><a href="#ref-for-filesystemfilehandle⑤">2.5.1. Directory iteration</a>
+    <li><a href="#ref-for-filesystemfilehandle⑥">2.5.2. The getFileHandle() method</a> <a href="#ref-for-filesystemfilehandle⑦">(2)</a>
+    <li><a href="#ref-for-filesystemfilehandle⑧">3. Accessing Local File System</a> <a href="#ref-for-filesystemfilehandle⑨">(2)</a>
+    <li><a href="#ref-for-filesystemfilehandle①⓪">3.2.2. Starting Directory</a>
+    <li><a href="#ref-for-filesystemfilehandle①①">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-filesystemfilehandle①②">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-filesystemfilehandle①③">3.6. Drag and Drop</a> <a href="#ref-for-filesystemfilehandle①④">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemfilehandle-getfile">
+   <b><a href="#dom-filesystemfilehandle-getfile">#dom-filesystemfilehandle-getfile</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemfilehandle-getfile">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemfilehandle-getfile①">2.4.1. The getFile() method</a> <a href="#ref-for-dom-filesystemfilehandle-getfile②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemfilehandle-createwritable">
+   <b><a href="#dom-filesystemfilehandle-createwritable">#dom-filesystemfilehandle-createwritable</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemfilehandle-createwritable">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemfilehandle-createwritable①">2.4.2. The createWritable() method</a> <a href="#ref-for-dom-filesystemfilehandle-createwritable②">(2)</a> <a href="#ref-for-dom-filesystemfilehandle-createwritable③">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemfilehandle-createsyncaccesshandle">
+   <b><a href="#dom-filesystemfilehandle-createsyncaccesshandle">#dom-filesystemfilehandle-createsyncaccesshandle</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemfilehandle-createsyncaccesshandle">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemfilehandle-createsyncaccesshandle①">2.4.3. The createSyncAccessHandle() method</a> <a href="#ref-for-dom-filesystemfilehandle-createsyncaccesshandle②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-filesystemgetfileoptions">
+   <b><a href="#dictdef-filesystemgetfileoptions">#dictdef-filesystemgetfileoptions</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-filesystemgetfileoptions">2.5. The FileSystemDirectoryHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemgetfileoptions-create">
+   <b><a href="#dom-filesystemgetfileoptions-create">#dom-filesystemgetfileoptions-create</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemgetfileoptions-create">2.5.2. The getFileHandle() method</a> <a href="#ref-for-dom-filesystemgetfileoptions-create①">(2)</a> <a href="#ref-for-dom-filesystemgetfileoptions-create②">(3)</a> <a href="#ref-for-dom-filesystemgetfileoptions-create③">(4)</a> <a href="#ref-for-dom-filesystemgetfileoptions-create④">(5)</a>
+    <li><a href="#ref-for-dom-filesystemgetfileoptions-create⑤">2.5.3. The getDirectoryHandle() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-filesystemgetdirectoryoptions">
+   <b><a href="#dictdef-filesystemgetdirectoryoptions">#dictdef-filesystemgetdirectoryoptions</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-filesystemgetdirectoryoptions">2.5. The FileSystemDirectoryHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemgetdirectoryoptions-create">
+   <b><a href="#dom-filesystemgetdirectoryoptions-create">#dom-filesystemgetdirectoryoptions-create</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemgetdirectoryoptions-create">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-dom-filesystemgetdirectoryoptions-create①">(2)</a> <a href="#ref-for-dom-filesystemgetdirectoryoptions-create②">(3)</a> <a href="#ref-for-dom-filesystemgetdirectoryoptions-create③">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-filesystemremoveoptions">
+   <b><a href="#dictdef-filesystemremoveoptions">#dictdef-filesystemremoveoptions</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-filesystemremoveoptions">2.5. The FileSystemDirectoryHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemremoveoptions-recursive">
+   <b><a href="#dom-filesystemremoveoptions-recursive">#dom-filesystemremoveoptions-recursive</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemremoveoptions-recursive">2.5.4. The removeEntry() method</a> <a href="#ref-for-dom-filesystemremoveoptions-recursive①">(2)</a> <a href="#ref-for-dom-filesystemremoveoptions-recursive②">(3)</a> <a href="#ref-for-dom-filesystemremoveoptions-recursive③">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="filesystemdirectoryhandle">
+   <b><a href="#filesystemdirectoryhandle">#filesystemdirectoryhandle</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-filesystemdirectoryhandle">2.3. The FileSystemHandle interface</a>
+    <li><a href="#ref-for-filesystemdirectoryhandle①">2.5. The FileSystemDirectoryHandle interface</a> <a href="#ref-for-filesystemdirectoryhandle②">(2)</a> <a href="#ref-for-filesystemdirectoryhandle③">(3)</a> <a href="#ref-for-filesystemdirectoryhandle④">(4)</a>
+    <li><a href="#ref-for-filesystemdirectoryhandle⑤">2.5.1. Directory iteration</a> <a href="#ref-for-filesystemdirectoryhandle⑥">(2)</a> <a href="#ref-for-filesystemdirectoryhandle⑦">(3)</a>
+    <li><a href="#ref-for-filesystemdirectoryhandle⑧">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-filesystemdirectoryhandle⑨">(2)</a>
+    <li><a href="#ref-for-filesystemdirectoryhandle①⓪">3. Accessing Local File System</a>
+    <li><a href="#ref-for-filesystemdirectoryhandle①①">3.2.2. Starting Directory</a> <a href="#ref-for-filesystemdirectoryhandle①②">(2)</a>
+    <li><a href="#ref-for-filesystemdirectoryhandle①③">3.5. The showDirectoryPicker() method</a>
+    <li><a href="#ref-for-filesystemdirectoryhandle①④">3.6. Drag and Drop</a> <a href="#ref-for-filesystemdirectoryhandle①⑤">(2)</a>
+    <li><a href="#ref-for-filesystemdirectoryhandle①⑥">4. Accessing the Origin Private File System</a> <a href="#ref-for-filesystemdirectoryhandle①⑦">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="filesystemdirectoryhandle-iterator-past-results">
+   <b><a href="#filesystemdirectoryhandle-iterator-past-results">#filesystemdirectoryhandle-iterator-past-results</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-filesystemdirectoryhandle-iterator-past-results">2.5.1. Directory iteration</a> <a href="#ref-for-filesystemdirectoryhandle-iterator-past-results①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemdirectoryhandle-getfilehandle">
+   <b><a href="#dom-filesystemdirectoryhandle-getfilehandle">#dom-filesystemdirectoryhandle-getfilehandle</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemdirectoryhandle-getfilehandle">2.5. The FileSystemDirectoryHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemdirectoryhandle-getfilehandle①">2.5.2. The getFileHandle() method</a> <a href="#ref-for-dom-filesystemdirectoryhandle-getfilehandle②">(2)</a> <a href="#ref-for-dom-filesystemdirectoryhandle-getfilehandle③">(3)</a> <a href="#ref-for-dom-filesystemdirectoryhandle-getfilehandle④">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemdirectoryhandle-getdirectoryhandle">
+   <b><a href="#dom-filesystemdirectoryhandle-getdirectoryhandle">#dom-filesystemdirectoryhandle-getdirectoryhandle</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle">2.5. The FileSystemDirectoryHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle①">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle②">(2)</a> <a href="#ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle③">(3)</a> <a href="#ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle④">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemdirectoryhandle-removeentry">
+   <b><a href="#dom-filesystemdirectoryhandle-removeentry">#dom-filesystemdirectoryhandle-removeentry</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemdirectoryhandle-removeentry">2.5. The FileSystemDirectoryHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemdirectoryhandle-removeentry①">2.5.4. The removeEntry() method</a> <a href="#ref-for-dom-filesystemdirectoryhandle-removeentry②">(2)</a> <a href="#ref-for-dom-filesystemdirectoryhandle-removeentry③">(3)</a> <a href="#ref-for-dom-filesystemdirectoryhandle-removeentry④">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemdirectoryhandle-resolve">
+   <b><a href="#dom-filesystemdirectoryhandle-resolve">#dom-filesystemdirectoryhandle-resolve</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemdirectoryhandle-resolve">2.5. The FileSystemDirectoryHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemdirectoryhandle-resolve①">2.5.5. The resolve() method</a> <a href="#ref-for-dom-filesystemdirectoryhandle-resolve②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="enumdef-writecommandtype">
+   <b><a href="#enumdef-writecommandtype">#enumdef-writecommandtype</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-writecommandtype">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-writecommandtype-write">
+   <b><a href="#dom-writecommandtype-write">#dom-writecommandtype-write</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-writecommandtype-write">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dom-writecommandtype-write①">(2)</a>
+    <li><a href="#ref-for-dom-writecommandtype-write②">2.6.1. The write() method</a> <a href="#ref-for-dom-writecommandtype-write③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-writecommandtype-seek">
+   <b><a href="#dom-writecommandtype-seek">#dom-writecommandtype-seek</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-writecommandtype-seek">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-dom-writecommandtype-seek①">2.6.1. The write() method</a>
+    <li><a href="#ref-for-dom-writecommandtype-seek②">2.6.2. The seek() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-writecommandtype-truncate">
+   <b><a href="#dom-writecommandtype-truncate">#dom-writecommandtype-truncate</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-writecommandtype-truncate">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-dom-writecommandtype-truncate①">2.6.1. The write() method</a> <a href="#ref-for-dom-writecommandtype-truncate②">(2)</a>
+    <li><a href="#ref-for-dom-writecommandtype-truncate③">2.6.3. The truncate() method</a> <a href="#ref-for-dom-writecommandtype-truncate④">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-writeparams">
+   <b><a href="#dictdef-writeparams">#dictdef-writeparams</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-writeparams">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dictdef-writeparams①">(2)</a> <a href="#ref-for-dictdef-writeparams②">(3)</a> <a href="#ref-for-dictdef-writeparams③">(4)</a> <a href="#ref-for-dictdef-writeparams④">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-writeparams-type">
+   <b><a href="#dom-writeparams-type">#dom-writeparams-type</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-writeparams-type">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-dom-writeparams-type①">2.6.1. The write() method</a> <a href="#ref-for-dom-writeparams-type②">(2)</a> <a href="#ref-for-dom-writeparams-type③">(3)</a> <a href="#ref-for-dom-writeparams-type④">(4)</a>
+    <li><a href="#ref-for-dom-writeparams-type⑤">2.6.2. The seek() method</a>
+    <li><a href="#ref-for-dom-writeparams-type⑥">2.6.3. The truncate() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-writeparams-size">
+   <b><a href="#dom-writeparams-size">#dom-writeparams-size</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-writeparams-size">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dom-writeparams-size①">(2)</a>
+    <li><a href="#ref-for-dom-writeparams-size②">2.6.1. The write() method</a>
+    <li><a href="#ref-for-dom-writeparams-size③">2.6.3. The truncate() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-writeparams-position">
+   <b><a href="#dom-writeparams-position">#dom-writeparams-position</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-writeparams-position">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dom-writeparams-position①">(2)</a> <a href="#ref-for-dom-writeparams-position②">(3)</a> <a href="#ref-for-dom-writeparams-position③">(4)</a>
+    <li><a href="#ref-for-dom-writeparams-position④">2.6.1. The write() method</a> <a href="#ref-for-dom-writeparams-position⑤">(2)</a>
+    <li><a href="#ref-for-dom-writeparams-position⑥">2.6.2. The seek() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-writeparams-data">
+   <b><a href="#dom-writeparams-data">#dom-writeparams-data</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-writeparams-data">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-dom-writeparams-data①">2.6.1. The write() method</a> <a href="#ref-for-dom-writeparams-data②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="typedefdef-filesystemwritechunktype">
+   <b><a href="#typedefdef-filesystemwritechunktype">#typedefdef-filesystemwritechunktype</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-typedefdef-filesystemwritechunktype">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-typedefdef-filesystemwritechunktype①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="filesystemwritablefilestream">
+   <b><a href="#filesystemwritablefilestream">#filesystemwritablefilestream</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-filesystemwritablefilestream">2.1. Concepts</a>
+    <li><a href="#ref-for-filesystemwritablefilestream①">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-filesystemwritablefilestream②">2.4.2. The createWritable() method</a> <a href="#ref-for-filesystemwritablefilestream③">(2)</a>
+    <li><a href="#ref-for-filesystemwritablefilestream④">2.4.3. The createSyncAccessHandle() method</a>
+    <li><a href="#ref-for-filesystemwritablefilestream⑤">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemwritablefilestream⑥">(2)</a> <a href="#ref-for-filesystemwritablefilestream⑦">(3)</a> <a href="#ref-for-filesystemwritablefilestream⑧">(4)</a> <a href="#ref-for-filesystemwritablefilestream⑨">(5)</a> <a href="#ref-for-filesystemwritablefilestream①⓪">(6)</a> <a href="#ref-for-filesystemwritablefilestream①①">(7)</a> <a href="#ref-for-filesystemwritablefilestream①②">(8)</a> <a href="#ref-for-filesystemwritablefilestream①③">(9)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="filesystemwritablefilestream-file">
+   <b><a href="#filesystemwritablefilestream-file">#filesystemwritablefilestream-file</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-filesystemwritablefilestream-file">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="filesystemwritablefilestream-buffer">
+   <b><a href="#filesystemwritablefilestream-buffer">#filesystemwritablefilestream-buffer</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-filesystemwritablefilestream-buffer">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-filesystemwritablefilestream-buffer①">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemwritablefilestream-buffer②">(2)</a> <a href="#ref-for-filesystemwritablefilestream-buffer③">(3)</a> <a href="#ref-for-filesystemwritablefilestream-buffer④">(4)</a> <a href="#ref-for-filesystemwritablefilestream-buffer⑤">(5)</a> <a href="#ref-for-filesystemwritablefilestream-buffer⑥">(6)</a> <a href="#ref-for-filesystemwritablefilestream-buffer⑦">(7)</a> <a href="#ref-for-filesystemwritablefilestream-buffer⑧">(8)</a> <a href="#ref-for-filesystemwritablefilestream-buffer⑨">(9)</a> <a href="#ref-for-filesystemwritablefilestream-buffer①⓪">(10)</a> <a href="#ref-for-filesystemwritablefilestream-buffer①①">(11)</a> <a href="#ref-for-filesystemwritablefilestream-buffer①②">(12)</a> <a href="#ref-for-filesystemwritablefilestream-buffer①③">(13)</a> <a href="#ref-for-filesystemwritablefilestream-buffer①④">(14)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="filesystemwritablefilestream-seekoffset">
+   <b><a href="#filesystemwritablefilestream-seekoffset">#filesystemwritablefilestream-seekoffset</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-filesystemwritablefilestream-seekoffset">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemwritablefilestream-seekoffset①">(2)</a> <a href="#ref-for-filesystemwritablefilestream-seekoffset②">(3)</a> <a href="#ref-for-filesystemwritablefilestream-seekoffset③">(4)</a> <a href="#ref-for-filesystemwritablefilestream-seekoffset④">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="create-a-new-filesystemwritablefilestream">
+   <b><a href="#create-a-new-filesystemwritablefilestream">#create-a-new-filesystemwritablefilestream</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-create-a-new-filesystemwritablefilestream">2.4.2. The createWritable() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="write-a-chunk">
+   <b><a href="#write-a-chunk">#write-a-chunk</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-write-a-chunk">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemwritablefilestream-write">
+   <b><a href="#dom-filesystemwritablefilestream-write">#dom-filesystemwritablefilestream-write</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemwritablefilestream-write">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dom-filesystemwritablefilestream-write①">(2)</a>
+    <li><a href="#ref-for-dom-filesystemwritablefilestream-write②">2.6.1. The write() method</a> <a href="#ref-for-dom-filesystemwritablefilestream-write③">(2)</a> <a href="#ref-for-dom-filesystemwritablefilestream-write④">(3)</a> <a href="#ref-for-dom-filesystemwritablefilestream-write⑤">(4)</a> <a href="#ref-for-dom-filesystemwritablefilestream-write⑥">(5)</a> <a href="#ref-for-dom-filesystemwritablefilestream-write⑦">(6)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemwritablefilestream-seek">
+   <b><a href="#dom-filesystemwritablefilestream-seek">#dom-filesystemwritablefilestream-seek</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemwritablefilestream-seek">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-dom-filesystemwritablefilestream-seek①">2.6.2. The seek() method</a> <a href="#ref-for-dom-filesystemwritablefilestream-seek②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemwritablefilestream-truncate">
+   <b><a href="#dom-filesystemwritablefilestream-truncate">#dom-filesystemwritablefilestream-truncate</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemwritablefilestream-truncate">2.6. The FileSystemWritableFileStream interface</a>
+    <li><a href="#ref-for-dom-filesystemwritablefilestream-truncate①">2.6.3. The truncate() method</a> <a href="#ref-for-dom-filesystemwritablefilestream-truncate②">(2)</a>
+    <li><a href="#ref-for-dom-filesystemwritablefilestream-truncate③">7.3. Filling up a users disk</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-filesystemreadwriteoptions">
+   <b><a href="#dictdef-filesystemreadwriteoptions">#dictdef-filesystemreadwriteoptions</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-filesystemreadwriteoptions">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-dictdef-filesystemreadwriteoptions①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemreadwriteoptions-at">
+   <b><a href="#dom-filesystemreadwriteoptions-at">#dom-filesystemreadwriteoptions-at</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemreadwriteoptions-at">2.7.1. The read() method</a> <a href="#ref-for-dom-filesystemreadwriteoptions-at①">(2)</a>
+    <li><a href="#ref-for-dom-filesystemreadwriteoptions-at②">2.7.2. The write() method</a> <a href="#ref-for-dom-filesystemreadwriteoptions-at③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="filesystemsyncaccesshandle">
+   <b><a href="#filesystemsyncaccesshandle">#filesystemsyncaccesshandle</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-filesystemsyncaccesshandle">2.1. Concepts</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle①">2.4. The FileSystemFileHandle interface</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle②">2.4.2. The createWritable() method</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle③">2.4.3. The createSyncAccessHandle() method</a> <a href="#ref-for-filesystemsyncaccesshandle④">(2)</a> <a href="#ref-for-filesystemsyncaccesshandle⑤">(3)</a> <a href="#ref-for-filesystemsyncaccesshandle⑥">(4)</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle⑦">2.7. The FileSystemSyncAccessHandle interface</a> <a href="#ref-for-filesystemsyncaccesshandle⑧">(2)</a> <a href="#ref-for-filesystemsyncaccesshandle⑨">(3)</a> <a href="#ref-for-filesystemsyncaccesshandle①⓪">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemsyncaccesshandle-read">
+   <b><a href="#dom-filesystemsyncaccesshandle-read">#dom-filesystemsyncaccesshandle-read</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-read">2.7.1. The read() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-read①">(2)</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-read②">2.7.5. The flush() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemsyncaccesshandle-write">
+   <b><a href="#dom-filesystemsyncaccesshandle-write">#dom-filesystemsyncaccesshandle-write</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-write">2.7.2. The write() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-write①">(2)</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-write②">2.7.5. The flush() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="filesystemsyncaccesshandle-file">
+   <b><a href="#filesystemsyncaccesshandle-file">#filesystemsyncaccesshandle-file</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemsyncaccesshandle-file①">(2)</a> <a href="#ref-for-filesystemsyncaccesshandle-file②">(3)</a>
+    <li><a href="#ref-for-filesystemsyncaccesshandle-file③">2.7. The FileSystemSyncAccessHandle interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="create-a-new-filesystemsyncaccesshandle">
+   <b><a href="#create-a-new-filesystemsyncaccesshandle">#create-a-new-filesystemsyncaccesshandle</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-create-a-new-filesystemsyncaccesshandle">2.4.3. The createSyncAccessHandle() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemsyncaccesshandle-truncate">
+   <b><a href="#dom-filesystemsyncaccesshandle-truncate">#dom-filesystemsyncaccesshandle-truncate</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-truncate">2.7. The FileSystemSyncAccessHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-truncate①">2.7.3. The truncate() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-truncate②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemsyncaccesshandle-getsize">
+   <b><a href="#dom-filesystemsyncaccesshandle-getsize">#dom-filesystemsyncaccesshandle-getsize</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-getsize">2.7. The FileSystemSyncAccessHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-getsize①">2.7.4. The getSize() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-getsize②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemsyncaccesshandle-flush">
+   <b><a href="#dom-filesystemsyncaccesshandle-flush">#dom-filesystemsyncaccesshandle-flush</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-flush">2.7. The FileSystemSyncAccessHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-flush①">2.7.5. The flush() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-flush②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filesystemsyncaccesshandle-close">
+   <b><a href="#dom-filesystemsyncaccesshandle-close">#dom-filesystemsyncaccesshandle-close</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-close">2.7. The FileSystemSyncAccessHandle interface</a>
+    <li><a href="#ref-for-dom-filesystemsyncaccesshandle-close①">2.7.6. The close() method</a> <a href="#ref-for-dom-filesystemsyncaccesshandle-close②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="typedefdef-startindirectory">
+   <b><a href="#typedefdef-startindirectory">#typedefdef-startindirectory</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-typedefdef-startindirectory">3. Accessing Local File System</a> <a href="#ref-for-typedefdef-startindirectory①">(2)</a>
+    <li><a href="#ref-for-typedefdef-startindirectory②">3.2.2. Starting Directory</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-filepickeraccepttype">
+   <b><a href="#dictdef-filepickeraccepttype">#dictdef-filepickeraccepttype</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-filepickeraccepttype">3. Accessing Local File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filepickeraccepttype-description">
+   <b><a href="#dom-filepickeraccepttype-description">#dom-filepickeraccepttype-description</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filepickeraccepttype-description">3.2.1. Accepted file types</a> <a href="#ref-for-dom-filepickeraccepttype-description①">(2)</a> <a href="#ref-for-dom-filepickeraccepttype-description②">(3)</a> <a href="#ref-for-dom-filepickeraccepttype-description③">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filepickeraccepttype-accept">
+   <b><a href="#dom-filepickeraccepttype-accept">#dom-filepickeraccepttype-accept</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filepickeraccepttype-accept">3.2.1. Accepted file types</a> <a href="#ref-for-dom-filepickeraccepttype-accept①">(2)</a> <a href="#ref-for-dom-filepickeraccepttype-accept②">(3)</a> <a href="#ref-for-dom-filepickeraccepttype-accept③">(4)</a> <a href="#ref-for-dom-filepickeraccepttype-accept④">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-filepickeroptions">
+   <b><a href="#dictdef-filepickeroptions">#dictdef-filepickeroptions</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-filepickeroptions">3. Accessing Local File System</a> <a href="#ref-for-dictdef-filepickeroptions①">(2)</a>
+    <li><a href="#ref-for-dictdef-filepickeroptions②">3.2.1. Accepted file types</a> <a href="#ref-for-dictdef-filepickeroptions③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filepickeroptions-types">
+   <b><a href="#dom-filepickeroptions-types">#dom-filepickeroptions-types</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filepickeroptions-types">3.2.1. Accepted file types</a> <a href="#ref-for-dom-filepickeroptions-types①">(2)</a> <a href="#ref-for-dom-filepickeroptions-types②">(3)</a> <a href="#ref-for-dom-filepickeroptions-types③">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filepickeroptions-excludeacceptalloption">
+   <b><a href="#dom-filepickeroptions-excludeacceptalloption">#dom-filepickeroptions-excludeacceptalloption</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filepickeroptions-excludeacceptalloption">3.2.1. Accepted file types</a> <a href="#ref-for-dom-filepickeroptions-excludeacceptalloption①">(2)</a> <a href="#ref-for-dom-filepickeroptions-excludeacceptalloption②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filepickeroptions-id">
+   <b><a href="#dom-filepickeroptions-id">#dom-filepickeroptions-id</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filepickeroptions-id">3.2.2. Starting Directory</a> <a href="#ref-for-dom-filepickeroptions-id①">(2)</a> <a href="#ref-for-dom-filepickeroptions-id②">(3)</a> <a href="#ref-for-dom-filepickeroptions-id③">(4)</a> <a href="#ref-for-dom-filepickeroptions-id④">(5)</a> <a href="#ref-for-dom-filepickeroptions-id⑤">(6)</a> <a href="#ref-for-dom-filepickeroptions-id⑥">(7)</a> <a href="#ref-for-dom-filepickeroptions-id⑦">(8)</a> <a href="#ref-for-dom-filepickeroptions-id⑧">(9)</a> <a href="#ref-for-dom-filepickeroptions-id⑨">(10)</a> <a href="#ref-for-dom-filepickeroptions-id①⓪">(11)</a> <a href="#ref-for-dom-filepickeroptions-id①①">(12)</a>
+    <li><a href="#ref-for-dom-filepickeroptions-id①②">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-dom-filepickeroptions-id①③">(2)</a>
+    <li><a href="#ref-for-dom-filepickeroptions-id①④">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-dom-filepickeroptions-id①⑤">(2)</a>
+    <li><a href="#ref-for-dom-filepickeroptions-id①⑥">3.5. The showDirectoryPicker() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-filepickeroptions-startin">
+   <b><a href="#dom-filepickeroptions-startin">#dom-filepickeroptions-startin</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-filepickeroptions-startin">3.2.2. Starting Directory</a> <a href="#ref-for-dom-filepickeroptions-startin①">(2)</a> <a href="#ref-for-dom-filepickeroptions-startin②">(3)</a> <a href="#ref-for-dom-filepickeroptions-startin③">(4)</a> <a href="#ref-for-dom-filepickeroptions-startin④">(5)</a> <a href="#ref-for-dom-filepickeroptions-startin⑤">(6)</a> <a href="#ref-for-dom-filepickeroptions-startin⑥">(7)</a> <a href="#ref-for-dom-filepickeroptions-startin⑦">(8)</a> <a href="#ref-for-dom-filepickeroptions-startin⑧">(9)</a>
+    <li><a href="#ref-for-dom-filepickeroptions-startin⑨">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-dom-filepickeroptions-startin①⓪">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-dom-filepickeroptions-startin①①">3.5. The showDirectoryPicker() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-openfilepickeroptions">
+   <b><a href="#dictdef-openfilepickeroptions">#dictdef-openfilepickeroptions</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-openfilepickeroptions">3. Accessing Local File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-openfilepickeroptions-multiple">
+   <b><a href="#dom-openfilepickeroptions-multiple">#dom-openfilepickeroptions-multiple</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-openfilepickeroptions-multiple">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-dom-openfilepickeroptions-multiple①">(2)</a> <a href="#ref-for-dom-openfilepickeroptions-multiple②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-savefilepickeroptions">
+   <b><a href="#dictdef-savefilepickeroptions">#dictdef-savefilepickeroptions</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-savefilepickeroptions">3. Accessing Local File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-savefilepickeroptions-suggestedname">
+   <b><a href="#dom-savefilepickeroptions-suggestedname">#dom-savefilepickeroptions-suggestedname</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-savefilepickeroptions-suggestedname">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-dom-savefilepickeroptions-suggestedname①">(2)</a> <a href="#ref-for-dom-savefilepickeroptions-suggestedname②">(3)</a> <a href="#ref-for-dom-savefilepickeroptions-suggestedname③">(4)</a> <a href="#ref-for-dom-savefilepickeroptions-suggestedname④">(5)</a> <a href="#ref-for-dom-savefilepickeroptions-suggestedname⑤">(6)</a> <a href="#ref-for-dom-savefilepickeroptions-suggestedname⑥">(7)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-directorypickeroptions">
+   <b><a href="#dictdef-directorypickeroptions">#dictdef-directorypickeroptions</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-directorypickeroptions">3. Accessing Local File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-directorypickeroptions-id">
+   <b><a href="#dom-directorypickeroptions-id">#dom-directorypickeroptions-id</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-directorypickeroptions-id">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-dom-directorypickeroptions-id①">(2)</a> <a href="#ref-for-dom-directorypickeroptions-id②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-directorypickeroptions-startin">
+   <b><a href="#dom-directorypickeroptions-startin">#dom-directorypickeroptions-startin</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-directorypickeroptions-startin">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-dom-directorypickeroptions-startin①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="local-file-system-handle-factories">
+   <b><a href="#local-file-system-handle-factories">#local-file-system-handle-factories</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-local-file-system-handle-factories">2.1. Concepts</a>
+    <li><a href="#ref-for-local-file-system-handle-factories①">2.3.2. The queryPermission() method</a>
+    <li><a href="#ref-for-local-file-system-handle-factories②">3.1. Local File System Permissions</a> <a href="#ref-for-local-file-system-handle-factories③">(2)</a>
+    <li><a href="#ref-for-local-file-system-handle-factories④">3.6. Drag and Drop</a>
+    <li><a href="#ref-for-local-file-system-handle-factories⑤">6.3. First-party vs third-party contexts.</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="is-allowed-to-show-a-file-picker">
+   <b><a href="#is-allowed-to-show-a-file-picker">#is-allowed-to-show-a-file-picker</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-is-allowed-to-show-a-file-picker">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-is-allowed-to-show-a-file-picker①">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-is-allowed-to-show-a-file-picker②">3.5. The showDirectoryPicker() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="process-accept-types">
+   <b><a href="#process-accept-types">#process-accept-types</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-process-accept-types">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-process-accept-types①">3.4. The showSaveFilePicker() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="validate-a-suffix">
+   <b><a href="#validate-a-suffix">#validate-a-suffix</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-validate-a-suffix">3.2.1. Accepted file types</a> <a href="#ref-for-validate-a-suffix①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="recently-picked-directory-map">
+   <b><a href="#recently-picked-directory-map">#recently-picked-directory-map</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-recently-picked-directory-map">3.2.2. Starting Directory</a> <a href="#ref-for-recently-picked-directory-map①">(2)</a> <a href="#ref-for-recently-picked-directory-map②">(3)</a> <a href="#ref-for-recently-picked-directory-map③">(4)</a> <a href="#ref-for-recently-picked-directory-map④">(5)</a> <a href="#ref-for-recently-picked-directory-map⑤">(6)</a> <a href="#ref-for-recently-picked-directory-map⑥">(7)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="path-id-map">
+   <b><a href="#path-id-map">#path-id-map</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-path-id-map">3.2.2. Starting Directory</a> <a href="#ref-for-path-id-map①">(2)</a> <a href="#ref-for-path-id-map②">(3)</a> <a href="#ref-for-path-id-map③">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="valid-path-id">
+   <b><a href="#valid-path-id">#valid-path-id</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-valid-path-id">3.2.2. Starting Directory</a> <a href="#ref-for-valid-path-id①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="enumdef-wellknowndirectory">
+   <b><a href="#enumdef-wellknowndirectory">#enumdef-wellknowndirectory</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-wellknowndirectory">3. Accessing Local File System</a> <a href="#ref-for-enumdef-wellknowndirectory①">(2)</a>
+    <li><a href="#ref-for-enumdef-wellknowndirectory②">3.2.2. Starting Directory</a> <a href="#ref-for-enumdef-wellknowndirectory③">(2)</a> <a href="#ref-for-enumdef-wellknowndirectory④">(3)</a> <a href="#ref-for-enumdef-wellknowndirectory⑤">(4)</a> <a href="#ref-for-enumdef-wellknowndirectory⑥">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-wellknowndirectory-desktop">
+   <b><a href="#dom-wellknowndirectory-desktop">#dom-wellknowndirectory-desktop</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-wellknowndirectory-desktop">3. Accessing Local File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-wellknowndirectory-documents">
+   <b><a href="#dom-wellknowndirectory-documents">#dom-wellknowndirectory-documents</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-wellknowndirectory-documents">3. Accessing Local File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-wellknowndirectory-downloads">
+   <b><a href="#dom-wellknowndirectory-downloads">#dom-wellknowndirectory-downloads</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-wellknowndirectory-downloads">3. Accessing Local File System</a>
+    <li><a href="#ref-for-dom-wellknowndirectory-downloads①">3.2.2. Starting Directory</a> <a href="#ref-for-dom-wellknowndirectory-downloads②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-wellknowndirectory-music">
+   <b><a href="#dom-wellknowndirectory-music">#dom-wellknowndirectory-music</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-wellknowndirectory-music">3. Accessing Local File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-wellknowndirectory-pictures">
+   <b><a href="#dom-wellknowndirectory-pictures">#dom-wellknowndirectory-pictures</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-wellknowndirectory-pictures">3. Accessing Local File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-wellknowndirectory-videos">
+   <b><a href="#dom-wellknowndirectory-videos">#dom-wellknowndirectory-videos</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-wellknowndirectory-videos">3. Accessing Local File System</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="wellknowndirectory-determine-the-directory-the-picker-will-start-in">
+   <b><a href="#wellknowndirectory-determine-the-directory-the-picker-will-start-in">#wellknowndirectory-determine-the-directory-the-picker-will-start-in</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-wellknowndirectory-determine-the-directory-the-picker-will-start-in">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-wellknowndirectory-determine-the-directory-the-picker-will-start-in①">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-wellknowndirectory-determine-the-directory-the-picker-will-start-in②">3.5. The showDirectoryPicker() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="wellknowndirectory-remember-a-picked-directory">
+   <b><a href="#wellknowndirectory-remember-a-picked-directory">#wellknowndirectory-remember-a-picked-directory</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-wellknowndirectory-remember-a-picked-directory">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-wellknowndirectory-remember-a-picked-directory①">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-wellknowndirectory-remember-a-picked-directory②">3.5. The showDirectoryPicker() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-window-showopenfilepicker">
+   <b><a href="#dom-window-showopenfilepicker">#dom-window-showopenfilepicker</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-window-showopenfilepicker">3. Accessing Local File System</a> <a href="#ref-for-dom-window-showopenfilepicker①">(2)</a>
+    <li><a href="#ref-for-dom-window-showopenfilepicker②">3.2.1. Accepted file types</a>
+    <li><a href="#ref-for-dom-window-showopenfilepicker③">3.3. The showOpenFilePicker() method</a> <a href="#ref-for-dom-window-showopenfilepicker④">(2)</a> <a href="#ref-for-dom-window-showopenfilepicker⑤">(3)</a> <a href="#ref-for-dom-window-showopenfilepicker⑥">(4)</a> <a href="#ref-for-dom-window-showopenfilepicker⑦">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-window-showsavefilepicker">
+   <b><a href="#dom-window-showsavefilepicker">#dom-window-showsavefilepicker</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-window-showsavefilepicker">3. Accessing Local File System</a> <a href="#ref-for-dom-window-showsavefilepicker①">(2)</a>
+    <li><a href="#ref-for-dom-window-showsavefilepicker②">3.1. Local File System Permissions</a>
+    <li><a href="#ref-for-dom-window-showsavefilepicker③">3.2.1. Accepted file types</a>
+    <li><a href="#ref-for-dom-window-showsavefilepicker④">3.4. The showSaveFilePicker() method</a> <a href="#ref-for-dom-window-showsavefilepicker⑤">(2)</a> <a href="#ref-for-dom-window-showsavefilepicker⑥">(3)</a> <a href="#ref-for-dom-window-showsavefilepicker⑦">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-window-showdirectorypicker">
+   <b><a href="#dom-window-showdirectorypicker">#dom-window-showdirectorypicker</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-window-showdirectorypicker">3. Accessing Local File System</a> <a href="#ref-for-dom-window-showdirectorypicker①">(2)</a>
+    <li><a href="#ref-for-dom-window-showdirectorypicker②">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-dom-window-showdirectorypicker③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-datatransferitem-getasfilesystemhandle">
+   <b><a href="#dom-datatransferitem-getasfilesystemhandle">#dom-datatransferitem-getasfilesystemhandle</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-datatransferitem-getasfilesystemhandle">3.6. Drag and Drop</a> <a href="#ref-for-dom-datatransferitem-getasfilesystemhandle①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="wellknowndirectory-origin-private-file-system">
+   <b><a href="#wellknowndirectory-origin-private-file-system">#wellknowndirectory-origin-private-file-system</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-wellknowndirectory-origin-private-file-system">2.2. Permissions</a>
+    <li><a href="#ref-for-wellknowndirectory-origin-private-file-system①">2.4.3. The createSyncAccessHandle() method</a> <a href="#ref-for-wellknowndirectory-origin-private-file-system②">(2)</a>
+    <li><a href="#ref-for-wellknowndirectory-origin-private-file-system③">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-wellknowndirectory-origin-private-file-system④">(2)</a>
+    <li><a href="#ref-for-wellknowndirectory-origin-private-file-system⑤">3.2.2. Starting Directory</a>
+    <li><a href="#ref-for-wellknowndirectory-origin-private-file-system⑥">4. Accessing the Origin Private File System</a> <a href="#ref-for-wellknowndirectory-origin-private-file-system⑦">(2)</a>
+    <li><a href="#ref-for-wellknowndirectory-origin-private-file-system⑧">7.3. Filling up a users disk</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-storagemanager-getdirectory">
+   <b><a href="#dom-storagemanager-getdirectory">#dom-storagemanager-getdirectory</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-storagemanager-getdirectory">1. Introduction</a>
+    <li><a href="#ref-for-dom-storagemanager-getdirectory①">2.1. Concepts</a>
+    <li><a href="#ref-for-dom-storagemanager-getdirectory②">4. Accessing the Origin Private File System</a> <a href="#ref-for-dom-storagemanager-getdirectory③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="wellknowndirectory-too-sensitive-or-dangerous">
+   <b><a href="#wellknowndirectory-too-sensitive-or-dangerous">#wellknowndirectory-too-sensitive-or-dangerous</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-wellknowndirectory-too-sensitive-or-dangerous">3.3. The showOpenFilePicker() method</a>
+    <li><a href="#ref-for-wellknowndirectory-too-sensitive-or-dangerous①">3.4. The showSaveFilePicker() method</a>
+    <li><a href="#ref-for-wellknowndirectory-too-sensitive-or-dangerous②">3.5. The showDirectoryPicker() method</a>
+    <li><a href="#ref-for-wellknowndirectory-too-sensitive-or-dangerous③">3.6. Drag and Drop</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="wellknowndirectory-malware-scans-and-safe-browsing-checks">
+   <b><a href="#wellknowndirectory-malware-scans-and-safe-browsing-checks">#wellknowndirectory-malware-scans-and-safe-browsing-checks</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-wellknowndirectory-malware-scans-and-safe-browsing-checks">2.6. The FileSystemWritableFileStream interface</a>
+   </ul>
+  </aside>
+<script>/* script-dfn-panel */
+
+document.body.addEventListener("click", function(e) {
+    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+    // Find the dfn element or panel, if any, that was clicked on.
+    var el = e.target;
+    var target;
+    var hitALink = false;
+    while(el.parentElement) {
+        if(el.tagName == "A") {
+            // Clicking on a link in a <dfn> shouldn't summon the panel
+            hitALink = true;
+        }
+        if(el.classList.contains("dfn-paneled")) {
+            target = "dfn";
+            break;
+        }
+        if(el.classList.contains("dfn-panel")) {
+            target = "dfn-panel";
+            break;
+        }
+        el = el.parentElement;
+    }
+    if(target != "dfn-panel") {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+            el.classList.remove("on");
+            el.classList.remove("activated");
+        });
+    }
+    if(target == "dfn" && !hitALink) {
+        // open the panel
+        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
+        if(dfnPanel) {
+            dfnPanel.classList.add("on");
+            var rect = el.getBoundingClientRect();
+            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+            dfnPanel.style.top = window.scrollY + rect.top + "px";
+            var panelRect = dfnPanel.getBoundingClientRect();
+            var panelWidth = panelRect.right - panelRect.left;
+            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                // Reposition, because the panel is overflowing
+                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+            }
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
+        }
+    } else if(target == "dfn-panel") {
+        // Switch it to "activated" state, which pins it.
+        el.classList.add("activated");
+        el.style.left = null;
+        el.style.top = null;
+    }
+
+});
+</script>
+<script>/* script-mdn-anno */
+
+            document.body.addEventListener("click", (e) => {
+                if(e.target.closest(".mdn-anno-btn")) {
+                    e.target.closest(".mdn-anno").classList.toggle("wrapped");
+                }
+            });
+            </script>
+<script>/* script-var-click-highlighting */
+
+    document.addEventListener("click", e=>{
+        if(e.target.nodeName == "VAR") {
+            highlightSameAlgoVars(e.target);
+        }
+    });
+    {
+        const indexCounts = new Map();
+        const indexNames = new Map();
+        function highlightSameAlgoVars(v) {
+            // Find the algorithm container.
+            let algoContainer = null;
+            let searchEl = v;
+            while(algoContainer == null && searchEl != document.body) {
+                searchEl = searchEl.parentNode;
+                if(searchEl.hasAttribute("data-algorithm")) {
+                    algoContainer = searchEl;
+                }
+            }
+
+            // Not highlighting document-global vars,
+            // too likely to be unrelated.
+            if(algoContainer == null) return;
+
+            const algoName = algoContainer.getAttribute("data-algorithm");
+            const varName = getVarName(v);
+            const addClass = !v.classList.contains("selected");
+            let highlightClass = null;
+            if(addClass) {
+                const index = chooseHighlightIndex(algoName, varName);
+                indexCounts.get(algoName)[index] += 1;
+                indexNames.set(algoName+"///"+varName, index);
+                highlightClass = nameFromIndex(index);
+            } else {
+                const index = previousHighlightIndex(algoName, varName);
+                indexCounts.get(algoName)[index] -= 1;
+                highlightClass = nameFromIndex(index);
+            }
+
+            // Find all same-name vars, and toggle their class appropriately.
+            for(const el of algoContainer.querySelectorAll("var")) {
+                if(getVarName(el) == varName) {
+                    el.classList.toggle("selected", addClass);
+                    el.classList.toggle(highlightClass, addClass);
+                }
+            }
+        }
+        function getVarName(el) {
+            return el.textContent.replace(/(\s|\xa0)+/, " ").trim();
+        }
+        function chooseHighlightIndex(algoName, varName) {
+            let indexes = null;
+            if(indexCounts.has(algoName)) {
+                indexes = indexCounts.get(algoName);
+            } else {
+                // 7 classes right now
+                indexes = [0,0,0,0,0,0,0];
+                indexCounts.set(algoName, indexes);
+            }
+
+            // If the element was recently unclicked,
+            // *and* that color is still unclaimed,
+            // give it back the same color.
+            const lastIndex = previousHighlightIndex(algoName, varName);
+            if(indexes[lastIndex] === 0) return lastIndex;
+
+            // Find the earliest index with the lowest count.
+            const minCount = Math.min.apply(null, indexes);
+            let index = null;
+            for(var i = 0; i < indexes.length; i++) {
+                if(indexes[i] == minCount) {
+                    return i;
+                }
+            }
+        }
+        function previousHighlightIndex(algoName, varName) {
+            return indexNames.get(algoName+"///"+varName);
+        }
+        function nameFromIndex(index) {
+            return "selected" + index;
+        }
+    }
+    </script>


### PR DESCRIPTION
This draft PR adds [AccessHandles](https://github.com/WICG/file-system-access/blob/access-handle-spec/AccessHandle.md) to the spec. It's currently missing the content on all AccessHandle methods, as well as the logic that releases the lock once a WritableStream is closed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/pull/344.html" title="Last updated on Nov 22, 2021, 11:58 PM UTC (ad31fa9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/344/840b322...ad31fa9.html" title="Last updated on Nov 22, 2021, 11:58 PM UTC (ad31fa9)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/pull/344.html" title="Last updated on Apr 11, 2022, 3:36 PM UTC (99725c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/344/840b322...99725c0.html" title="Last updated on Apr 11, 2022, 3:36 PM UTC (99725c0)">Diff</a>