### PR TITLE
Editorial: Properly format enum strings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -117,10 +117,12 @@ permission-related algorithms and types are defined as follows:
   1. Otherwise, if |entry|'s [=file system entry/parent=] is not null, this descriptor's [=permission state=] must be
      equal to the [=permission state=] for a descriptor with the same {{FileSystemPermissionDescriptor/mode}},
      and a {{FileSystemPermissionDescriptor/handle}} representing |entry|'s [=file system entry/parent=].
-  1. Otherwise, if |desc|.{{FileSystemPermissionDescriptor/mode}} is "`readwrite`":
+  1. Otherwise, if |desc|.{{FileSystemPermissionDescriptor/mode}} is
+     "{{FileSystemPermissionMode/readwrite}}":
     1. Let |read state| be the [=permission state=] for a descriptor
        with the same {{FileSystemPermissionDescriptor/handle}},
-       but whose {{FileSystemPermissionDescriptor/mode}} is "`read`".
+       but whose {{FileSystemPermissionDescriptor/mode}} is
+       "{{FileSystemPermissionMode/read}}".
     1. If |read state| is not "{{PermissionState/granted}}", this descriptor's [=permission state=]
        must be equal to |read state|.
 
@@ -200,22 +202,29 @@ partial interface FileSystemHandle {
   : |status| = await |handle| . {{FileSystemHandle/queryPermission()|queryPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : "{{FileSystemPermissionMode/read}}" })
   : |status| = await |handle| . {{FileSystemHandle/queryPermission()}}
   : |status| = (await navigator.{{Navigator/permissions}}.{{Permissions/query()|query}}({ {{PermissionDescriptor/name}} : "{{PermissionName/file-system}}", {{FileSystemPermissionDescriptor/handle}} : |handle| })).{{PermissionStatus/state}}
-  :: Queries the current state of the read permission of this handle. If this returns `"prompt"`
-     the website will have to call {{FileSystemHandle/requestPermission()}} before any
-     operations on the handle can be done. If this returns `"denied"` any operations will reject.
+  :: Queries the current state of the read permission of this handle.
+     If this returns "{{PermissionState/prompt}}" the website will have to call
+     {{FileSystemHandle/requestPermission()}} before any operations on the
+     handle can be done.
+     If this returns "{{PermissionState/denied}}" any operations will reject.
 
-     Usually handles returned by the [=local file system handle factories=] will initially return `"granted"` for
-     their read permission state, however other than through the user revoking permission, a handle
-     retrieved from IndexedDB is also likely to return `"prompt"`.
+     Usually handles returned by the [=local file system handle factories=] will
+     initially return "{{PermissionState/granted}}" for their read permission
+     state, however other than through the user revoking permission, a handle
+     retrieved from IndexedDB is also likely to return
+     "{{PermissionState/prompt}}".
 
   : |status| = await |handle| . {{FileSystemHandle/queryPermission()|queryPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : "{{FileSystemPermissionMode/readwrite}}" })
   : |status| = (await navigator.{{Navigator/permissions}}.{{Permissions/query()|query}}({ {{PermissionDescriptor/name}} : "{{PermissionName/file-system}}", {{FileSystemPermissionDescriptor/handle}} : |handle|, {{FileSystemPermissionDescriptor/mode}} : "{{FileSystemPermissionMode/readwrite}}" }).{{PermissionStatus/state}}
-  :: Queries the current state of the write permission of this handle. If this returns `"prompt"`,
-     attempting to modify the file or directory this handle represents will require user activation
-     and will result in a confirmation prompt being shown to the user. However if the state of the
-     read permission of this handle is also `"prompt"` the website will need to call
-     {{FileSystemHandle/requestPermission()}}. There is no automatic prompting for read access when
-     attempting to read from a file or directory.
+  :: Queries the current state of the write permission of this handle.
+     If this returns "{{PermissionState/prompt}}", attempting to modify the
+     file or directory this handle represents will require user activation
+     and will result in a confirmation prompt being shown to the user.
+     However if the state of the read permission of this handle is also
+     "{{PermissionState/prompt}}" the website will need to call
+     {{FileSystemHandle/requestPermission()}}.
+     There is no automatic prompting for read access when attempting to
+     read from a file or directory.
 </div>
 
 Advisement: The integration with the permissions API's {{Permissions/query()}} method is not yet implemented in Chrome.
@@ -237,19 +246,23 @@ The <dfn method for=FileSystemHandle>queryPermission(|descriptor|)</dfn> method,
 <div class="note domintro">
   : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : "{{FileSystemPermissionMode/read}}" })
   : |status| = await |handle| . {{FileSystemHandle/requestPermission()}}
