### PR TITLE
Editorial: Fix references to permissions spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -203,7 +203,7 @@ permission-related algorithms and types are defined as follows:
   Given a {{FileSystemPermissionDescriptor}} |desc| and a {{PermissionStatus}} |status|,
   run these steps:
 
-  1. Run the [=boolean permission query algorithm=] on |desc| and |status|.
+  1. Run the <a spec=permissions>default permission query algorithm</a> on |desc| and |status|.
   1. If |status|.{{PermissionStatus/state}} is not {{PermissionState/"prompt"}}, abort.
   1. Let |settings| be |desc|.{{FileSystemPermissionDescriptor/handle}}'s [=relevant settings object=].
   1. Let |global| be |settings|'s [=environment settings object/global object=].
@@ -212,7 +212,7 @@ permission-related algorithms and types are defined as follows:
   1. If |settings|'s [=environment settings object/origin=] is not [=same origin=] with |settings|'s [=top-level origin=],
      throw a {{SecurityError}}.
   1. [=Request permission to use=] |desc|.
-  1. Run the [=boolean permission query algorithm=] on |desc| and |status|.
+  1. Run the <a spec=permissions>default permission query algorithm</a> on |desc| and |status|.
 
   Issue(WICG/permissions-request#2): Ideally this user activation requirement would be defined upstream.
 
@@ -276,7 +276,7 @@ the {{FileSystemHandle}} interface can all be associated with the same [=/entry=
 <div algorithm="serialization steps">
 {{FileSystemHandle}} objects are [=serializable objects=].
 
-Advisement: In the Origin Trial as available in Chrome 78, these objects are not yet serializable. 
+Advisement: In the Origin Trial as available in Chrome 78, these objects are not yet serializable.
 In Chrome 82 they are.
 
 Their [=serialization steps=], given |value|, |serialized| and <var ignore>forStorage</var> are:
@@ -427,7 +427,7 @@ A {{FileSystemFileHandle}}'s associated [=FileSystemHandle/entry=] must be a [=f
 {{FileSystemFileHandle}} objects are [=serializable objects=]. Their [=serialization steps=] and
 [=deserialization steps=] are the same as those for {{FileSystemHandle}}.
 
-Advisement: In the Origin Trial as available in Chrome 78, these objects are not yet serializable. 
+Advisement: In the Origin Trial as available in Chrome 78, these objects are not yet serializable.
 In Chrome 82 they are.
 
 ### The {{FileSystemFileHandle/getFile()}} method ### {#api-filesystemfilehandle-getfile}
@@ -544,7 +544,7 @@ A {{FileSystemDirectoryHandle}}'s associated [=FileSystemHandle/entry=] must be 
 {{FileSystemDirectoryHandle}} objects are [=serializable objects=]. Their [=serialization steps=] and
 [=deserialization steps=] are the same as those for {{FileSystemHandle}}.
 
-Advisement: In the Origin Trial as available in Chrome 78, these objects are not yet serializable. 
+Advisement: In the Origin Trial as available in Chrome 78, these objects are not yet serializable.
 In Chrome 82 they are.
 
 Advisement: In Chrome versions upto Chrome 85 `getFileHandle` and `getDirectoryHandle` where
@@ -1741,7 +1741,7 @@ these steps:
   1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
 
   1. [=Request permission to use=] |desc|.
-  1. Run the [=boolean permission query algorithm=] on |desc| and |status|.
+  1. Run the <a spec=permissions>default permission query algorithm</a> on |desc| and |status|.
   1. If |status| is not {{PermissionState/"granted"}},
      reject |result| with a {{AbortError}} and abort.
 
@@ -1775,10 +1775,10 @@ respectively.
 The <dfn method for=DataTransferItem>getAsFileSystemHandle()</dfn> method steps are:
 
 1. If the {{DataTransferItem}} object is not in the <a spec=html>read/write
-    mode</a> or the <a spec=html>read-only mode</a>, return 
+    mode</a> or the <a spec=html>read-only mode</a>, return
     [=a promise resolved with=] `null`.
 
-1. If the <a spec=html>the drag data item kind</a> is not <em>File</em>, 
+1. If the <a spec=html>the drag data item kind</a> is not <em>File</em>,
     then return [=a promise resolved with=] `null`.
 
 1. Let |p| be [=a new promise=].

--- a/index.bs
+++ b/index.bs
@@ -203,7 +203,7 @@ permission-related algorithms and types are defined as follows:
   Given a {{FileSystemPermissionDescriptor}} |desc| and a {{PermissionStatus}} |status|,
   run these steps:
 
-  1. Run the <a spec=permissions>default permission query algorithm</a> on |desc| and |status|.
+  1. Run the [=default permission query algorithm=] on |desc| and |status|.
   1. If |status|.{{PermissionStatus/state}} is not {{PermissionState/"prompt"}}, abort.
   1. Let |settings| be |desc|.{{FileSystemPermissionDescriptor/handle}}'s [=relevant settings object=].
   1. Let |global| be |settings|'s [=environment settings object/global object=].
@@ -212,7 +212,7 @@ permission-related algorithms and types are defined as follows:
   1. If |settings|'s [=environment settings object/origin=] is not [=same origin=] with |settings|'s [=top-level origin=],
      throw a {{SecurityError}}.
   1. [=Request permission to use=] |desc|.
-  1. Run the <a spec=permissions>default permission query algorithm</a> on |desc| and |status|.
+  1. Run the [=default permission query algorithm=] on |desc| and |status|.
 
   Issue(WICG/permissions-request#2): Ideally this user activation requirement would be defined upstream.
 
@@ -1741,7 +1741,7 @@ these steps:
   1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
 
   1. [=Request permission to use=] |desc|.
-  1. Run the <a spec=permissions>default permission query algorithm</a> on |desc| and |status|.
+  1. Run the [=default permission query algorithm=] on |desc| and |status|.
   1. If |status| is not {{PermissionState/"granted"}},
      reject |result| with a {{AbortError}} and abort.
 


### PR DESCRIPTION
Stolen from https://github.com/WICG/file-system-access/commit/dc8b56dc01ee3ad8bbb63ecd804b5be79c13262a. The changes to the permissions spec mentioned there have since been merged.

Also cleans up some trailing whitespace that we might as well clean up. Thanks, new editor settiing.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/a-sully/file-system-access/pull/390.html" title="Last updated on Nov 15, 2022, 12:06 AM UTC (d15bf6d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/390/70f0a00...a-sully:d15bf6d.html" title="Last updated on Nov 15, 2022, 12:06 AM UTC (d15bf6d)">Diff</a>