### PR TITLE
Mark options parameter as required

### DIFF
--- a/AccessHandle.md
+++ b/AccessHandle.md
@@ -190,9 +190,9 @@ This proposal only currently considers additions to OPFS, but it would probably
 be worthwhile to expand the new functionality to arbitrary file handles. While
 the exact behavior of *AccessHandles* outside of OPFS would need to be defined
 in detail, it's almost certain that the one described in this proposal should
-not be the default. To avoid setting it as such, we propose adding a *mode*
-string parameter to *createAccessHandle()* and *createSyncAccessHandle()*.
-Some possible values *mode* could take are:
+not be the default. To avoid setting it as such, we propose adding a required
+*mode* string parameter to *createAccessHandle()* and
+*createSyncAccessHandle()*. Some possible values *mode* could take are:
 
 *  'shared': The current behavior seen in File System Access API in general,
    there is no locking and modifications are atomic (meaning that they would

--- a/AccessHandle.md
+++ b/AccessHandle.md
@@ -190,9 +190,9 @@ This proposal only currently considers additions to OPFS, but it would probably
 be worthwhile to expand the new functionality to arbitrary file handles. While
 the exact behavior of *AccessHandles* outside of OPFS would need to be defined
 in detail, it's almost certain that the one described in this proposal should
-not be the default. To avoid setting it as such, we propose adding an optional
-*mode* string parameter to *createAccessHandle()* and
-*createSyncAccessHandle()*. Some possible values *mode* could take are:
+not be the default. To avoid setting it as such, we propose adding a *mode*
+string parameter to *createAccessHandle()* and *createSyncAccessHandle()*.
+Some possible values *mode* could take are:
 
 *  'shared': The current behavior seen in File System Access API in general,
    there is no locking and modifications are atomic (meaning that they would
@@ -206,7 +206,8 @@ not be the default. To avoid setting it as such, we propose adding an optional
    It's possible that this mode would only be allowed in OPFS.
 
 Both the naming and semantics of the *mode* parameter have to be more concretely
-defined.
+defined. When a default behavior is agreed upon, the parameter should be made
+optional.
 
 ### Assurances on non-awaited consistency
 
@@ -243,9 +244,9 @@ interface FileSystemFileHandle : FileSystemHandle {
   Promise<File> getFile();
   Promise<FileSystemWritableFileStream> createWritable(optional FileSystemCreateWritableOptions options = {});
 
-  Promise<FileSystemAccessHandle> createAccessHandle(optional FileSystemFileHandleCreateAccessHandleOptions options = {});
+  Promise<FileSystemAccessHandle> createAccessHandle(FileSystemFileHandleCreateAccessHandleOptions options = {});
   [Exposed=DedicatedWorker]
-  Promise<FileSystemSyncAccessHandle> createSyncAccessHandle(optional FileSystemFileHandleCreateAccessHandleOptions options = {});
+  Promise<FileSystemSyncAccessHandle> createSyncAccessHandle(FileSystemFileHandleCreateAccessHandleOptions options = {});
 };
 
 dictionary FileSystemFileHandleCreateAccessHandleOptions {

--- a/AccessHandle.md
+++ b/AccessHandle.md
@@ -250,7 +250,7 @@ interface FileSystemFileHandle : FileSystemHandle {
 };
 
 dictionary FileSystemFileHandleCreateAccessHandleOptions {
-  AccessHandleMode mode;
+  required AccessHandleMode mode;
 };
 
 // For more details and possible modes, see "Exposing AccessHandles on all


### PR DESCRIPTION
Make the options parameter for createSyncAccessHandle and createAccessHandle required, to make it clear that a default behavior has not been decided yet.

Add a note about this on "Exposing AccessHandles on all filesystems", mentioning that the parameter should be made optional eventually.