-  :: If the state of the read permission of this handle is anything other than `"prompt"`, this
-     will return that state directly. If it is `"prompt"` however, user activation is needed and
-     this will show a confirmation prompt to the user. The new read permission state is then
-     returned, depending on the user's response to the prompt.
+  :: If the state of the read permission of this handle is anything other than
+    "{{PermissionState/prompt}}", this will return that state directly.
+    If it is "{{PermissionState/prompt}}" however, user activation is needed and
+     this will show a confirmation prompt to the user.
+     The new read permission state is then returned, depending on
+     the user's response to the prompt.
 
   : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : "{{FileSystemPermissionMode/readwrite}}" })
-  :: If the state of the write permission of this handle is anything other than `"prompt"`, this
-     will return that state directly. If the status of the read permission of this handle is
-     `"denied"` this will return that.
+  :: If the state of the write permission of this handle is anything other than
+     "{{PermissionState/prompt}}", this will return that state directly.
+     If the status of the read permission of this handle is
+     "{{PermissionState/denied}}" this will return that.
 
-     Otherwise the state of the write permission is `"prompt"` and this will show a confirmation
-     prompt to the user. The new write permission state is then returned, depending on what the user
-     selected.
+     Otherwise the state of the write permission is "{{PermissionState/prompt}}"
+     and this will show a confirmation prompt to the user.
+     The new write permission state is then returned, depending on
+     what the user selected.
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -112,16 +112,17 @@ permission-related algorithms and types are defined as follows:
 
   1. Let |entry| be |desc|.{{FileSystemPermissionDescriptor/handle}}'s [=FileSystemHandle/entry=].
   1. If |entry| represents a [=/file system entry=] in a [=/bucket file system=],
-    this descriptor's [=permission state=] must always be {{PermissionState/"granted"}}.
+     this descriptor's [=permission state=] must always be
+     "{{PermissionState/granted}}".
   1. Otherwise, if |entry|'s [=file system entry/parent=] is not null, this descriptor's [=permission state=] must be
-    equal to the [=permission state=] for a descriptor with the same {{FileSystemPermissionDescriptor/mode}},
-    and a {{FileSystemPermissionDescriptor/handle}} representing |entry|'s [=file system entry/parent=].
-  1. Otherwise, if |desc|.{{FileSystemPermissionDescriptor/mode}} is {{"readwrite"}}:
+     equal to the [=permission state=] for a descriptor with the same {{FileSystemPermissionDescriptor/mode}},
+     and a {{FileSystemPermissionDescriptor/handle}} representing |entry|'s [=file system entry/parent=].
+  1. Otherwise, if |desc|.{{FileSystemPermissionDescriptor/mode}} is "`readwrite`":
     1. Let |read state| be the [=permission state=] for a descriptor
