### PR TITLE
Editorial: Fix undefined "pairs" ref

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1305,7 +1305,8 @@ const options = {
 To <dfn>process accept types</dfn>, given {{FilePickerOptions}} |options|,
 run these steps:
 
-1. Let |accepts options| be a empty [=/list=] of [=pairs=].
+1. Let |accepts options| be a empty [=/list=] of [=tuples=]
+   consisting of a description and a filter.
 1. [=list/For each=] |type| of |options|.{{FilePickerOptions/types}}:
   1. Let |description| be |type|.{{FilePickerAcceptType/description}}.
   1. [=map/For each=] |typeString| → |suffixes| of |type|.{{FilePickerAcceptType/accept}}:
@@ -1332,13 +1333,13 @@ run these steps:
   1. If |description| is an empty string,
     set |description| to some user understandable string describing |filter|.
 
-  1. [=list/Append=] |description|/|filter| to |accepts options|.
+  1. [=list/Append=] (|description|, |filter|) to |accepts options|.
 
 1. If either |accepts options| is [=list/empty=],
   or |options|.{{FilePickerOptions/excludeAcceptAllOption}} is `false`:
   1. Let |description| be a user understandable string describing "all files".
     1. Let |filter| be an algorithm that returns `true`.
-    1. [=list/Append=] |description|/|filter| to |accepts options|.
+    1. [=list/Append=] (|description|, |filter|) to |accepts options|.
 
 1. If |accepts options| is empty, throw a {{TypeError}}.
 


### PR DESCRIPTION
Use of `[=pairs=]` currently causes a bikeshed compilation warning


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/a-sully/file-system-access/pull/391.html" title="Last updated on Nov 11, 2022, 11:40 PM UTC (17a76ca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/391/70f0a00...a-sully:17a76ca.html" title="Last updated on Nov 11, 2022, 11:40 PM UTC (17a76ca)">Diff</a>