### PR TITLE
Default FilePickerAcceptType.description to the empty string

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -299,7 +299,7 @@ enum WellKnownDirectory {
 typedef (WellKnownDirectory or FileSystemHandle) StartInDirectory;
 
 dictionary FilePickerAcceptType {
-    USVString description;
+    USVString description = "";
     record<USVString, (USVString or sequence<USVString>)> accept;
 };
 
@@ -452,9 +452,6 @@ run these steps:
 1. Let |accepts options| be a empty [=/list=] of [=tuples=]
    consisting of a description and a filter.
 1. [=list/For each=] |type| of |options|["{{FilePickerOptions/types}}"]:
-  1. Let |description| be |type|["{{FilePickerAcceptType/description}}"] if
-     |type|["{{FilePickerAcceptType/description}}"] [=map/exists=];
-     otherwise the empty string.
   1. [=map/For each=] |typeString| → |suffixes| of
      |type|["{{FilePickerAcceptType/accept}}"]:
     1. Let |parsedType| be the result of [=parse a MIME type=] with |typeString|.
@@ -479,6 +476,7 @@ run these steps:
         1. If |filename| ends with |suffix|, return `true`.
     1. Return `false`.
 
+  1. Let |description| be |type|["{{FilePickerAcceptType/description}}"].
   1. If |description| is an empty string,
     set |description| to some user understandable string describing |filter|.
 


### PR DESCRIPTION
This has no behavioral changes, since _not specifying_ the description field currently behaves the same as if the description was specified as the empty string

Fixes #422


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/a-sully/file-system-access/pull/423.html" title="Last updated on Jun 23, 2023, 4:08 PM UTC (7d53d65)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/423/739b0c4...a-sully:7d53d65.html" title="Last updated on Jun 23, 2023, 4:08 PM UTC (7d53d65)">Diff</a>