-      with the same {{FileSystemPermissionDescriptor/handle}},
-      but {{FileSystemPermissionDescriptor/mode}} = {{"read"}}.
-    1. If |read state| is not {{PermissionState/"granted"}}, this descriptor's [=permission state=]
-      must be equal to |read state|.
+       with the same {{FileSystemPermissionDescriptor/handle}},
+       but whose {{FileSystemPermissionDescriptor/mode}} is "`read`".
+    1. If |read state| is not "{{PermissionState/granted}}", this descriptor's [=permission state=]
+       must be equal to |read state|.
 
 Issue(whatwg/fs#101): Make these checks no longer associated with an entry.
 
@@ -131,7 +132,8 @@ Issue(whatwg/fs#101): Make these checks no longer associated with an entry.
   run these steps:
 
   1. Run the [=default permission query algorithm=] on |desc| and |status|.
-  1. If |status|.{{PermissionStatus/state}} is not {{PermissionState/"prompt"}}, abort.
+  1. If |status|.{{PermissionStatus/state}} is not "{{PermissionState/prompt}}",
+     then abort these steps.
   1. Let |settings| be |desc|.{{FileSystemPermissionDescriptor/handle}}'s [=relevant settings object=].
   1. Let |global| be |settings|'s [=environment settings object/global object=].
   1. If |global| is not a {{Window}}, then
@@ -151,7 +153,7 @@ To <dfn lt="querying file system permission|query file system permission">query 
 given a {{FileSystemHandle}} |handle| and a {{FileSystemPermissionMode}} |mode|, run these steps:
 
 1. Let |desc| be a {{FileSystemPermissionDescriptor}}.
-1. Set |desc|.{{PermissionDescriptor/name}} to {{"file-system"}}.
+1. Set |desc|.{{PermissionDescriptor/name}} to "{{PermissionName/file-system}}".
 1. Set |desc|.{{FileSystemPermissionDescriptor/handle}} to |handle|.
 1. Set |desc|.{{FileSystemPermissionDescriptor/mode}} to |mode|.
 1. Return |desc|'s [=permission state=].
@@ -163,17 +165,20 @@ To <dfn lt="requesting file system permission|request file system permission">re
 given a {{FileSystemHandle}} |handle| and a {{FileSystemPermissionMode}} |mode|, run these steps:
 
 1. Let |desc| be a {{FileSystemPermissionDescriptor}}.
-1. Set |desc|.{{PermissionDescriptor/name}} to {{"file-system"}}.
+1. Set |desc|.{{PermissionDescriptor/name}} to "{{PermissionName/file-system}}".
 1. Set |desc|.{{FileSystemPermissionDescriptor/handle}} to |handle|.
 1. Set |desc|.{{FileSystemPermissionDescriptor/mode}} to |mode|.
 1. Let |status| be the result of running <a spec=permissions>create a PermissionStatus</a> for |desc|.
-1. Run the [=permission request algorithm=] for the {{"file-system"}} feature, given |desc| and |status|.
+1. Run the [=permission request algorithm=] for the
+   "{{PermissionName/file-system}}" feature, given |desc| and |status|.
 1. Return |desc|'s [=permission state=].
 
 </div>
 
-Issue(119): Currently {{FileSystemPermissionMode}} can only be {{"read"}} or {{"readwrite"}}. In
-the future we might want to add a "write" mode as well to support write-only handles.
+Issue(119): Currently {{FileSystemPermissionMode}} can only be
+"{{FileSystemPermissionMode/read}}" or "{{FileSystemPermissionMode/readwrite}}".
+In the future we might want to add a "write" mode as well to support write-only
+handles.
 
 ## The {{FileSystemHandle}} interface ## {#api-filesystemhandle}
 
@@ -192,9 +197,9 @@ partial interface FileSystemHandle {
 ### The {{FileSystemHandle/queryPermission()}} method ### {#api-filesystemhandle-querypermission}
 
 <div class="note domintro">
-  : |status| = await |handle| . {{FileSystemHandle/queryPermission()|queryPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : {{"read"}} })
+  : |status| = await |handle| . {{FileSystemHandle/queryPermission()|queryPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : "{{FileSystemPermissionMode/read}}" })
   : |status| = await |handle| . {{FileSystemHandle/queryPermission()}}
-  : |status| = (await navigator.{{Navigator/permissions}}.{{Permissions/query()|query}}({ {{PermissionDescriptor/name}} : "file-system", {{FileSystemPermissionDescriptor/handle}} : |handle| })).{{PermissionStatus/state}}
+  : |status| = (await navigator.{{Navigator/permissions}}.{{Permissions/query()|query}}({ {{PermissionDescriptor/name}} : "{{PermissionName/file-system}}", {{FileSystemPermissionDescriptor/handle}} : |handle| })).{{PermissionStatus/state}}
   :: Queries the current state of the read permission of this handle. If this returns `"prompt"`
      the website will have to call {{FileSystemHandle/requestPermission()}} before any
      operations on the handle can be done. If this returns `"denied"` any operations will reject.
@@ -203,8 +208,8 @@ partial interface FileSystemHandle {
      their read permission state, however other than through the user revoking permission, a handle
      retrieved from IndexedDB is also likely to return `"prompt"`.
 
-  : |status| = await |handle| . {{FileSystemHandle/queryPermission()|queryPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : {{"readwrite"}} })
-  : |status| = (await navigator.{{Navigator/permissions}}.{{Permissions/query()|query}}({ {{PermissionDescriptor/name}} : "file-system", {{FileSystemPermissionDescriptor/handle}} : |handle|, {{FileSystemPermissionDescriptor/mode}} : {{"readwrite"}}}).{{PermissionStatus/state}}
+  : |status| = await |handle| . {{FileSystemHandle/queryPermission()|queryPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : "{{FileSystemPermissionMode/readwrite}}" })
+  : |status| = (await navigator.{{Navigator/permissions}}.{{Permissions/query()|query}}({ {{PermissionDescriptor/name}} : "{{PermissionName/file-system}}", {{FileSystemPermissionDescriptor/handle}} : |handle|, {{FileSystemPermissionDescriptor/mode}} : "{{FileSystemPermissionMode/readwrite}}" }).{{PermissionStatus/state}}
   :: Queries the current state of the write permission of this handle. If this returns `"prompt"`,
      attempting to modify the file or directory this handle represents will require user activation
      and will result in a confirmation prompt being shown to the user. However if the state of the
@@ -230,14 +235,14 @@ The <dfn method for=FileSystemHandle>queryPermission(|descriptor|)</dfn> method,
 ### The {{FileSystemHandle/requestPermission()}} method ### {#api-filesystemhandle-requestpermission}
 
 <div class="note domintro">
-  : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : {{"read"}} })
+  : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : "{{FileSystemPermissionMode/read}}" })
   : |status| = await |handle| . {{FileSystemHandle/requestPermission()}}
   :: If the state of the read permission of this handle is anything other than `"prompt"`, this
      will return that state directly. If it is `"prompt"` however, user activation is needed and
      this will show a confirmation prompt to the user. The new read permission state is then
      returned, depending on the user's response to the prompt.
 
-  : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : {{"readwrite"}} })
+  : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : "{{FileSystemPermissionMode/readwrite}}" })
   :: If the state of the write permission of this handle is anything other than `"prompt"`, this
      will return that state directly. If the status of the read permission of this handle is
      `"denied"` this will return that.
