### PR TITLE
Editorial: Replace backticks with quotes in broken drag-and-drop example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -983,9 +983,9 @@ elem.addEventListener('drop', async (e) => {
 
   for await (const handle of fileHandlesPromises) {
     if (handle.kind === 'directory') {
-      console.log(`Directory: ${handle.name}`);
+      console.log('Directory: ${handle.name}');
     } else {
-      console.log(`File: ${handle.name}`);
+      console.log('File: ${handle.name}');
     }
   }
 });


### PR DESCRIPTION
This was accidentally broken in #357


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/a-sully/file-system-access/pull/424.html" title="Last updated on Jul 12, 2023, 5:41 PM UTC (8408b9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/file-system-access/424/d8f5556...a-sully:8408b9a.html" title="Last updated on Jul 12, 2023, 5:41 PM UTC (8408b9a)">Diff</a>