### PR TITLE
Meta: Use ubuntu-latest in GitHub workflow

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   main:
     name: Build, Validate and Deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: sidvishnoi/spec-prod@v1


### PR DESCRIPTION
CI is failing due to the following error:
```
  Bikeshed now requires Python 3.9; you are on 3.8.10.
      If you're seeing this message in your CI run, you are
      likely specifying an old OS; try `ubuntu-latest`.
```