@@ -324,13 +329,13 @@ The fact that the user picked the specific files returned by the [=local file sy
 should be treated by the user agent as the user intending to grant read access to the website
 for the returned files. As such, at the time the promise returned by one of the [=local file system handle factories=]
 resolves, [=permission state=] for a descriptor with {{FileSystemPermissionDescriptor/handle}} set to the returned handle,
-and {{FileSystemPermissionDescriptor/mode}} set to {{"read"}}
-should be {{PermissionState/"granted"}}.
+and {{FileSystemPermissionDescriptor/mode}} set to "{{FileSystemPermissionMode/read}}"
+should be "{{PermissionState/granted}}".
 
 Additionally for calls to {{showSaveFilePicker}}
 the [=permission state=] for a descriptor with {{FileSystemPermissionDescriptor/handle}} set to the returned handle,
-and {{FileSystemPermissionDescriptor/mode}} set to {{readwrite}}
-should be {{PermissionState/"granted"}}.
+and {{FileSystemPermissionDescriptor/mode}} set to "{{FileSystemPermissionMode/readwrite}}"
+should be "{{PermissionState/granted}}".
 
 <div algorithm>
 To verify that an |environment| <dfn>is allowed to show a file picker</dfn>, run these steps:
@@ -537,7 +542,7 @@ via the {{WellKnownDirectory}} is used.
 // The file picker will fall back to opening to the Downloads directory. TODO: link this.
 const options = {
   <l>{{FilePickerOptions/id}}</l>: 'foo',  // Unmapped.
-  <l>{{FilePickerOptions/startIn}}</l>: <l>{{WellKnownDirectory/"downloads"}}</l>,  // Start here.
+  <l>{{FilePickerOptions/startIn}}</l>: <l>"{{WellKnownDirectory/downloads}}"</l>,  // Start here.
 };
 
 // Later...
@@ -546,7 +551,7 @@ const options = {
 // might have been evicted.
 const options = {
   <l>{{FilePickerOptions/id}}</l>: 'foo',  // Maybe mapped. If so, start here.
-  <l>{{FilePickerOptions/startIn}}</l>: <l>{{WellKnownDirectory/"downloads"}}</l>,  // Otherwise, start here.
+  <l>{{FilePickerOptions/startIn}}</l>: <l>"{{WellKnownDirectory/downloads}}"</l>,  // Otherwise, start here.
 };
 </pre>
 
@@ -867,7 +872,7 @@ these steps:
 
   1. [=Request permission to use=] |desc|.
   1. Run the [=default permission query algorithm=] on |desc| and |status|.
-  1. If |status| is not {{PermissionState/"granted"}},
+  1. If |status| is not "{{PermissionState/granted}}",
      [=/reject=] |result| with a "{{AbortError}}" {{DOMException}} and abort.
 
   1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].

--- a/index.bs
+++ b/index.bs
@@ -542,7 +542,7 @@ via the {{WellKnownDirectory}} is used.
 // The file picker will fall back to opening to the Downloads directory. TODO: link this.
 const options = {
   <l>{{FilePickerOptions/id}}</l>: 'foo',  // Unmapped.
-  <l>{{FilePickerOptions/startIn}}</l>: <l>"{{WellKnownDirectory/downloads}}"</l>,  // Start here.
+  <l>{{FilePickerOptions/startIn}}</l>: "<l>{{WellKnownDirectory/downloads}}</l>",  // Start here.
 };
 
 // Later...
@@ -551,7 +551,7 @@ const options = {
 // might have been evicted.
 const options = {
   <l>{{FilePickerOptions/id}}</l>: 'foo',  // Maybe mapped. If so, start here.
-  <l>{{FilePickerOptions/startIn}}</l>: <l>"{{WellKnownDirectory/downloads}}"</l>,  // Otherwise, start here.
+  <l>{{FilePickerOptions/startIn}}</l>: "<l>{{WellKnownDirectory/downloads}}</l>",  // Otherwise, start here.
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -247,8 +247,8 @@ The <dfn method for=FileSystemHandle>queryPermission(|descriptor|)</dfn> method,
   : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : "{{FileSystemPermissionMode/read}}" })
   : |status| = await |handle| . {{FileSystemHandle/requestPermission()}}
   :: If the state of the read permission of this handle is anything other than
-    "{{PermissionState/prompt}}", this will return that state directly.
-    If it is "{{PermissionState/prompt}}" however, user activation is needed and
+     "{{PermissionState/prompt}}", this will return that state directly.
+     If it is "{{PermissionState/prompt}}" however, user activation is needed and
      this will show a confirmation prompt to the user.
      The new read permission state is then returned, depending on
      the user's response to the prompt.


### PR DESCRIPTION
Before: `{{PermissionState/"granted"}}`
After: `"{{PermissionState/granted}}"`

See whatwg/fs#133. Also called out here: https://github.com/WICG/file-system-access/pull/417#discussion_r1231615477


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/a-sully/file-system-access/pull/418.html" title="Last updated on Jun 20, 2023, 9:33 PM UTC (55810a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/418/a350a87...a-sully:55810a9.html" title="Last updated on Jun 20, 2023, 9:33 PM UTC (55810a9)">Diff</a>