### PR TITLE
Add note that suggestedName extension restrictions should match FilePickerOptions.types

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1644,6 +1644,7 @@ these steps:
      {{SaveFilePickerOptions/suggestedName}} and |accepts options| is [=implementation-defined=].
      If the {{SaveFilePickerOptions/suggestedName}} is deemed too dangerous, user agents should ignore or sanitize the
      suggested file name, similar to the sanitization done when fetching something <a spec=html>as a download</a>.
+     Restricted extensions for the suggested file name should match the restrictions for {{FilePickerOptions/types}}.
 
      Note: A user agent could for example pick whichever option in |accepts options| that matches
      {{SaveFilePickerOptions/suggestedName}} as the default filter.


### PR DESCRIPTION
Having these restrictions be different seems to go against user/developer expectations.

Extensions suggested via `suggestedName` should also not be longer than 16 code points, for example.